### PR TITLE
feat(runtime): Role.DangerousPermissions — forestage adapter passthrough

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -93,9 +93,17 @@ type Role struct {
 	Runtime       Runtime       `toml:"runtime"`
 	RestartPolicy RestartPolicy `toml:"restart_policy,omitempty"`
 	Permissions   string        `toml:"permissions,omitempty"`
-	Persona       string        `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
-	Identity      string        `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")
-	HealthCheck   *HealthCheck  `toml:"-"`
+	// DangerousPermissions, when true, causes adapters that support it to
+	// append --dangerously-skip-permissions (or equivalent) to the spawned
+	// agent. Intended for autonomous marvel-managed teams where no
+	// interactive approver exists. Per orc finding-023, the permission UI
+	// is a cooperative contract; real enforcement belongs to curtain.
+	// Combined with a curtain profile, this is the default sensible shape
+	// for autonomous fleet agents.
+	DangerousPermissions bool         `toml:"dangerous_permissions,omitempty"`
+	Persona              string       `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
+	Identity             string       `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")
+	HealthCheck          *HealthCheck `toml:"-"`
 }
 
 // ShiftPhase represents the current phase of a shift operation.

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -275,3 +275,35 @@ func TestForestagePrepareNoPermissions(t *testing.T) {
 		t.Errorf("command should still inject identity prompt, got: %s", result.Command)
 	}
 }
+
+func TestForestagePrepareDangerousPermissions(t *testing.T) {
+	t.Parallel()
+	f := &Forestage{}
+	ctx := testContext()
+	ctx.Role.DangerousPermissions = true
+
+	result, err := f.Prepare(ctx)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if !strings.Contains(result.Command, "--dangerously-skip-permissions") {
+		t.Errorf("command should contain --dangerously-skip-permissions when Role.DangerousPermissions=true, got: %s", result.Command)
+	}
+}
+
+func TestForestagePrepareDangerousPermissionsDefaultOff(t *testing.T) {
+	t.Parallel()
+	f := &Forestage{}
+	ctx := testContext()
+	// Role.DangerousPermissions not set — default false
+
+	result, err := f.Prepare(ctx)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if strings.Contains(result.Command, "--dangerously-skip-permissions") {
+		t.Errorf("command must NOT contain --dangerously-skip-permissions when Role.DangerousPermissions is false (default), got: %s", result.Command)
+	}
+}

--- a/internal/runtime/forestage.go
+++ b/internal/runtime/forestage.go
@@ -62,6 +62,15 @@ func (f *Forestage) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 		args = append(args, "--permission-mode", ctx.Role.Permissions)
 	}
 
+	// Inject dangerous-skip when the role opts in. Forestage accepts this
+	// natively (ArcavenAE/forestage@4c4e28a) and passes it through as
+	// --dangerously-skip-permissions to the claude subprocess. Intended
+	// for autonomous marvel-managed agents where no interactive approver
+	// exists — see orc finding-023 for the contract-vs-fence framing.
+	if ctx.Role.DangerousPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+
 	// Inject script if specified in the role's runtime config.
 	if ctx.Session.Runtime.Script != "" {
 		args = append(args, "--script", ctx.Session.Runtime.Script)


### PR DESCRIPTION
## Summary

Adds `Role.DangerousPermissions bool` to marvel's `Role` type. When true, the forestage adapter appends `--dangerously-skip-permissions` to the spawned command. Forestage accepts this natively as of [ArcavenAE/forestage@4c4e28a](https://github.com/ArcavenAE/forestage/commit/4c4e28a) and passes it through to claude.

## Why

Per orc `_kos/findings/finding-023-permission-contract-vs-sandbox.md`, the Claude permission UI is a **cooperative contract** with the agent, not a security boundary. The actual enforcement belongs to curtain (kernel-level sandbox). Combined with a curtain profile, `--dangerously-skip-permissions` is the default sensible shape for autonomous fleet agents: skip the contract ceremony, let the kernel bound the process.

This is the marvel-side counterpart to forestage's Part A of ArcavenAE/forestage#37.

## Manifest example

```toml
[[team.role]]
name = "worker"
replicas = 3
dangerous_permissions = true

  [team.role.runtime]
  image = "forestage"
```

## Test plan

- [x] `TestForestagePrepareDangerousPermissions` — true appends the flag
- [x] `TestForestagePrepareDangerousPermissionsDefaultOff` — default (false) does not append
- [x] `just lint` (0 issues)
- [x] `just test` (all packages pass)

## Refs

- aae-orc-8gr (closes)
- orc finding-023 (contract-vs-fence)
- orc finding-024 (the Policy + Projection work that will subsume this under a richer model)