### PR TITLE
fix(apply): runtime pre-flight + exec-argv logging (#9)

### DIFF
--- a/_kos/ideas/log-rrd-deduplication.md
+++ b/_kos/ideas/log-rrd-deduplication.md
@@ -1,0 +1,127 @@
+# idea: RRD-style log deduplication in marvel's log ring
+
+Captured session-026. Not yet a frontier question — brainstorming.
+
+## The Cisco IOS idea
+
+Cisco's syslog suppresses repeated identical messages and emits a
+periodic summary line:
+
+```
+Apr 17 14:00:02: %LINK-3-UPDOWN: Interface GigabitEthernet0/1 changed state to down
+Apr 17 14:00:05: last message repeated 385 times
+```
+
+That single line replaces 385 rows. The reader learns two things the
+raw stream doesn't convey: the event is *still happening* and the
+rate at which it's happening.
+
+## Where it would help marvel
+
+The daemon's in-memory log ring (`internal/logbuf`, default 10k
+lines) is vulnerable to noisy repetition in at least three observed
+cases:
+
+1. **SSH connect polls** — Skippy's monitor loop hits the daemon at
+   0.5 Hz. `ssh: client connected: michael.pursifull (SHA256:…)` dominates
+   the ring. 10k lines cover ~5.5 hours before any interesting event
+   scrolls off. Filed as `aae-orc-1d2`.
+2. **CrashLoopBackOff chatter** — before this PR (#21), a failing
+   agent could spam `health: restarting session X (failures=N, restarts=M)`
+   every tick. With the fix, the rate is bounded by exponential backoff —
+   but the problem class remains for any repeating handler log line.
+3. **Reconciler "no change" tracing** — if a debug-level log is ever
+   added for the common "actual == desired, no-op" case, the ring
+   fills instantly.
+
+Same ring, same problem.
+
+## What RRD-style dedup looks like here
+
+Logical shape per-emit:
+
+- Compute a dedup key from the log line — either a content hash with
+  volatile fields blanked (timestamps, session IDs, pane numbers) or
+  an explicit `log.With(dedupKey=…)`.
+- Track per-key: `{lastSeen, count, firstSeen, template}`.
+- On emit of a key that matches the *previous* line: increment count,
+  do **not** write to the ring.
+- On emit of a different key: if the previous run had count > 1,
+  emit a summary line (`… repeated N times over Δ`), then emit the new
+  line.
+- On a timer (e.g. every 60s), flush any open run so long-running
+  repetition still surfaces.
+
+Cisco's original was "previous line only." Modern variants (Docker,
+systemd-journald via `Storage=persistent` + `--follow`, Loki's LogQL
+unwrap) track *multiple* concurrent keys so interleaved repetition
+still compresses. Pick one — "previous line only" is the lightest to
+ship and catches the three cases above, which are all monotonic.
+
+## Why this is interesting specifically for agent systems
+
+A couple of structural reasons AI-agent control planes amplify the
+win over plain server logging:
+
+1. **Agents can fail identically forever.** A shell with a typo in
+   `~/.zshrc` crashes the same way, `N` restarts in a row. A claude
+   subprocess with a broken permission-mode config fails the same
+   way. A curtain sandbox that denies an access a tool needs fails
+   the same way. Dedup captures "305 identical failures in 8 minutes"
+   as one informative line and preserves the original error verbatim
+   without repeating it.
+2. **Reading logs is itself an agent task.** A supervisor agent
+   tailing the log ring is a reasonable pattern. If it's digesting
+   the same line 1,000 times, it's paying 1,000 tokens and getting
+   one bit of information. Dedup lowers the cost of log-consumption
+   prompts and keeps context windows clear.
+3. **Ring buffers are small.** `DefaultLogBufferLines = 10000`. In
+   a multi-agent fleet with a chatty health check, one bad pod's
+   restart storm can push every startup line and cross-agent event
+   out of the window inside minutes — blinding the next operator
+   who runs `marvel daemon logs`.
+4. **Metric emission is latent in the log.** "Repeated 385 times
+   over 8m30s" *is* a rate metric — just not in the metrics pipeline.
+   A dedup layer that also exposes `{dedupKey, count, windowStart,
+   windowEnd}` as a structured event is a natural on-ramp to the
+   OTEL metric story without requiring all call sites to emit a
+   counter manually.
+
+## Things to probe
+
+- **Key extraction.** "Same line except for a pane ID" — regex to
+  normalize, or require call sites to opt in with an explicit key?
+  Auto-normalization is more useful but more dangerous (false dedup
+  collapses real distinct events).
+- **Summary cadence.** Emit on key-change only, or also periodically
+  while a run continues? Periodic is more informative but noisier.
+- **Tail behavior for `marvel daemon logs -f`.** Does `-f` see dedup
+  summaries or the raw stream? Probably dedup — the whole point is
+  the tail stays legible.
+- **Structured form.** Do we expose `repeat_count` as a field in the
+  logs RPC result for programmatic tailing, so supervisor agents and
+  dashboards can react to rate instead of line count?
+- **Interaction with existing work.**
+    - `aae-orc-1d2` (ssh poll noise) is the immediate motivator; dedup
+      makes that filed-but-undressed concern go away without hiding
+      the signal.
+    - `aae-orc-k0t` (marvel events — structured state-transition log)
+      is the structured-event cousin of this idea. If events exist,
+      dedup might live at the *event* layer too.
+    - Metrics (`internal/otel`) overlaps: dedup produces rate data
+      that could feed a `marvel_log_repeats_total{key=…}` counter.
+
+## Crystallization candidate
+
+If this idea gets picked up, the frontier question would be:
+
+> *What is the right boundary between structured events, OTEL metrics,
+> and a dedup-summarizing log ring in marvel's observability story?*
+
+Probe shape: implement a minimal "previous-line dedup" with a
+content-hash key strategy in `internal/logbuf`. Wire it into the
+daemon. Measure ring utilization over a 1-hour run on desk against
+the status quo. Decide whether to promote or graveyard.
+
+See also: `aae-orc-1d2`, `aae-orc-k0t`, Skippy's session-026 remote
+log testing.

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -135,6 +137,71 @@ func validateManifest(m *Manifest) (*Manifest, error) {
 		}
 	}
 	return m, nil
+}
+
+// ValidateRuntimes checks that each role's runtime command (and script,
+// if set) actually resolves on the daemon's host before the manifest
+// is applied. Returns an aggregated error listing every missing binary
+// so the operator sees all problems at once — not just the first.
+//
+// Resolution rules match exec.Command semantics:
+//   - Absolute path ("/usr/local/bin/forestage"): os.Stat must succeed.
+//   - Path with separator ("bin/simulator", "./scripts/x"): resolved
+//     relative to the daemon CWD via os.Stat.
+//   - Plain name ("sleep", "forestage"): exec.LookPath searches $PATH.
+//   - Empty command: flagged; the manifest parser already catches this
+//     but we defend here so misuse of the public API surfaces clearly.
+//
+// Scripts are checked as absolute/relative paths (never PATH-resolved)
+// because scripts are typically repo-relative files, not executables.
+//
+// See ArcavenAE/marvel#9 / aae-orc-rjm — the pre-fix behavior was to
+// silently create panes whose processes exited immediately, hiding the
+// real error behind a downstream "can't find pane" warning.
+func (m *Manifest) ValidateRuntimes() error {
+	var missing []string
+	for ti, t := range m.Teams {
+		for ri, r := range t.Roles {
+			ctx := fmt.Sprintf("team[%d=%s].role[%d=%s]", ti, t.Name, ri, r.Name)
+			if err := validateCommand(r.Runtime.Command); err != nil {
+				missing = append(missing, fmt.Sprintf("  %s: command %q: %v", ctx, r.Runtime.Command, err))
+			}
+			if r.Runtime.Script != "" {
+				if err := validateScript(r.Runtime.Script); err != nil {
+					missing = append(missing, fmt.Sprintf("  %s: script %q: %v", ctx, r.Runtime.Script, err))
+				}
+			}
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("runtime pre-flight failed on %d role(s):\n%s", len(missing), strings.Join(missing, "\n"))
+	}
+	return nil
+}
+
+func validateCommand(cmd string) error {
+	if cmd == "" {
+		return errors.New("empty")
+	}
+	// Path — either absolute or contains a separator — must exist on disk.
+	if filepath.IsAbs(cmd) || strings.ContainsRune(cmd, filepath.Separator) {
+		if _, err := os.Stat(cmd); err != nil {
+			return fmt.Errorf("not found: %w", err)
+		}
+		return nil
+	}
+	// Plain name — must resolve on $PATH.
+	if _, err := exec.LookPath(cmd); err != nil {
+		return fmt.Errorf("not on PATH: %w", err)
+	}
+	return nil
+}
+
+func validateScript(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("not found: %w", err)
+	}
+	return nil
 }
 
 // Apply converts a manifest into store resources and creates them.

--- a/internal/api/manifest_test.go
+++ b/internal/api/manifest_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -410,5 +411,95 @@ func TestManifestApply(t *testing.T) {
 	// Idempotent re-apply
 	if err := m.Apply(store); err != nil {
 		t.Fatalf("re-apply: %v", err)
+	}
+}
+
+func TestValidateRuntimesOK(t *testing.T) {
+	t.Parallel()
+	// Any two binaries guaranteed on POSIX test hosts.
+	m := &Manifest{
+		Workspace: ManifestWorkspace{Name: "ok"},
+		Teams: []ManifestTeam{{
+			Name: "squad",
+			Roles: []ManifestRole{
+				{Name: "a", Replicas: 1, Runtime: ManifestRuntime{Command: "sh"}},
+				{Name: "b", Replicas: 1, Runtime: ManifestRuntime{Command: "/bin/sh"}},
+			},
+		}},
+	}
+	if err := m.ValidateRuntimes(); err != nil {
+		t.Fatalf("expected OK, got %v", err)
+	}
+}
+
+func TestValidateRuntimesMissing(t *testing.T) {
+	t.Parallel()
+	m := &Manifest{
+		Workspace: ManifestWorkspace{Name: "missing"},
+		Teams: []ManifestTeam{{
+			Name: "squad",
+			Roles: []ManifestRole{
+				{Name: "a", Replicas: 1, Runtime: ManifestRuntime{Command: "sh"}},
+				{Name: "b", Replicas: 1, Runtime: ManifestRuntime{Command: "no-such-binary-marvel-9xyz"}},
+				{Name: "c", Replicas: 1, Runtime: ManifestRuntime{Command: "/nope/not/here"}},
+				// Relative path, also missing.
+				{Name: "d", Replicas: 1, Runtime: ManifestRuntime{Command: "bin/nothing-here"}},
+			},
+		}},
+	}
+	err := m.ValidateRuntimes()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	// Every missing role should be named in the error so operators see
+	// them all at once rather than one round-trip per problem.
+	for _, want := range []string{"role[1=b]", "role[2=c]", "role[3=d]", "runtime pre-flight failed on 3 role(s)"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected error to contain %q, got:\n%s", want, msg)
+		}
+	}
+	// Role a (present) must not appear.
+	if strings.Contains(msg, "role[0=a]") {
+		t.Errorf("role[0=a] has a valid command; should not be reported:\n%s", msg)
+	}
+}
+
+func TestValidateRuntimesScriptMissing(t *testing.T) {
+	t.Parallel()
+	m := &Manifest{
+		Workspace: ManifestWorkspace{Name: "script-missing"},
+		Teams: []ManifestTeam{{
+			Name: "squad",
+			Roles: []ManifestRole{
+				{
+					Name: "a", Replicas: 1,
+					Runtime: ManifestRuntime{Command: "sh", Script: "scripts/does-not-exist.lua"},
+				},
+			},
+		}},
+	}
+	err := m.ValidateRuntimes()
+	if err == nil {
+		t.Fatal("expected error on missing script, got nil")
+	}
+	if !strings.Contains(err.Error(), "script") {
+		t.Errorf("expected error to mention script, got: %v", err)
+	}
+}
+
+func TestValidateRuntimesEmptyCommand(t *testing.T) {
+	t.Parallel()
+	m := &Manifest{
+		Workspace: ManifestWorkspace{Name: "empty"},
+		Teams: []ManifestTeam{{
+			Name: "squad",
+			Roles: []ManifestRole{
+				{Name: "a", Replicas: 1, Runtime: ManifestRuntime{Command: ""}},
+			},
+		}},
+	}
+	if err := m.ValidateRuntimes(); err == nil {
+		t.Fatal("expected error on empty command")
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -404,6 +404,14 @@ func (d *Daemon) handleApply(params json.RawMessage) Response {
 		return Response{Error: fmt.Sprintf("parse manifest: %v", err)}
 	}
 
+	// Pre-flight: refuse to apply if any role's runtime command/script
+	// isn't resolvable. See ArcavenAE/marvel#9 — without this a missing
+	// binary produced no diagnostic, just a silent pane that exited
+	// immediately and entered the restart loop.
+	if err := m.ValidateRuntimes(); err != nil {
+		return Response{Error: err.Error()}
+	}
+
 	if err := m.Apply(d.store); err != nil {
 		return Response{Error: fmt.Sprintf("apply manifest: %v", err)}
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -512,6 +512,52 @@ func TestHandleLogsDefaultN(t *testing.T) {
 	}
 }
 
+// TestHandleApplyRuntimePreflight: manifest with a missing runtime
+// binary must be rejected at apply time, not silently accepted to
+// become a silent pane-dies-immediately restart loop later.
+// See ArcavenAE/marvel#9.
+func TestHandleApplyRuntimePreflight(t *testing.T) {
+	_, sock, teardown := startTestDaemon(t, "test-apply-preflight")
+	t.Cleanup(teardown)
+
+	manifest := `
+workspace:
+  name: preflight-bad
+teams:
+  - name: squad
+    roles:
+      - name: worker
+        replicas: 1
+        runtime:
+          command: no-such-binary-marvel-preflight-9xyz
+`
+	resp, err := SendRequest(sock, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(manifest)}),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected error from apply with missing runtime binary")
+	}
+	if !strings.Contains(resp.Error, "pre-flight") {
+		t.Fatalf("expected pre-flight in error, got: %s", resp.Error)
+	}
+
+	// The rejected manifest must not have created any store state.
+	resp, err = SendRequest(sock, Request{
+		Method: "get",
+		Params: mustMarshal(t, map[string]string{"resource_type": "workspaces"}),
+	})
+	if err != nil {
+		t.Fatalf("get workspaces: %v", err)
+	}
+	if strings.Contains(string(resp.Result), "preflight-bad") {
+		t.Fatalf("preflight-bad workspace should not exist: %s", string(resp.Result))
+	}
+}
+
 func TestListenNetwork(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -86,6 +86,12 @@ func (m *Manager) Create(sess *api.Session) error {
 
 	cmd, envs := m.resolveRuntime(sess)
 
+	// Log the exact command line we're about to exec so post-hoc
+	// debugging has the argv — operators otherwise had to guess what
+	// tmux new-window was actually running when a pane died quickly.
+	// See ArcavenAE/marvel#9.
+	log.Printf("session %s exec: %s", sess.Key(), cmd)
+
 	paneID, err := m.driver.NewPane(tmuxSess, cmd, sess.Name, envs)
 	if err != nil {
 		// Clean up store on failure.

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -65,11 +65,20 @@ func (d *Driver) HasSession(name string) bool {
 func (d *Driver) ListSessions() ([]string, error) {
 	out, err := d.cmd("list-sessions", "-F", "#S").Output()
 	if err != nil {
-		// tmux exits non-zero with "no server running" when there is no
-		// tmux server. Treat that as "zero sessions", not an error.
+		// Treat "there is no live tmux server" as zero sessions, not
+		// an error. tmux reports this two different ways depending on
+		// whether a server was ever started at this socket:
+		//   - "no server running on <path>" (server existed, then exited)
+		//   - "error connecting to <path> (No such file or directory)"
+		//     (server never started — socket file absent)
+		// Both mean the same thing to us.
 		var ee *exec.ExitError
-		if errors.As(err, &ee) && strings.Contains(string(ee.Stderr), "no server running") {
-			return nil, nil
+		if errors.As(err, &ee) {
+			stderr := string(ee.Stderr)
+			if strings.Contains(stderr, "no server running") ||
+				strings.Contains(stderr, "No such file or directory") {
+				return nil, nil
+			}
 		}
 		return nil, fmt.Errorf("list-sessions: %w", err)
 	}


### PR DESCRIPTION
## Summary

Closes Skippy's #9. `marvel work` now refuses a manifest whose runtime commands don't resolve, rather than silently spawning panes that exit immediately and entering a restart loop with no diagnostic.

### The three changes

1. **`Manifest.ValidateRuntimes()`** — for every `role.runtime.command`: plain name → `exec.LookPath` against `$PATH`; absolute/relative path → `os.Stat`. Same check for `role.runtime.script`. Aggregates all failures into one error so operators see every problem, not just the first.
2. **`handleApply` calls it** before `m.Apply`. A bad manifest is rejected; no store state is created.
3. **`session.Manager.Create` logs the argv** at spawn time (`session X exec: <cmd>`) so post-hoc debugging has what actually ran.

### Bonus fix surfaced while testing

`tmux.Driver.ListSessions` now treats `error connecting to <path> (No such file or directory)` as zero-sessions. Previously only `no server running` was handled; the socket-never-existed case produced a spurious `cleanup orphan tmux on startup` warning during the daemon's first-ever run on a fresh host.

### Also included (separate commit)

`_kos/ideas/log-rrd-deduplication.md` — the Cisco-style log-repeat-summary idea captured during testing. Standalone kos idea, not part of the fix itself. Tracked in bd as `aae-orc-4wz`.

## Test plan

- [x] `just lint` clean
- [x] `just test-race` green
- [x] `TestValidateRuntimesOK` / `Missing` / `ScriptMissing` / `EmptyCommand`
- [x] `TestHandleApplyRuntimePreflight` — full RPC round-trip, rejected manifest creates no store state
- [ ] Validate on Skippy's Pi 5: apply both of his original repros (forestage-not-on-PATH, `bin/simulator` missing) and confirm the error now fires at apply time with the binary name visible

Refs: #9