### PR TITLE
test(daemon): backfill tests + fix HasPane + add coverage floor (#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,18 @@ jobs:
       - name: Display coverage summary
         run: go tool cover -func=coverage.out
 
+      - name: Enforce coverage floor
+        # Ratchet this up over time. Must not decrease.
+        env:
+          COVERAGE_FLOOR: "38.0"
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%",""); print $3}')
+          echo "total coverage: ${total}% (floor: ${COVERAGE_FLOOR}%)"
+          awk -v t="$total" -v f="$COVERAGE_FLOOR" 'BEGIN{exit !(t+0 >= f+0)}' || {
+            echo "::error::coverage ${total}% fell below floor ${COVERAGE_FLOOR}%" >&2
+            exit 1
+          }
+
       - name: Validate build
         run: go build -o /dev/null ./cmd/marvel
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,9 +2,12 @@ package daemon
 
 import (
 	"encoding/json"
+	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -292,6 +295,220 @@ name = "squad"
 	}
 	if len(sessionsAfter) != 0 {
 		t.Fatalf("expected 0 sessions after delete workspace, got %d", len(sessionsAfter))
+	}
+}
+
+// startTestDaemon brings up a daemon on a per-test Unix socket with one
+// running session (sleep 300 in a generic adapter) and returns the
+// session key, socket, and a teardown func. The session's tmux pane is
+// alive, so inject/capture/ReapDead have something to hit.
+//
+// The daemon's log ring is wired as one of the log.SetOutput writers so
+// tests exercising 'logs' RPC see real startup log lines. Production
+// does this in cmd/marvel/main.go; tests do it here.
+func startTestDaemon(t *testing.T, workspace string) (sessionKey, sock string, teardown func()) {
+	t.Helper()
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+
+	// Restore the default log output when the test ends so we don't
+	// leak the ring-buffer sink into sibling tests.
+	prevLogFlags := log.Flags()
+	log.SetOutput(io.MultiWriter(d.LogBuffer(), os.Stderr))
+	origRestore := func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(prevLogFlags)
+	}
+
+	sock = filepath.Join(os.TempDir(), "marvel-test-"+workspace+".sock")
+	if err := d.Start(sock); err != nil {
+		origRestore()
+		t.Fatalf("start daemon: %v", err)
+	}
+	teardown = func() {
+		d.Stop()
+		_ = os.Remove(sock)
+		origRestore()
+	}
+
+	manifest := `
+[workspace]
+name = "` + workspace + `"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+
+    [team.role.runtime]
+    command = "sleep"
+    args = ["300"]
+`
+	resp, err := SendRequest(sock, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(manifest)}),
+	})
+	if err != nil || resp.Error != "" {
+		teardown()
+		t.Fatalf("apply: err=%v resp.Error=%q", err, resp.Error)
+	}
+	// Wait for reconciliation to create the session + pane.
+	time.Sleep(600 * time.Millisecond)
+
+	resp, err = SendRequest(sock, Request{
+		Method: "get",
+		Params: mustMarshal(t, map[string]string{"resource_type": "sessions"}),
+	})
+	if err != nil || resp.Error != "" {
+		teardown()
+		t.Fatalf("get sessions: err=%v resp.Error=%q", err, resp.Error)
+	}
+	var sessions []struct {
+		Name      string
+		Workspace string
+		PaneID    string
+	}
+	if err := json.Unmarshal(resp.Result, &sessions); err != nil {
+		teardown()
+		t.Fatalf("unmarshal sessions: %v", err)
+	}
+	if len(sessions) == 0 {
+		teardown()
+		t.Fatal("expected at least one session after apply")
+	}
+	sessionKey = sessions[0].Workspace + "/" + sessions[0].Name
+	return sessionKey, sock, teardown
+}
+
+func TestHandleInjectCapture(t *testing.T) {
+	sessionKey, sock, teardown := startTestDaemon(t, "test-inject")
+	t.Cleanup(teardown)
+
+	// Inject text into the session's pane. The sleep process ignores
+	// stdin so the text sits in the tty buffer — capture-pane will
+	// still render it as input characters on the pane.
+	marker := "XXXX-INJECT-MARKER-" + t.Name()
+	resp, err := SendRequest(sock, Request{
+		Method: "inject",
+		Params: mustMarshal(t, map[string]any{
+			"session_key": sessionKey,
+			"text":        marker,
+			"literal":     true,
+		}),
+	})
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("inject error: %s", resp.Error)
+	}
+	var injectResult map[string]string
+	_ = json.Unmarshal(resp.Result, &injectResult)
+	if injectResult["status"] != "injected" {
+		t.Fatalf("expected status injected, got %s", injectResult["status"])
+	}
+
+	// tmux send-keys + capture is eventually-consistent; give it a beat.
+	time.Sleep(200 * time.Millisecond)
+
+	resp, err = SendRequest(sock, Request{
+		Method: "capture",
+		Params: mustMarshal(t, map[string]any{"session_key": sessionKey}),
+	})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("capture error: %s", resp.Error)
+	}
+	var captureResult map[string]string
+	_ = json.Unmarshal(resp.Result, &captureResult)
+	if captureResult["status"] != "captured" {
+		t.Fatalf("expected status captured, got %s", captureResult["status"])
+	}
+	if !strings.Contains(captureResult["content"], marker) {
+		t.Fatalf("expected captured content to contain %q, got: %q", marker, captureResult["content"])
+	}
+}
+
+func TestHandleInjectUnknownSession(t *testing.T) {
+	_, sock, teardown := startTestDaemon(t, "test-inject-err")
+	t.Cleanup(teardown)
+
+	resp, err := SendRequest(sock, Request{
+		Method: "inject",
+		Params: mustMarshal(t, map[string]any{
+			"session_key": "does-not-exist/nobody-0",
+			"text":        "hello",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected error injecting into unknown session")
+	}
+}
+
+func TestHandleLogs(t *testing.T) {
+	_, sock, teardown := startTestDaemon(t, "test-logs")
+	t.Cleanup(teardown)
+
+	resp, err := SendRequest(sock, Request{
+		Method: "logs",
+		Params: mustMarshal(t, map[string]any{"n": 100}),
+	})
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("logs error: %s", resp.Error)
+	}
+	var result logsResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal logs: %v", err)
+	}
+	if len(result.Lines) == 0 {
+		t.Fatal("expected at least one log line from daemon startup")
+	}
+	// The daemon prints 'marvel daemon listening on ...' on Start —
+	// the ring buffer should have it.
+	var sawListening bool
+	for _, line := range result.Lines {
+		if strings.Contains(line, "marvel daemon listening on") {
+			sawListening = true
+			break
+		}
+	}
+	if !sawListening {
+		t.Fatalf("expected listening log line; got %d lines, first: %q", len(result.Lines), result.Lines[0])
+	}
+}
+
+func TestHandleLogsDefaultN(t *testing.T) {
+	_, sock, teardown := startTestDaemon(t, "test-logs-default")
+	t.Cleanup(teardown)
+
+	// No params — should default to the full ring.
+	resp, err := SendRequest(sock, Request{Method: "logs"})
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("logs error: %s", resp.Error)
+	}
+	var result logsResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal logs: %v", err)
+	}
+	if len(result.Lines) == 0 {
+		t.Fatal("expected at least one log line with no params")
 	}
 }
 

--- a/internal/daemon/testmain_test.go
+++ b/internal/daemon/testmain_test.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// See tmux/testmain_test.go for the rationale.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		os.Exit(m.Run())
+	}
+	socket := fmt.Sprintf("marvel-test-daemon-%d", os.Getpid())
+	if err := os.Setenv("MARVEL_TMUX_SOCKET", socket); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set MARVEL_TMUX_SOCKET: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	os.Exit(code)
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/arcavenae/marvel/internal/api"
 	"github.com/arcavenae/marvel/internal/tmux"
@@ -155,5 +156,67 @@ func TestCleanupOrphanTmux(t *testing.T) {
 	}
 	if !driver.HasSession(outsider) {
 		t.Fatalf("non-prefix session %s must not be touched", outsider)
+	}
+}
+
+func TestReapDead(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-reap-dead"
+	t.Cleanup(func() {
+		_ = mgr.CleanupWorkspace(ws)
+	})
+
+	// Two live sessions plus a bookkeeping session whose pane we'll kill
+	// out-of-band so ReapDead has something to clear.
+	for _, name := range []string{"live-0", "dying-0"} {
+		sess := &api.Session{
+			Name:      name,
+			Workspace: ws,
+			Team:      "agents",
+			Role:      "worker",
+			Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+		}
+		if err := mgr.Create(sess); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	dying, err := store.GetSession(ws + "/dying-0")
+	if err != nil {
+		t.Fatalf("get dying-0: %v", err)
+	}
+	// Kill the pane behind the manager's back — simulates a runtime
+	// process that crashed or a tmux window the user closed manually.
+	// tmux processes the kill-pane asynchronously; poll HasPane until
+	// it reports the pane gone (or give up) before we ReapDead, so the
+	// test isn't racing the tmux server.
+	if err := driver.KillPane(dying.PaneID); err != nil {
+		t.Fatalf("kill pane %s: %v", dying.PaneID, err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for driver.HasPane(dying.PaneID) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if driver.HasPane(dying.PaneID) {
+		t.Fatalf("tmux still reports pane %s alive after kill-pane", dying.PaneID)
+	}
+
+	reaped := mgr.ReapDead()
+	if len(reaped) != 1 || reaped[0] != dying.Key() {
+		t.Fatalf("expected ReapDead to return [%s], got %v", dying.Key(), reaped)
+	}
+	if _, err := store.GetSession(dying.Key()); err == nil {
+		t.Fatal("expected dying session to be removed from store")
+	}
+	if _, err := store.GetSession(ws + "/live-0"); err != nil {
+		t.Fatalf("expected live-0 to survive ReapDead: %v", err)
 	}
 }

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -1,0 +1,26 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// See tmux/testmain_test.go for the rationale — per-package tmux
+// server isolation so parallel `go test ./...` binaries don't race on
+// the system-wide tmux server. Prod-style intra-process concurrency
+// is covered by tmux.TestDriverConcurrentUse.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		os.Exit(m.Run())
+	}
+	socket := fmt.Sprintf("marvel-test-session-%d", os.Getpid())
+	if err := os.Setenv("MARVEL_TMUX_SOCKET", socket); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set MARVEL_TMUX_SOCKET: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	os.Exit(code)
+}

--- a/internal/team/testmain_test.go
+++ b/internal/team/testmain_test.go
@@ -1,0 +1,23 @@
+package team
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// See internal/tmux/testmain_test.go for the rationale.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		os.Exit(m.Run())
+	}
+	socket := fmt.Sprintf("marvel-test-team-%d", os.Getpid())
+	if err := os.Setenv("MARVEL_TMUX_SOCKET", socket); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set MARVEL_TMUX_SOCKET: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	os.Exit(code)
+}

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -110,8 +110,14 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 }
 
 // HasPane checks if a tmux pane still exists.
+//
+// display-message -t <paneID> -p <fmt> exits 0 even when the target
+// pane is gone, so it can't be used to test pane liveness. list-panes
+// validates the target against the live pane list and exits 1 for
+// unknown IDs. See ArcavenAE/marvel#10 — before this change ReapDead
+// never saw dead panes and sessions stayed 'running/unknown' forever.
 func (d *Driver) HasPane(paneID string) bool {
-	cmd := exec.Command(d.binary, "display-message", "-t", paneID, "-p", "")
+	cmd := exec.Command(d.binary, "list-panes", "-t", paneID, "-F", "#{pane_id}")
 	return cmd.Run() == nil
 }
 

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -4,6 +4,7 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -11,29 +12,58 @@ import (
 // Driver manages tmux sessions and panes by shelling out to the tmux binary.
 type Driver struct {
 	binary string
+
+	// socket is the tmux server socket name. Empty means the default
+	// tmux server. When non-empty every tmux invocation prepends
+	// -L <socket>, scoping the driver to a dedicated server.
+	//
+	// Set via the MARVEL_TMUX_SOCKET env var at NewDriver time. Tests
+	// use this to get per-package isolation from the system-wide tmux.
+	socket string
 }
 
 // NewDriver creates a tmux driver, verifying tmux is available.
+//
+// If MARVEL_TMUX_SOCKET is set, the driver talks to a dedicated tmux
+// server at that socket name (tmux -L <socket>). Useful for test
+// isolation and for running marvel alongside an unrelated tmux
+// workflow on the same machine.
 func NewDriver() (*Driver, error) {
 	path, err := exec.LookPath("tmux")
 	if err != nil {
 		return nil, fmt.Errorf("tmux not found: %w", err)
 	}
-	return &Driver{binary: path}, nil
+	return &Driver{binary: path, socket: os.Getenv("MARVEL_TMUX_SOCKET")}, nil
 }
+
+// cmd builds an exec.Cmd for tmux with the driver's socket prefix
+// applied. All Driver methods go through this helper so the socket
+// scoping is enforced in exactly one place.
+func (d *Driver) cmd(args ...string) *exec.Cmd {
+	if d.socket != "" {
+		full := make([]string, 0, len(args)+2)
+		full = append(full, "-L", d.socket)
+		full = append(full, args...)
+		return exec.Command(d.binary, full...)
+	}
+	return exec.Command(d.binary, args...)
+}
+
+// Socket returns the tmux socket name the driver is scoped to, or
+// empty string for the default tmux server. Used by test teardown to
+// kill the right server.
+func (d *Driver) Socket() string { return d.socket }
 
 // HasSession checks if a tmux session exists.
 func (d *Driver) HasSession(name string) bool {
-	cmd := exec.Command(d.binary, "has-session", "-t", name)
-	return cmd.Run() == nil
+	return d.cmd("has-session", "-t", name).Run() == nil
 }
 
 // ListSessions returns the names of every tmux session on the server.
 // If no tmux server is running, returns an empty slice and no error —
 // that's the same "no sessions" condition as a freshly started daemon.
 func (d *Driver) ListSessions() ([]string, error) {
-	cmd := exec.Command(d.binary, "list-sessions", "-F", "#S")
-	out, err := cmd.Output()
+	out, err := d.cmd("list-sessions", "-F", "#S").Output()
 	if err != nil {
 		// tmux exits non-zero with "no server running" when there is no
 		// tmux server. Treat that as "zero sessions", not an error.
@@ -57,8 +87,7 @@ func (d *Driver) NewSession(name string) error {
 	if d.HasSession(name) {
 		return nil
 	}
-	cmd := exec.Command(d.binary, "new-session", "-d", "-s", name)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := d.cmd("new-session", "-d", "-s", name).CombinedOutput(); err != nil {
 		return fmt.Errorf("new-session %s: %s: %w", name, string(out), err)
 	}
 	return nil
@@ -89,8 +118,7 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 	}
 	args = append(args, command)
 
-	cmd := exec.Command(d.binary, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := d.cmd(args...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("new-pane in %s: %s: %w", session, string(out), err)
 	}
@@ -98,13 +126,11 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 
 	// Set pane title for identification.
 	if title != "" {
-		setTitle := exec.Command(d.binary, "select-pane", "-t", paneID, "-T", title)
-		_ = setTitle.Run()
+		_ = d.cmd("select-pane", "-t", paneID, "-T", title).Run()
 	}
 
 	// Ensure window closes when command exits (don't leave orphaned shells).
-	setOpt := exec.Command(d.binary, "set-option", "-t", paneID, "remain-on-exit", "off")
-	_ = setOpt.Run()
+	_ = d.cmd("set-option", "-t", paneID, "remain-on-exit", "off").Run()
 
 	return paneID, nil
 }
@@ -117,14 +143,12 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 // unknown IDs. See ArcavenAE/marvel#10 — before this change ReapDead
 // never saw dead panes and sessions stayed 'running/unknown' forever.
 func (d *Driver) HasPane(paneID string) bool {
-	cmd := exec.Command(d.binary, "list-panes", "-t", paneID, "-F", "#{pane_id}")
-	return cmd.Run() == nil
+	return d.cmd("list-panes", "-t", paneID, "-F", "#{pane_id}").Run() == nil
 }
 
 // KillPane destroys a specific pane.
 func (d *Driver) KillPane(paneID string) error {
-	cmd := exec.Command(d.binary, "kill-pane", "-t", paneID)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := d.cmd("kill-pane", "-t", paneID).CombinedOutput(); err != nil {
 		return fmt.Errorf("kill-pane %s: %s: %w", paneID, string(out), err)
 	}
 	return nil
@@ -135,9 +159,24 @@ func (d *Driver) KillSession(name string) error {
 	if !d.HasSession(name) {
 		return nil
 	}
-	cmd := exec.Command(d.binary, "kill-session", "-t", name)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := d.cmd("kill-session", "-t", name).CombinedOutput(); err != nil {
 		return fmt.Errorf("kill-session %s: %s: %w", name, string(out), err)
+	}
+	return nil
+}
+
+// KillServer shuts down the tmux server this driver is scoped to.
+// Used by test teardown to drop a per-package tmux server at the end of
+// the package's tests; safe to call when no server is running (returns
+// nil). Production code should not call this — it tears down every
+// tmux workload on the server.
+func (d *Driver) KillServer() error {
+	if out, err := d.cmd("kill-server").CombinedOutput(); err != nil {
+		// kill-server exits non-zero when no server is running.
+		if strings.Contains(string(out), "no server running") {
+			return nil
+		}
+		return fmt.Errorf("kill-server: %s: %w", string(out), err)
 	}
 	return nil
 }
@@ -152,14 +191,12 @@ func (d *Driver) SendKeys(paneID, text string, literal, enter bool) error {
 	}
 	args = append(args, text)
 
-	cmd := exec.Command(d.binary, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := d.cmd(args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("send-keys %s: %s: %w", paneID, string(out), err)
 	}
 
 	if enter {
-		enterCmd := exec.Command(d.binary, "send-keys", "-t", paneID, "Enter")
-		if out, err := enterCmd.CombinedOutput(); err != nil {
+		if out, err := d.cmd("send-keys", "-t", paneID, "Enter").CombinedOutput(); err != nil {
 			return fmt.Errorf("send-keys Enter %s: %s: %w", paneID, string(out), err)
 		}
 	}
@@ -169,8 +206,7 @@ func (d *Driver) SendKeys(paneID, text string, literal, enter bool) error {
 // CapturePane captures the visible content of a tmux pane and returns it as a
 // string. Captures the entire visible area including trailing whitespace lines.
 func (d *Driver) CapturePane(paneID string) (string, error) {
-	cmd := exec.Command(d.binary, "capture-pane", "-t", paneID, "-p")
-	out, err := cmd.CombinedOutput()
+	out, err := d.cmd("capture-pane", "-t", paneID, "-p").CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("capture-pane %s: %s: %w", paneID, string(out), err)
 	}
@@ -181,10 +217,9 @@ func (d *Driver) CapturePane(paneID string) (string, error) {
 // numbers. Negative values reference the scrollback buffer (e.g., -100 for
 // 100 lines of history). This allows capturing scrollback beyond the visible area.
 func (d *Driver) CapturePaneRange(paneID string, start, end int) (string, error) {
-	cmd := exec.Command(d.binary, "capture-pane", "-t", paneID, "-p",
+	out, err := d.cmd("capture-pane", "-t", paneID, "-p",
 		"-S", fmt.Sprintf("%d", start),
-		"-E", fmt.Sprintf("%d", end))
-	out, err := cmd.CombinedOutput()
+		"-E", fmt.Sprintf("%d", end)).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("capture-pane %s [%d:%d]: %s: %w", paneID, start, end, string(out), err)
 	}
@@ -193,9 +228,8 @@ func (d *Driver) CapturePaneRange(paneID string, start, end int) (string, error)
 
 // ListPanes lists all panes across all windows in a session.
 func (d *Driver) ListPanes(session string) ([]PaneInfo, error) {
-	cmd := exec.Command(d.binary, "list-panes", "-t", session, "-s",
-		"-F", "#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{pane_title}")
-	out, err := cmd.CombinedOutput()
+	out, err := d.cmd("list-panes", "-t", session, "-s",
+		"-F", "#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{pane_title}").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("list-panes %s: %s: %w", session, string(out), err)
 	}

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -126,6 +126,42 @@ func TestListSessions(t *testing.T) {
 	}
 }
 
+func TestHasPane(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	sessionName := "marvel-test-haspane"
+	t.Cleanup(func() {
+		_ = d.KillSession(sessionName)
+	})
+	if err := d.NewSession(sessionName); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+
+	paneID, err := d.NewPane(sessionName, "sleep 60", "haspane-test", nil)
+	if err != nil {
+		t.Fatalf("new pane: %v", err)
+	}
+
+	if !d.HasPane(paneID) {
+		t.Fatalf("expected HasPane(%s)=true for live pane", paneID)
+	}
+
+	// Regression guard — ArcavenAE/marvel#10. Kill the pane; HasPane
+	// must report false. The old implementation used display-message -p
+	// which returned exit 0 even for dead panes, so ReapDead never
+	// reaped and orphan sessions stayed 'running/unknown' forever.
+	if err := d.KillPane(paneID); err != nil {
+		t.Fatalf("kill pane: %v", err)
+	}
+	if d.HasPane(paneID) {
+		t.Fatalf("HasPane(%s)=true after kill-pane — should be false", paneID)
+	}
+}
+
 func TestSendKeys(t *testing.T) {
 	skipIfNoTmux(t)
 	d, err := NewDriver()

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -1,8 +1,12 @@
 package tmux
 
 import (
+	"fmt"
 	"os/exec"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func skipIfNoTmux(t *testing.T) {
@@ -276,15 +280,106 @@ func TestCapturePaneRange(t *testing.T) {
 		t.Fatalf("send echo: %v", err)
 	}
 
-	_ = exec.Command("sleep", "0.3").Run()
+	// Poll until content is actually rendered instead of sleep-then-
+	// capture: tmux send-keys returning isn't a guarantee the shell has
+	// executed, and a blanket sleep hides real problems. If the pane
+	// disappears mid-wait (shell exited) surface that as a fatal — the
+	// test's job is to exercise capture on a live pane.
+	var content string
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !d.HasPane(paneID) {
+			t.Fatalf("pane %s vanished before capture — investigate shell behavior", paneID)
+		}
+		c, err := d.CapturePaneRange(paneID, 0, 4)
+		if err == nil && strings.Contains(c, "LINE_TEST") {
+			content = c
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if content == "" {
+		_, err := d.CapturePaneRange(paneID, 0, 4)
+		t.Fatalf("capture-pane range did not see LINE_TEST within deadline: lastErr=%v", err)
+	}
+}
 
-	// Capture first 5 lines of visible area
-	content, err := d.CapturePaneRange(paneID, 0, 4)
+// TestDriverConcurrentUse exercises the production pattern: many
+// goroutines sharing one Driver and one tmux server, each owning its
+// own session and performing the full create-inject-capture-teardown
+// motion. Proves the driver (and tmux itself) serializes safely under
+// concurrent use — not a 'tests don't race each other' isolation fix
+// but a 'marvel daemon handles N concurrent RPCs' guarantee.
+//
+// Each goroutine owns its own session; no goroutine touches another's
+// pane IDs. Failures here indicate a real driver-level concurrency
+// bug, not a test flake.
+func TestDriverConcurrentUse(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
 	if err != nil {
-		t.Fatalf("capture-pane range: %v", err)
+		t.Fatalf("new driver: %v", err)
 	}
 
-	if content == "" {
-		t.Fatal("expected non-empty range content")
+	const workers = 8
+	const opsPerWorker = 3
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+
+	for w := 0; w < workers; w++ {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sessionName := fmt.Sprintf("marvel-test-concurrent-%d", w)
+			defer func() { _ = d.KillSession(sessionName) }()
+
+			if err := d.NewSession(sessionName); err != nil {
+				errCh <- fmt.Errorf("worker %d new-session: %w", w, err)
+				return
+			}
+
+			for op := 0; op < opsPerWorker; op++ {
+				paneID, err := d.NewPane(sessionName,
+					fmt.Sprintf("sleep %d", 30+op), // long-running so pane stays alive
+					fmt.Sprintf("worker-%d-op-%d", w, op), nil)
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d op %d new-pane: %w", w, op, err)
+					return
+				}
+				if !d.HasPane(paneID) {
+					errCh <- fmt.Errorf("worker %d op %d HasPane(%s)=false right after NewPane", w, op, paneID)
+					return
+				}
+				// Inject something and immediately read it back.
+				marker := fmt.Sprintf("CONCURRENT-%d-%d", w, op)
+				if err := d.SendKeys(paneID, marker, true, false); err != nil {
+					errCh <- fmt.Errorf("worker %d op %d send-keys: %w", w, op, err)
+					return
+				}
+				if _, err := d.CapturePane(paneID); err != nil {
+					errCh <- fmt.Errorf("worker %d op %d capture: %w", w, op, err)
+					return
+				}
+				// Kill our own pane. Production pattern: sessions clean
+				// up their own panes; we do not reach into another
+				// worker's sessions.
+				if err := d.KillPane(paneID); err != nil {
+					errCh <- fmt.Errorf("worker %d op %d kill-pane: %w", w, op, err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	var failures []string
+	for err := range errCh {
+		failures = append(failures, err.Error())
+	}
+	if len(failures) > 0 {
+		t.Fatalf("concurrent use produced %d failures:\n  %s", len(failures), strings.Join(failures, "\n  "))
 	}
 }

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -1,0 +1,33 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestMain isolates this test binary on a dedicated tmux server
+// (tmux -L <socket>). `go test ./...` forks one binary per package,
+// and different binaries are independent processes — not production's
+// one-binary-many-goroutines model. Without isolation each binary
+// would churn the same system-wide tmux server, racing against siblings.
+//
+// Intra-binary concurrency (the actual prod pattern — many goroutines
+// sharing one Driver) is exercised by TestDriverConcurrentUse.
+//
+// If tmux isn't installed, the individual tests skip themselves; no
+// socket to set up and nothing to tear down.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		os.Exit(m.Run())
+	}
+	socket := fmt.Sprintf("marvel-test-tmux-%d", os.Getpid())
+	if err := os.Setenv("MARVEL_TMUX_SOCKET", socket); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set MARVEL_TMUX_SOCKET: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

Coverage sprint. Totals moved from **37.4% → 39.1%** (+1.7pp). Per-package: daemon **28.2 → 33.9**, session **53.4 → 60.3**, tmux **84.0 → 89.0**. Also fixes marvel#10 as a side effect of writing the regression test.

### Tests added
- `TestHandleInjectCapture` — inject RPC round-trip + capture assertion
- `TestHandleInjectUnknownSession` — error path
- `TestHandleLogs` / `TestHandleLogsDefaultN` — log-ring RPC (session-025 shipped B14 with 0% coverage)
- `TestReapDead` (session) — kill pane out-of-band, assert store cleared
- `TestHasPane` (tmux) — regression guard

### Bug fix

While writing `TestReapDead` I discovered `Driver.HasPane` uses `display-message -t <paneID> -p ""` which returns exit 0 even for dead panes. `ReapDead` therefore never reaped. This is the root cause of **#10** — sessions stuck 'running/unknown' after their underlying process exits. Swapped to `list-panes -t <paneID> -F #{pane_id}` which correctly errors on unknown pane IDs.

### CI gate

New 'Enforce coverage floor' step in `ci.yml`'s quality-gate job, floor at **38.0%** (1.1pp headroom below current). Intended to be ratcheted up as coverage improves; must not decrease.

## Test plan

- [x] `just lint` — clean
- [x] `just test-race` — all packages green
- [x] New `TestHasPane` fails on old `HasPane` (verified by reverting), passes on new — regression guard works
- [x] Coverage gate logic verified locally: passes at 38.0%, would fail at 50.0%
- [ ] Validate on Skippy's Pi 5 once alpha lands (linux/arm64) — particularly session cleanup behavior in a long-running fleet

Refs: #10