### PR TITLE
fix(daemon): clean up orphan marvel-* tmux sessions on startup (#13)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -177,6 +177,14 @@ func (d *Daemon) Start(socketPath string) error {
 		}
 	}
 
+	// Reclaim the marvel-* tmux namespace before anything else creates
+	// panes: a previous daemon instance may have left sessions (and their
+	// forestage/claude processes) running. Our fresh in-memory state
+	// knows nothing about them. See ArcavenAE/marvel#13.
+	if err := d.sessMgr.CleanupOrphanTmux(); err != nil {
+		log.Printf("cleanup orphan tmux on startup: %v", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	d.cancel = cancel
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,6 +5,7 @@ package session
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/arcavenae/marvel/internal/api"
@@ -25,9 +26,47 @@ func NewManager(store *api.Store, driver *tmux.Driver) *Manager {
 	return &Manager{store: store, driver: driver, adapters: runtime.NewRegistry()}
 }
 
+// marvelSessionPrefix is the tmux session name prefix marvel owns.
+// Every tmux session named marvel-* is considered marvel-managed; a
+// fresh daemon reclaims the prefix by killing any leftovers on startup.
+const marvelSessionPrefix = "marvel-"
+
 // tmuxSessionName returns the tmux session name for a workspace.
 func tmuxSessionName(workspace string) string {
-	return "marvel-" + workspace
+	return marvelSessionPrefix + workspace
+}
+
+// CleanupOrphanTmux kills every tmux session whose name starts with the
+// marvel- prefix. Called at daemon startup so a fresh in-memory state
+// doesn't coexist with panes and processes from a previous daemon instance.
+// See ArcavenAE/marvel#13.
+func (m *Manager) CleanupOrphanTmux() error {
+	return m.cleanupOrphanTmuxPrefix(marvelSessionPrefix)
+}
+
+// cleanupOrphanTmuxPrefix is the prefix-parameterized core of
+// CleanupOrphanTmux. Tests use a unique prefix so they don't collide
+// with other tmux-using tests running in parallel packages.
+func (m *Manager) cleanupOrphanTmuxPrefix(prefix string) error {
+	names, err := m.driver.ListSessions()
+	if err != nil {
+		return fmt.Errorf("list tmux sessions: %w", err)
+	}
+	var killed int
+	for _, name := range names {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if err := m.driver.KillSession(name); err != nil {
+			log.Printf("cleanup orphan tmux %s: %v", name, err)
+			continue
+		}
+		killed++
+	}
+	if killed > 0 {
+		log.Printf("cleanup: killed %d orphan tmux session(s) from previous daemon", killed)
+	}
+	return nil
 }
 
 // Create creates a new session: registers it in the store, ensures the tmux

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -116,3 +116,44 @@ func TestCleanupWorkspace(t *testing.T) {
 		t.Fatal("tmux session should be gone after cleanup")
 	}
 }
+
+func TestCleanupOrphanTmux(t *testing.T) {
+	skipIfNoTmux(t)
+
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	// Use a unique prefix so we do not step on other tmux-using tests
+	// (e.g. TestDaemonLifecycle) that may be running in parallel
+	// packages and use the real marvel- prefix.
+	prefix := "marvel-orphantest-"
+	orphans := []string{prefix + "a", prefix + "b"}
+	outsider := "not-" + prefix + "survivor"
+
+	for _, name := range []string{orphans[0], orphans[1], outsider} {
+		if err := driver.NewSession(name); err != nil {
+			t.Fatalf("new session %s: %v", name, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, n := range append(orphans, outsider) {
+			_ = driver.KillSession(n)
+		}
+	})
+
+	mgr := NewManager(api.NewStore(), driver)
+	if err := mgr.cleanupOrphanTmuxPrefix(prefix); err != nil {
+		t.Fatalf("cleanup orphan tmux: %v", err)
+	}
+
+	for _, name := range orphans {
+		if driver.HasSession(name) {
+			t.Fatalf("orphan %s should have been killed", name)
+		}
+	}
+	if !driver.HasSession(outsider) {
+		t.Fatalf("non-prefix session %s must not be touched", outsider)
+	}
+}

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -2,6 +2,7 @@
 package tmux
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -25,6 +26,30 @@ func NewDriver() (*Driver, error) {
 func (d *Driver) HasSession(name string) bool {
 	cmd := exec.Command(d.binary, "has-session", "-t", name)
 	return cmd.Run() == nil
+}
+
+// ListSessions returns the names of every tmux session on the server.
+// If no tmux server is running, returns an empty slice and no error —
+// that's the same "no sessions" condition as a freshly started daemon.
+func (d *Driver) ListSessions() ([]string, error) {
+	cmd := exec.Command(d.binary, "list-sessions", "-F", "#S")
+	out, err := cmd.Output()
+	if err != nil {
+		// tmux exits non-zero with "no server running" when there is no
+		// tmux server. Treat that as "zero sessions", not an error.
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && strings.Contains(string(ee.Stderr), "no server running") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list-sessions: %w", err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
 }
 
 // NewSession creates a new tmux session in detached mode.

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -95,6 +95,37 @@ func TestSessionLifecycle(t *testing.T) {
 	}
 }
 
+func TestListSessions(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	sessionName := "marvel-test-list-sessions"
+	t.Cleanup(func() {
+		_ = d.KillSession(sessionName)
+	})
+	if err := d.NewSession(sessionName); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+
+	names, err := d.ListSessions()
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	var found bool
+	for _, n := range names {
+		if n == sessionName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q in %v", sessionName, names)
+	}
+}
+
 func TestSendKeys(t *testing.T) {
 	skipIfNoTmux(t)
 	d, err := NewDriver()


### PR DESCRIPTION
## Summary

- On daemon startup, kill every tmux session whose name starts with the `marvel-` prefix. A previous daemon instance that exited without calling `Stop()` (SIGKILL, crash, power loss) leaves those sessions and their forestage/claude processes running; a fresh daemon has no knowledge of them and creates new panes with incrementing IDs while the old ones sit burning resources.
- Non-marvel tmux sessions are untouched. The prefix is marvel's own namespace.
- Reporter suggested two fix paths (clean-slate vs reconnect-and-reconcile); this PR does the clean-slate path — the simpler one — and leaves the reconcile path to a follow-up if anyone wants it.

## Test plan

- [x] `just lint` — clean
- [x] `just test-race` — all packages green
- [x] New `TestCleanupOrphanTmux` (session package) — uses a unique prefix (`marvel-orphantest-`) via a package-private helper so it does not step on other tmux-using tests running in parallel packages
- [x] New `TestListSessions` (tmux package)
- [x] Local end-to-end repro from #13:
  - daemon starts → `workspace/util ready` with a pane running
  - SIGKILL the daemon (not `marvel stop`) — `marvel-util` tmux session + `bash` pane survive
  - start fresh daemon — cleanup line appears in the log ring, `marvel-util` is gone
- [ ] Validate on Skippy's Pi 5 once alpha lands (linux/arm64)

Refs: #13