### PR TITLE
fix(upgrade): route alpha channel to single marvel formula

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -97,10 +97,15 @@ func isOwnedByPackageManager(path string) bool {
 }
 
 func upgradeViaHomebrew(channel string) error {
+	// Note: marvel currently ships a single homebrew formula (`marvel`)
+	// covering both alpha and stable builds — goreleaser publishes
+	// alpha-tagged bottles to the same formula. The ArcavenAE/tap
+	// does not have a `marvel-a` formula. If/when alpha gets split
+	// into its own tap formula (the pattern used by forestage-a,
+	// threedoors-a, jr-a), route the alpha channel back here.
+	// The `channel` parameter is retained for that future fork.
+	_ = channel
 	formula := "ArcavenAE/tap/marvel"
-	if channel == "alpha" {
-		formula = "ArcavenAE/tap/marvel-a"
-	}
 
 	fmt.Printf("Installed via Homebrew. Running: brew upgrade %s\n", formula)
 


### PR DESCRIPTION
## Summary

\`marvel upgrade\` on an alpha build tried \`brew upgrade ArcavenAE/tap/marvel-a\`, but the tap only has \`marvel.rb\` — goreleaser publishes both stable and alpha bottles to a single formula. Homebrew errored with \`No available formula or cask with the name arcavenae/tap/marvel-a\` and \`marvel upgrade\` was a silent no-op for every alpha user.

Route both channels to \`ArcavenAE/tap/marvel\`. The \`channel\` parameter is retained for the day alpha/stable split into separate formulae (pattern used by \`forestage-a\`, \`threedoors-a\`, \`jr-a\`).

Discovered in session-026 while trying to upgrade from 718e8b6 → 4c7dbdf to pick up \`marvel daemon logs\`.

## Test plan

- [x] \`just lint\` clean
- [x] \`just test-race\` still green (upgrade has no tests; no regressions elsewhere)
- [ ] Validate with \`marvel upgrade\` once the next alpha lands

Refs: aae-orc-7ol