### PR TITLE
fix(daemon): cascade team deletion on workspace delete (#15)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -509,6 +509,19 @@ func (d *Daemon) handleDelete(params json.RawMessage) Response {
 		if getErr != nil {
 			return Response{Error: getErr.Error()}
 		}
+		// Cascade: delete teams in this workspace (and their sessions) so the
+		// reconciler doesn't respawn sessions against orphaned team records.
+		for _, t := range d.store.ListTeams() {
+			if t.Workspace != ws.Name {
+				continue
+			}
+			for _, s := range d.store.ListSessionsByTeam(t.Workspace, t.Name) {
+				_ = d.sessMgr.Delete(s.Key())
+			}
+			if delErr := d.store.DeleteTeam(t.Key()); delErr != nil {
+				log.Printf("delete workspace %s: delete team %s: %v", ws.Name, t.Key(), delErr)
+			}
+		}
 		_ = d.sessMgr.CleanupWorkspace(ws.Name)
 		err = d.store.DeleteWorkspace(p.Name)
 	default:

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -258,6 +258,41 @@ name = "squad"
 	if resp.Error != "" {
 		t.Fatalf("delete error: %s", resp.Error)
 	}
+
+	// Verify cascade: teams and sessions from the deleted workspace must be
+	// gone so the reconciler doesn't respawn sessions against orphan teams.
+	// See ArcavenAE/marvel#15.
+	time.Sleep(500 * time.Millisecond)
+
+	resp, err = SendRequest(sock, Request{
+		Method: "get",
+		Params: mustMarshal(t, map[string]string{"resource_type": "teams"}),
+	})
+	if err != nil {
+		t.Fatalf("get teams after delete workspace: %v", err)
+	}
+	var teamsAfter []json.RawMessage
+	if err := json.Unmarshal(resp.Result, &teamsAfter); err != nil {
+		t.Fatalf("unmarshal teams after delete: %v", err)
+	}
+	if len(teamsAfter) != 0 {
+		t.Fatalf("expected 0 teams after delete workspace, got %d", len(teamsAfter))
+	}
+
+	resp, err = SendRequest(sock, Request{
+		Method: "get",
+		Params: mustMarshal(t, map[string]string{"resource_type": "sessions"}),
+	})
+	if err != nil {
+		t.Fatalf("get sessions after delete workspace: %v", err)
+	}
+	var sessionsAfter []json.RawMessage
+	if err := json.Unmarshal(resp.Result, &sessionsAfter); err != nil {
+		t.Fatalf("unmarshal sessions after delete: %v", err)
+	}
+	if len(sessionsAfter) != 0 {
+		t.Fatalf("expected 0 sessions after delete workspace, got %d", len(sessionsAfter))
+	}
 }
 
 func TestListenNetwork(t *testing.T) {


### PR DESCRIPTION
## Summary

- `marvel delete workspace <name>` left team records in the store, so the reconciler kept respawning sessions against orphan teams indefinitely.
- Fix cascades team deletion (and their sessions) inside the workspace-delete handler, mirroring the existing team-delete cascade.
- `TestDaemonLifecycle` now asserts teams and sessions are zero after delete workspace — previously the test only checked the RPC return value, which is exactly how the bug slipped through.

## Test plan

- [x] `just lint` — clean
- [x] `go test ./internal/daemon/ -run TestDaemonLifecycle -v` — passes with new cascade assertions
- [x] `just test` — all tests green
- [x] Local end-to-end repro with `examples/generic-agent.yaml`:
  - Before delete: 1 team, 1 session
  - After delete: 0 teams, 0 sessions, 0 workspaces
  - +3s later: still 0 sessions (reconciler no longer has orphan teams to respawn against)
- [ ] Validate on Skippy's Pi 5 once alpha lands (linux/arm64)

Refs: #15