### PR TITLE
fix(health): exponential backoff + max-restart cap on crashing roles (#11)

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -15,6 +15,13 @@ const (
 	SessionRunning   SessionState = "running"
 	SessionSucceeded SessionState = "succeeded"
 	SessionFailed    SessionState = "failed"
+	// SessionCrashLoopBackOff is the state the reconciler assigns to a
+	// role whose replicas keep failing faster than they start, while
+	// backoff is in effect. Borrowed from Kubernetes' vocabulary.
+	// The session stays in this state until backoff elapses and
+	// another restart is attempted, or MaxRestarts is reached and the
+	// state transitions to Failed.
+	SessionCrashLoopBackOff SessionState = "crashloop-backoff"
 )
 
 // HealthState represents the health of a session.
@@ -104,6 +111,11 @@ type Role struct {
 	Persona              string       `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
 	Identity             string       `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")
 	HealthCheck          *HealthCheck `toml:"-"`
+	// MaxRestarts caps the number of restarts for any single replica
+	// slot in this role before the reconciler gives up and leaves the
+	// session in SessionFailed. Zero means unlimited; negative values
+	// are clamped to zero. See ArcavenAE/marvel#11.
+	MaxRestarts int `toml:"max_restarts,omitempty"`
 }
 
 // ShiftPhase represents the current phase of a shift operation.

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -21,11 +21,91 @@ type Controller struct {
 	sessMgr    *session.Manager
 	SocketPath string
 	mu         sync.Mutex
+
+	// roleHealth tracks per-role crash-loop state: restart count and
+	// next-allowed-restart deadline. Keyed by workspace/team/role so
+	// state survives session delete+recreate across restarts — the
+	// pre-fix implementation reset the counter on every rebuild, which
+	// made the backoff and max-restart caps impossible to enforce.
+	// See ArcavenAE/marvel#11.
+	roleHealth map[string]*RoleHealth
+
+	// now is an injection point for tests; nil means time.Now().UTC().
+	now func() time.Time
 }
+
+// RoleHealth is the per-role crash-loop tracking state.
+type RoleHealth struct {
+	RestartCount  int
+	LastRestartAt time.Time
+	// BackoffUntil is the wall-clock after which the next restart is
+	// allowed. Sessions whose role is inside the backoff window are
+	// marked SessionCrashLoopBackOff and left alive (not deleted) so
+	// operators see the condition and the reconciler doesn't respawn.
+	BackoffUntil time.Time
+}
+
+// Restart backoff configuration. Exponential with a 5-minute cap — the
+// defaults Skippy suggested in ArcavenAE/marvel#11.
+const (
+	restartBackoffInitial = 30 * time.Second
+	restartBackoffMax     = 5 * time.Minute
+)
 
 // NewController creates a team controller.
 func NewController(store *api.Store, sessMgr *session.Manager) *Controller {
-	return &Controller{store: store, sessMgr: sessMgr}
+	return &Controller{
+		store:      store,
+		sessMgr:    sessMgr,
+		roleHealth: make(map[string]*RoleHealth),
+	}
+}
+
+// computeBackoff returns the exponential backoff duration for the nth
+// restart (1-indexed): 30s, 60s, 2m, 4m, 5m, 5m, ...
+func computeBackoff(n int) time.Duration {
+	if n <= 1 {
+		return restartBackoffInitial
+	}
+	d := restartBackoffInitial << (n - 1)
+	if d <= 0 || d > restartBackoffMax { // guards against overflow too
+		return restartBackoffMax
+	}
+	return d
+}
+
+func (c *Controller) nowUTC() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now().UTC()
+}
+
+func (c *Controller) getRoleHealth(key string) *RoleHealth {
+	rh, ok := c.roleHealth[key]
+	if !ok {
+		rh = &RoleHealth{}
+		c.roleHealth[key] = rh
+	}
+	return rh
+}
+
+// RoleHealthSnapshot returns the current restart state for a role,
+// useful for tests and for `marvel describe team` observability.
+// Returns (nil, false) if the role has no recorded crash-loop history.
+func (c *Controller) RoleHealthSnapshot(workspace, team, role string) (*RoleHealth, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := workspace + "/" + team + "/" + role
+	rh, ok := c.roleHealth[key]
+	if !ok {
+		return nil, false
+	}
+	return &RoleHealth{
+		RestartCount:  rh.RestartCount,
+		LastRestartAt: rh.LastRestartAt,
+		BackoffUntil:  rh.BackoffUntil,
+	}, true
 }
 
 // ReconcileOnce runs one reconciliation pass for all teams.
@@ -62,6 +142,15 @@ func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
 	actual := len(current)
 
 	if actual < desired {
+		// Respect crash-loop backoff. If the role is cooling down from
+		// a recent restart, hold off on spawning replacements until the
+		// backoff window elapses. Without this the reconciler would
+		// immediately recreate a session we just deleted and defeat
+		// the whole backoff. See ArcavenAE/marvel#11.
+		roleKey := t.Workspace + "/" + t.Name + "/" + role.Name
+		if rh, ok := c.roleHealth[roleKey]; ok && c.nowUTC().Before(rh.BackoffUntil) {
+			return
+		}
 		for i := actual; i < desired; i++ {
 			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, t.Generation, c.nextIndex(t, role, t.Generation))
 			sess := &api.Session{
@@ -149,14 +238,14 @@ func (c *Controller) evaluateHealth() {
 
 		if sess.FailureCount >= role.HealthCheck.FailureThreshold {
 			sess.HealthState = api.HealthUnhealthy
-			c.applyRestartPolicy(sess, role)
+			c.applyRestartPolicy(sess, t, role)
 		} else {
 			sess.HealthState = api.HealthUnhealthy
 		}
 	}
 }
 
-func (c *Controller) applyRestartPolicy(sess *api.Session, role *api.Role) {
+func (c *Controller) applyRestartPolicy(sess *api.Session, t *api.Team, role *api.Role) {
 	switch role.RestartPolicy {
 	case api.RestartNever:
 		sess.State = api.SessionFailed
@@ -164,18 +253,59 @@ func (c *Controller) applyRestartPolicy(sess *api.Session, role *api.Role) {
 			sess.Key(), sess.FailureCount)
 	case api.RestartOnFailure:
 		if sess.State == api.SessionFailed {
-			c.restartSession(sess)
+			c.restartSession(sess, t, role)
 		} else {
 			sess.State = api.SessionFailed
 		}
 	default: // RestartAlways
-		c.restartSession(sess)
+		c.restartSession(sess, t, role)
 	}
 }
 
-func (c *Controller) restartSession(sess *api.Session) {
-	log.Printf("health: restarting session %s (failures=%d, restarts=%d)",
-		sess.Key(), sess.FailureCount, sess.RestartCount)
+// restartSession decides whether to restart an unhealthy session now,
+// hold it in crash-loop backoff, or mark it permanently failed. State
+// is tracked on the Controller's roleHealth map (keyed by workspace/
+// team/role) so the restart count and backoff window survive the
+// Delete+Recreate round-trip that a restart implies.
+//
+// Policy summary:
+//   - First restart is immediate (k8s-style).
+//   - Subsequent restarts wait the exponential backoff window.
+//   - If role.MaxRestarts > 0 and we've hit it, the session moves to
+//     SessionFailed and stays there.
+//
+// Ref: ArcavenAE/marvel#11, aae-orc-xhk.
+func (c *Controller) restartSession(sess *api.Session, t *api.Team, role *api.Role) {
+	roleKey := t.Workspace + "/" + t.Name + "/" + role.Name
+	rh := c.getRoleHealth(roleKey)
+	now := c.nowUTC()
+
+	// Permanent failure: max restarts reached.
+	if role.MaxRestarts > 0 && rh.RestartCount >= role.MaxRestarts {
+		if sess.State != api.SessionFailed {
+			log.Printf("health: session %s: role %s hit max_restarts=%d, not restarting",
+				sess.Key(), roleKey, role.MaxRestarts)
+		}
+		sess.State = api.SessionFailed
+		return
+	}
+
+	// Inside the backoff window: mark visible, keep the pane alive,
+	// let the reconciler hold steady — do not create replacements
+	// during backoff, and do not re-kill the session we're waiting on.
+	if now.Before(rh.BackoffUntil) {
+		sess.State = api.SessionCrashLoopBackOff
+		return
+	}
+
+	// Backoff elapsed (or first-ever restart) — proceed.
+	rh.RestartCount++
+	rh.LastRestartAt = now
+	nextBackoff := computeBackoff(rh.RestartCount + 1)
+	rh.BackoffUntil = now.Add(nextBackoff)
+
+	log.Printf("health: restarting session %s (role %s restart #%d, next backoff=%s)",
+		sess.Key(), roleKey, rh.RestartCount, nextBackoff)
 	sess.RestartCount++
 	sess.State = api.SessionFailed
 	if err := c.sessMgr.Delete(sess.Key()); err != nil {

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -481,6 +481,11 @@ func TestHealthRestartAlways(t *testing.T) {
 	store, _, ctrl, cleanup := setup(t)
 	t.Cleanup(cleanup)
 
+	// Clock injection: lets us fast-forward past the crash-loop backoff
+	// window so we can observe recreation in a single test run.
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
 	createTeamFixture(t, store, "test-health-restart", "squad", []api.Role{
 		{
 			Name: "worker", Replicas: 1,
@@ -500,18 +505,212 @@ func TestHealthRestartAlways(t *testing.T) {
 	// Set stale heartbeat.
 	sessions[0].LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
 
-	// Eval + reconcile: unhealthy → delete → reconciler recreates.
+	// Tick 1: unhealthy → first restart is immediate (count goes 0→1),
+	// session is deleted, but reconciler holds off on recreating because
+	// the role is now in backoff.
+	ctrl.ReconcileOnce()
+	if got := store.ListSessionsByTeamRole("test-health-restart", "squad", "worker"); len(got) != 0 {
+		t.Fatalf("expected 0 sessions immediately after first restart (backoff active), got %d", len(got))
+	}
+	rh, ok := ctrl.RoleHealthSnapshot("test-health-restart", "squad", "worker")
+	if !ok || rh.RestartCount != 1 {
+		t.Fatalf("expected RestartCount=1 after first restart, got %+v (ok=%v)", rh, ok)
+	}
+
+	// Fast-forward past the backoff window. The reconciler should now
+	// see actual < desired and respawn a replacement.
+	clock.Advance(2 * time.Minute)
 	ctrl.ReconcileOnce()
 
 	sessions = store.ListSessionsByTeamRole("test-health-restart", "squad", "worker")
 	if len(sessions) != 1 {
-		t.Fatalf("expected 1 session after restart, got %d", len(sessions))
+		t.Fatalf("expected 1 session after backoff elapsed, got %d", len(sessions))
 	}
-	// Recreated session has a fresh CreatedAt.
 	if !sessions[0].CreatedAt.After(origCreatedAt) {
 		t.Fatal("expected new session with later CreatedAt after restart")
 	}
 }
+
+// TestHealthRestartBackoffHoldsReplacement: after the first restart
+// the reconciler must NOT respawn a replacement for the dead replica
+// until the backoff window elapses.
+func TestHealthRestartBackoffHoldsReplacement(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-health-hold", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartAlways,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	store.ListSessionsByTeamRole("test-health-hold", "squad", "worker")[0].LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+	ctrl.ReconcileOnce() // first restart triggered + session deleted
+
+	// Several reconciler ticks while still inside backoff: actual=0,
+	// desired=1, but no respawn because the role is cooling down.
+	for i := 0; i < 5; i++ {
+		clock.Advance(5 * time.Second)
+		ctrl.ReconcileOnce()
+		got := store.ListSessionsByTeamRole("test-health-hold", "squad", "worker")
+		if len(got) != 0 {
+			t.Fatalf("tick %d: backoff violated — found %d sessions", i, len(got))
+		}
+	}
+
+	// Backoff elapses, respawn happens.
+	clock.Advance(90 * time.Second) // definitely past 60s initial backoff
+	ctrl.ReconcileOnce()
+	got := store.ListSessionsByTeamRole("test-health-hold", "squad", "worker")
+	if len(got) != 1 {
+		t.Fatalf("expected respawn once backoff elapsed, got %d sessions", len(got))
+	}
+}
+
+// TestHealthRestartBackoffSiblingMarked: when one replica triggers the
+// backoff and a sibling in the same role then fails, the sibling is
+// marked SessionCrashLoopBackOff and kept alive — it does NOT get a
+// second restart inside the same cooling window.
+func TestHealthRestartBackoffSiblingMarked(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-health-sibling", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 2,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartAlways,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	ctrl.ReconcileOnce() // both workers created
+	workers := store.ListSessionsByTeamRole("test-health-sibling", "squad", "worker")
+	if len(workers) != 2 {
+		t.Fatalf("expected 2 workers, got %d", len(workers))
+	}
+
+	// Fail worker-0 → triggers first restart for the role.
+	workers[0].LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+	ctrl.ReconcileOnce()
+
+	// Now fail worker-1 while still inside the backoff window.
+	// (Only one session survives; find it fresh from the store.)
+	workers = store.ListSessionsByTeamRole("test-health-sibling", "squad", "worker")
+	if len(workers) != 1 {
+		t.Fatalf("expected 1 surviving worker during backoff, got %d", len(workers))
+	}
+	workers[0].LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+	ctrl.ReconcileOnce()
+
+	// Sibling must be alive, marked CrashLoopBackOff, and the role
+	// restart counter must NOT have ticked past 1.
+	workers = store.ListSessionsByTeamRole("test-health-sibling", "squad", "worker")
+	if len(workers) != 1 {
+		t.Fatalf("sibling should still exist during backoff, got %d", len(workers))
+	}
+	if workers[0].State != api.SessionCrashLoopBackOff {
+		t.Fatalf("sibling expected SessionCrashLoopBackOff, got %q", workers[0].State)
+	}
+	rh, _ := ctrl.RoleHealthSnapshot("test-health-sibling", "squad", "worker")
+	if rh.RestartCount != 1 {
+		t.Fatalf("RestartCount must stay at 1 during backoff, got %d", rh.RestartCount)
+	}
+}
+
+// TestHealthRestartMaxReached: once the role passes MaxRestarts the
+// session is marked Failed permanently and not respawned.
+func TestHealthRestartMaxReached(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-health-maxrst", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartAlways,
+			MaxRestarts:   2,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	// Loop: reconcile, stale the current session, advance clock, reconcile.
+	// After 2 successful restarts, a third failure must not be restarted.
+	for i := 0; i < 3; i++ {
+		ctrl.ReconcileOnce() // creates or recreates session
+		got := store.ListSessionsByTeamRole("test-health-maxrst", "squad", "worker")
+		if len(got) == 0 {
+			t.Fatalf("iteration %d: expected a running session", i)
+		}
+		got[0].LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+		ctrl.ReconcileOnce() // fail + (maybe) restart
+		clock.Advance(10 * time.Minute)
+	}
+
+	rh, _ := ctrl.RoleHealthSnapshot("test-health-maxrst", "squad", "worker")
+	if rh.RestartCount != 2 {
+		t.Fatalf("expected RestartCount capped at MaxRestarts=2, got %d", rh.RestartCount)
+	}
+	// After the third failure, the session should be in Failed (not
+	// recreated, not CrashLoopBackOff).
+	ctrl.ReconcileOnce()
+	got := store.ListSessionsByTeamRole("test-health-maxrst", "squad", "worker")
+	if len(got) != 1 {
+		t.Fatalf("expected failed session still in store, got %d", len(got))
+	}
+	if got[0].State != api.SessionFailed {
+		t.Fatalf("expected state=failed after MaxRestarts exceeded, got %q", got[0].State)
+	}
+}
+
+// TestComputeBackoff locks in the exponential curve shape so future
+// tweaks are intentional and reviewable.
+func TestComputeBackoff(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		n    int
+		want time.Duration
+	}{
+		{0, 30 * time.Second},
+		{1, 30 * time.Second},
+		{2, 60 * time.Second},
+		{3, 120 * time.Second},
+		{4, 240 * time.Second},
+		{5, 5 * time.Minute}, // capped
+		{20, 5 * time.Minute},
+	}
+	for _, tc := range cases {
+		if got := computeBackoff(tc.n); got != tc.want {
+			t.Errorf("computeBackoff(%d) = %s, want %s", tc.n, got, tc.want)
+		}
+	}
+}
+
+// testClock is a simple monotonically-advancing clock used in place of
+// time.Now for deterministic crash-loop tests.
+type testClock struct {
+	t time.Time
+}
+
+func newTestClock(start time.Time) *testClock { return &testClock{t: start} }
+func (c *testClock) Now() time.Time           { return c.t }
+func (c *testClock) Advance(d time.Duration)  { c.t = c.t.Add(d) }
 
 func TestShiftSessionNaming(t *testing.T) {
 	skipIfNoTmux(t)


### PR DESCRIPTION
## Summary

Closes the crash-loop footgun from #11. Reconciler used to restart failed sessions immediately with no backoff, and the restart counter lived on the session itself — so it reset every rebuild and the cap was silently ineffective. When any runtime goes into a crash loop, the daemon would spin pane IDs upward forever, burn CPU, and drown the log ring.

### Design

Crash-loop state moves off the session and onto the role:

- New per-role `RoleHealth` on the controller (keyed `workspace/team/role`). Restart count + backoff deadline survive delete+recreate.
- **Exponential backoff**: 30s → 60s → 120s → 240s → 5m (capped). First restart is immediate (k8s-style); subsequent wait.
- New `Role.MaxRestarts` manifest field. `0` = unlimited, `N` = transition to `SessionFailed` once exceeded.
- New `SessionCrashLoopBackOff` state — visible in `marvel get sessions` for sibling replicas that fail inside the same cooling window.
- `reconcileRole` respects the role's `BackoffUntil` and skips spawning replacements while cooling down. Without this the reconciler would immediately recreate what we just deleted and defeat the whole backoff.
- `Controller.now` injection point for deterministic tests.
- `Controller.RoleHealthSnapshot()` exposes state for tests today, `marvel describe team` tomorrow.

## Test plan

- [x] `just lint` — clean
- [x] `just test-race` — all packages green
- [x] New tests cover: first-restart-immediate + backoff-then-respawn, reconciler-holds-during-backoff, sibling-replica-marked-CrashLoopBackOff, max-restarts-cap-reached, and backoff-curve shape.
- [ ] Validate on Skippy's Pi 5 once alpha lands — feed a crashing role and observe exponential cadence + cap in the daemon log ring.

Refs: #11