### PR TITLE
fix: reap-path crash-loop backoff + Crashed marker (#10, #11)

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -22,7 +22,30 @@ const (
 	// another restart is attempted, or MaxRestarts is reached and the
 	// state transitions to Failed.
 	SessionCrashLoopBackOff SessionState = "crashloop-backoff"
+	// SessionCrashed is the transition state set by ReapDead when the
+	// underlying tmux pane vanished (clean exit, manual kill, runtime
+	// binary crashed). The session is kept in the store — with PaneID
+	// cleared — so operators see the event via `marvel get sessions`
+	// during the backoff window. The reconciler does not count Crashed
+	// sessions toward replica totals, and clears any stale Crashed
+	// sessions for a role at the moment it spawns a replacement. See
+	// ArcavenAE/marvel#10, aae-orc-8ci.
+	SessionCrashed SessionState = "crashed"
 )
+
+// CountsAsAlive reports whether a session in this state should count
+// toward a role's replica total. Pending and Running are obviously alive;
+// CrashLoopBackOff sessions still have a live pane (the reconciler is
+// deliberately not restarting them), so they are counted too. Succeeded,
+// Failed, and Crashed sessions are terminal markers kept for visibility
+// and do NOT count.
+func (s SessionState) CountsAsAlive() bool {
+	switch s {
+	case SessionPending, SessionRunning, SessionCrashLoopBackOff:
+		return true
+	}
+	return false
+}
 
 // HealthState represents the health of a session.
 type HealthState string

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -186,10 +186,23 @@ func (m *Manager) Delete(key string) error {
 	return nil
 }
 
-// ReapDead removes sessions whose tmux pane no longer exists.
-// Returns the keys of reaped sessions.
-func (m *Manager) ReapDead() []string {
-	var reaped []string
+// ReapedSession captures the identity of a session whose pane vanished
+// and that ReapDead removed from the store. Carries the role coordinates
+// so the team controller can attribute the crash to the right role for
+// restart bookkeeping — the reap path is one of two converging points
+// into the crash-loop backoff logic (the other is the health path). See
+// ArcavenAE/marvel#11.
+type ReapedSession struct {
+	Key       string
+	Workspace string
+	Team      string
+	Role      string
+}
+
+// ReapDead removes sessions whose tmux pane no longer exists and returns
+// enough identity information for the caller to do per-role bookkeeping.
+func (m *Manager) ReapDead() []ReapedSession {
+	var reaped []ReapedSession
 	for _, sess := range m.store.ListSessions() {
 		if sess.PaneID == "" {
 			continue
@@ -200,7 +213,12 @@ func (m *Manager) ReapDead() []string {
 				log.Printf("warning: reap session %s: %v", sess.Key(), err)
 				continue
 			}
-			reaped = append(reaped, sess.Key())
+			reaped = append(reaped, ReapedSession{
+				Key:       sess.Key(),
+				Workspace: sess.Workspace,
+				Team:      sess.Team,
+				Role:      sess.Role,
+			})
 		}
 	}
 	return reaped

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -199,20 +199,34 @@ type ReapedSession struct {
 	Role      string
 }
 
-// ReapDead removes sessions whose tmux pane no longer exists and returns
-// enough identity information for the caller to do per-role bookkeeping.
+// ReapDead marks sessions whose tmux pane no longer exists as Crashed
+// (keeping them in the store with PaneID cleared so operators see the
+// transient via `marvel get sessions`) and returns enough identity
+// information for the caller to do per-role bookkeeping.
+//
+// Previously this method deleted reaped sessions immediately. The
+// resulting window — session gone from store, replacement not yet
+// spawned because of backoff — left operators with no visible signal
+// that a crash had occurred. See ArcavenAE/marvel#10, aae-orc-8ci.
+//
+// To keep the store bounded, each call first clears any existing
+// Crashed sessions for a role before marking the newly-reaped session
+// Crashed — so at most one Crashed marker exists per role at a time.
+// The team controller's reconcileRole additionally clears Crashed
+// markers for a role at the moment it spawns a replacement.
 func (m *Manager) ReapDead() []ReapedSession {
 	var reaped []ReapedSession
-	for _, sess := range m.store.ListSessions() {
+	sessions := m.store.ListSessions()
+	for _, sess := range sessions {
 		if sess.PaneID == "" {
+			// Already reaped (Crashed) or never had a pane. Skip.
 			continue
 		}
 		if !m.driver.HasPane(sess.PaneID) {
-			log.Printf("session %s: pane %s gone, reaping", sess.Key(), sess.PaneID)
-			if err := m.store.DeleteSession(sess.Key()); err != nil {
-				log.Printf("warning: reap session %s: %v", sess.Key(), err)
-				continue
-			}
+			log.Printf("session %s: pane %s gone, marking crashed", sess.Key(), sess.PaneID)
+			m.clearStaleCrashed(sessions, sess.Workspace, sess.Team, sess.Role, sess.Key())
+			sess.State = api.SessionCrashed
+			sess.PaneID = ""
 			reaped = append(reaped, ReapedSession{
 				Key:       sess.Key(),
 				Workspace: sess.Workspace,
@@ -222,6 +236,45 @@ func (m *Manager) ReapDead() []ReapedSession {
 		}
 	}
 	return reaped
+}
+
+// clearStaleCrashed removes any Crashed session for the given role,
+// excluding the session about to be marked Crashed. Caps the store at
+// one Crashed marker per role so the reap path can't accumulate ghosts
+// across a saturated role's many crashes.
+func (m *Manager) clearStaleCrashed(snapshot []*api.Session, workspace, team, role, exceptKey string) {
+	for _, other := range snapshot {
+		if other.State != api.SessionCrashed {
+			continue
+		}
+		if other.Workspace != workspace || other.Team != team || other.Role != role {
+			continue
+		}
+		if other.Key() == exceptKey {
+			continue
+		}
+		if err := m.store.DeleteSession(other.Key()); err != nil {
+			log.Printf("warning: delete stale crashed %s: %v", other.Key(), err)
+		}
+	}
+}
+
+// ClearCrashedForRole deletes all Crashed marker sessions for a
+// (workspace, team, role). Called by the team controller the moment it
+// spawns a replacement — the crash marker has served its observability
+// purpose and the fresh session is the new truth.
+func (m *Manager) ClearCrashedForRole(workspace, team, role string) {
+	for _, sess := range m.store.ListSessions() {
+		if sess.State != api.SessionCrashed {
+			continue
+		}
+		if sess.Workspace != workspace || sess.Team != team || sess.Role != role {
+			continue
+		}
+		if err := m.store.DeleteSession(sess.Key()); err != nil {
+			log.Printf("warning: clear crashed %s: %v", sess.Key(), err)
+		}
+	}
 }
 
 // DeleteAllInWorkspace destroys all sessions in a workspace.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -216,10 +216,87 @@ func TestReapDead(t *testing.T) {
 	if got := reaped[0]; got.Workspace != ws || got.Team != "agents" || got.Role != "worker" {
 		t.Fatalf("reaped session identity wrong: %+v", got)
 	}
-	if _, err := store.GetSession(dying.Key()); err == nil {
-		t.Fatal("expected dying session to be removed from store")
+	// Session is kept in the store as a Crashed marker so operators see
+	// the event via `marvel get sessions`. ReapDead no longer deletes.
+	got, err := store.GetSession(dying.Key())
+	if err != nil {
+		t.Fatalf("expected dying session to stay in store as Crashed marker: %v", err)
+	}
+	if got.State != api.SessionCrashed {
+		t.Fatalf("expected state=%s, got %s", api.SessionCrashed, got.State)
+	}
+	if got.PaneID != "" {
+		t.Fatalf("expected PaneID cleared on crash, got %q", got.PaneID)
 	}
 	if _, err := store.GetSession(ws + "/live-0"); err != nil {
 		t.Fatalf("expected live-0 to survive ReapDead: %v", err)
+	}
+}
+
+// TestReapDeadCapsCrashedMarkers verifies the store keeps at most one
+// Crashed session per role — a saturated role's many crashes must not
+// accumulate ghosts. See ArcavenAE/marvel#10, aae-orc-8ci.
+func TestReapDeadCapsCrashedMarkers(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-reap-cap"
+	t.Cleanup(func() {
+		_ = mgr.CleanupWorkspace(ws)
+	})
+
+	// Seed a pre-existing Crashed marker for the same role.
+	stale := &api.Session{
+		Name:      "agents-worker-g1-0",
+		Workspace: ws,
+		Team:      "agents",
+		Role:      "worker",
+		State:     api.SessionCrashed,
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := store.CreateSession(stale); err != nil {
+		t.Fatalf("seed stale crashed: %v", err)
+	}
+
+	// Live session whose pane we'll kill out-of-band.
+	fresh := &api.Session{
+		Name:      "agents-worker-g1-1",
+		Workspace: ws,
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(fresh); err != nil {
+		t.Fatalf("create fresh: %v", err)
+	}
+	if err := driver.KillPane(fresh.PaneID); err != nil {
+		t.Fatalf("kill pane %s: %v", fresh.PaneID, err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for driver.HasPane(fresh.PaneID) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	reaped := mgr.ReapDead()
+	if len(reaped) != 1 || reaped[0].Key != fresh.Key() {
+		t.Fatalf("expected ReapDead to return only %s, got %v", fresh.Key(), reaped)
+	}
+
+	// Stale marker must be gone; fresh now Crashed.
+	if _, err := store.GetSession(stale.Key()); err == nil {
+		t.Fatal("expected stale crashed marker to be cleared")
+	}
+	got, err := store.GetSession(fresh.Key())
+	if err != nil {
+		t.Fatalf("fresh crashed marker missing: %v", err)
+	}
+	if got.State != api.SessionCrashed {
+		t.Fatalf("fresh state=%s, want %s", got.State, api.SessionCrashed)
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -210,8 +210,11 @@ func TestReapDead(t *testing.T) {
 	}
 
 	reaped := mgr.ReapDead()
-	if len(reaped) != 1 || reaped[0] != dying.Key() {
+	if len(reaped) != 1 || reaped[0].Key != dying.Key() {
 		t.Fatalf("expected ReapDead to return [%s], got %v", dying.Key(), reaped)
+	}
+	if got := reaped[0]; got.Workspace != ws || got.Team != "agents" || got.Role != "worker" {
+		t.Fatalf("reaped session identity wrong: %+v", got)
 	}
 	if _, err := store.GetSession(dying.Key()); err == nil {
 		t.Fatal("expected dying session to be removed from store")

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -114,13 +114,80 @@ func (c *Controller) ReconcileOnce() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.sessMgr.ReapDead()
+	// The reap path converges with the health path on the crash-loop
+	// bookkeeping: a clean exit that vacates the pane is just as much a
+	// crash as a stale heartbeat, and must bump RoleHealth counters +
+	// extend the backoff window. Without this, `marvel inject ... "exit"`
+	// respawned instantly forever (ArcavenAE/marvel#11). We defer the
+	// spawn decision to reconcileRole, which already honors BackoffUntil
+	// and (now) MaxRestarts saturation.
+	for _, r := range c.sessMgr.ReapDead() {
+		c.noteReapedCrash(r)
+	}
 	c.evaluateHealth()
 
 	teams := c.store.ListTeams()
 	for _, t := range teams {
 		c.reconcileTeam(t)
 	}
+}
+
+// noteReapedCrash attributes a reaped session to its role and records a
+// crash in the role's health. If the team or role has vanished (e.g.,
+// workspace delete cascade in progress), the crash is untracked — the
+// reconciler won't try to recreate those sessions anyway.
+func (c *Controller) noteReapedCrash(r session.ReapedSession) {
+	t, err := c.store.GetTeam(r.Workspace + "/" + r.Team)
+	if err != nil {
+		return
+	}
+	var role *api.Role
+	for i := range t.Roles {
+		if t.Roles[i].Name == r.Role {
+			role = &t.Roles[i]
+			break
+		}
+	}
+	if role == nil {
+		return
+	}
+	roleKey := r.Workspace + "/" + r.Team + "/" + r.Role
+	if c.noteCrashAndBackoff(r.Workspace, r.Team, r.Role, role.MaxRestarts) {
+		rh := c.roleHealth[roleKey]
+		log.Printf("reap: session %s crashed (role %s restart #%d, next backoff=%s)",
+			r.Key, roleKey, rh.RestartCount, time.Until(rh.BackoffUntil))
+	} else {
+		log.Printf("reap: session %s crashed but role %s already at max_restarts=%d",
+			r.Key, roleKey, role.MaxRestarts)
+	}
+}
+
+// saturationFreezeUntil is the sentinel BackoffUntil used to freeze a
+// saturated role. Chosen far enough in the future that arithmetic on it
+// cannot overflow or wrap within the lifetime of a daemon process.
+var saturationFreezeUntil = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// noteCrashAndBackoff records a crash on the role: increments the restart
+// counter and extends the backoff window. Returns false (and does not
+// bump RestartCount) once the role has saturated MaxRestarts — in that
+// case it freezes BackoffUntil to the far future so reconcileRole's
+// backoff gate permanently refuses to spawn replacements. Shared by the
+// health path (via restartSession) and the reap path (via
+// noteReapedCrash) so both converge on the same RoleHealth state. See
+// ArcavenAE/marvel#11.
+func (c *Controller) noteCrashAndBackoff(workspace, team, role string, maxRestarts int) bool {
+	roleKey := workspace + "/" + team + "/" + role
+	rh := c.getRoleHealth(roleKey)
+	if maxRestarts > 0 && rh.RestartCount >= maxRestarts {
+		rh.BackoffUntil = saturationFreezeUntil
+		return false
+	}
+	now := c.nowUTC()
+	rh.RestartCount++
+	rh.LastRestartAt = now
+	nextBackoff := computeBackoff(rh.RestartCount + 1)
+	rh.BackoffUntil = now.Add(nextBackoff)
+	return true
 }
 
 func (c *Controller) reconcileTeam(t *api.Team) {
@@ -146,7 +213,11 @@ func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
 		// a recent restart, hold off on spawning replacements until the
 		// backoff window elapses. Without this the reconciler would
 		// immediately recreate a session we just deleted and defeat
-		// the whole backoff. See ArcavenAE/marvel#11.
+		// the whole backoff. Reap-path saturation (MaxRestarts) is
+		// also honored here: noteCrashAndBackoff freezes BackoffUntil
+		// to the far future on saturation, so this same gate refuses
+		// respawns once a role has exhausted its budget. See
+		// ArcavenAE/marvel#11.
 		roleKey := t.Workspace + "/" + t.Name + "/" + role.Name
 		if rh, ok := c.roleHealth[roleKey]; ok && c.nowUTC().Before(rh.BackoffUntil) {
 			return
@@ -280,8 +351,21 @@ func (c *Controller) restartSession(sess *api.Session, t *api.Team, role *api.Ro
 	rh := c.getRoleHealth(roleKey)
 	now := c.nowUTC()
 
-	// Permanent failure: max restarts reached.
-	if role.MaxRestarts > 0 && rh.RestartCount >= role.MaxRestarts {
+	// Inside the backoff window: mark visible, keep the pane alive,
+	// let the reconciler hold steady — do not create replacements
+	// during backoff, and do not re-kill the session we're waiting on.
+	// Checked before saturation so we don't clobber a CrashLoopBackOff
+	// marker with Failed on the tick that hits MaxRestarts.
+	if now.Before(rh.BackoffUntil) {
+		sess.State = api.SessionCrashLoopBackOff
+		return
+	}
+
+	// Saturation check: noteCrashAndBackoff refuses to record a crash
+	// once MaxRestarts is hit, so we treat a false return as permanent
+	// failure and keep the session in the store. reconcileRole's
+	// MaxRestarts gate then refuses to spawn a replacement.
+	if !c.noteCrashAndBackoff(t.Workspace, t.Name, role.Name, role.MaxRestarts) {
 		if sess.State != api.SessionFailed {
 			log.Printf("health: session %s: role %s hit max_restarts=%d, not restarting",
 				sess.Key(), roleKey, role.MaxRestarts)
@@ -290,28 +374,16 @@ func (c *Controller) restartSession(sess *api.Session, t *api.Team, role *api.Ro
 		return
 	}
 
-	// Inside the backoff window: mark visible, keep the pane alive,
-	// let the reconciler hold steady — do not create replacements
-	// during backoff, and do not re-kill the session we're waiting on.
-	if now.Before(rh.BackoffUntil) {
-		sess.State = api.SessionCrashLoopBackOff
-		return
-	}
-
-	// Backoff elapsed (or first-ever restart) — proceed.
-	rh.RestartCount++
-	rh.LastRestartAt = now
-	nextBackoff := computeBackoff(rh.RestartCount + 1)
-	rh.BackoffUntil = now.Add(nextBackoff)
-
 	log.Printf("health: restarting session %s (role %s restart #%d, next backoff=%s)",
-		sess.Key(), roleKey, rh.RestartCount, nextBackoff)
+		sess.Key(), roleKey, rh.RestartCount, time.Until(rh.BackoffUntil))
 	sess.RestartCount++
 	sess.State = api.SessionFailed
 	if err := c.sessMgr.Delete(sess.Key()); err != nil {
 		log.Printf("health: delete session %s for restart: %v", sess.Key(), err)
 	}
-	// Reconciler will recreate because actual < desired.
+	// Reconciler sees actual<desired on its next pass but holds off on
+	// recreating until BackoffUntil elapses (set by noteCrashAndBackoff
+	// above).
 }
 
 // InitiateShift starts a shift operation for a team.

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -206,7 +206,12 @@ func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
 	// aren't disrupted when only one role shifts and the team generation advances.
 	current := c.store.ListSessionsByTeamRole(t.Workspace, t.Name, role.Name)
 	desired := role.Replicas
-	actual := len(current)
+	actual := 0
+	for _, sess := range current {
+		if sess.State.CountsAsAlive() {
+			actual++
+		}
+	}
 
 	if actual < desired {
 		// Respect crash-loop backoff. If the role is cooling down from
@@ -222,6 +227,12 @@ func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
 		if rh, ok := c.roleHealth[roleKey]; ok && c.nowUTC().Before(rh.BackoffUntil) {
 			return
 		}
+		// Crash markers from the reap path have done their observability
+		// job by now (operators saw them during the backoff window). The
+		// fresh session is the new truth — clear stale Crashed markers
+		// for this role so nextIndex computes against live sessions only
+		// and `marvel get sessions` doesn't carry the ghost forward.
+		c.sessMgr.ClearCrashedForRole(t.Workspace, t.Name, role.Name)
 		for i := actual; i < desired; i++ {
 			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, t.Generation, c.nextIndex(t, role, t.Generation))
 			sess := &api.Session{

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -679,6 +680,156 @@ func TestHealthRestartMaxReached(t *testing.T) {
 	}
 }
 
+// TestReapPathBumpsRestartCount verifies that when a session's pane
+// vanishes (clean exit / manual kill) the reap path records the crash
+// against the role's RoleHealth — previously this path bypassed the
+// restart bookkeeping entirely, producing the zero-spacing respawn loop
+// Skippy reported as ArcavenAE/marvel#11.
+func TestReapPathBumpsRestartCount(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-reap-bump", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			// No HealthCheck: isolates the reap path from the
+			// heartbeat-staleness path in evaluateHealth.
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	sess := store.ListSessionsByTeamRole("test-reap-bump", "squad", "worker")[0]
+
+	// Simulate a clean exit / manual pane kill.
+	killPaneAndWait(t, sess.PaneID)
+
+	ctrl.ReconcileOnce() // reap + bookkeeping + backoff gate
+
+	rh, ok := ctrl.RoleHealthSnapshot("test-reap-bump", "squad", "worker")
+	if !ok {
+		t.Fatal("expected RoleHealth snapshot after reap")
+	}
+	if rh.RestartCount != 1 {
+		t.Fatalf("expected RestartCount=1 after reap, got %d", rh.RestartCount)
+	}
+	if !rh.BackoffUntil.After(clock.Now()) {
+		t.Fatalf("expected BackoffUntil after now, got %s (now=%s)", rh.BackoffUntil, clock.Now())
+	}
+	// The reconciler must NOT have immediately respawned during backoff.
+	got := store.ListSessionsByTeamRole("test-reap-bump", "squad", "worker")
+	if len(got) != 0 {
+		t.Fatalf("expected 0 sessions during reap backoff, got %d", len(got))
+	}
+}
+
+// TestReapPathRespawnsAfterBackoff: after the reap-triggered backoff
+// window elapses, the reconciler respawns the replica.
+func TestReapPathRespawnsAfterBackoff(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-reap-respawn", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	sess := store.ListSessionsByTeamRole("test-reap-respawn", "squad", "worker")[0]
+	origCreatedAt := sess.CreatedAt
+
+	killPaneAndWait(t, sess.PaneID)
+	ctrl.ReconcileOnce() // reap + bookkeeping
+
+	// Advance past the initial backoff window (60s for restart #1).
+	clock.Advance(90 * time.Second)
+	ctrl.ReconcileOnce()
+
+	got := store.ListSessionsByTeamRole("test-reap-respawn", "squad", "worker")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session after backoff elapsed, got %d", len(got))
+	}
+	if !got[0].CreatedAt.After(origCreatedAt) {
+		t.Fatal("expected new session with later CreatedAt after reap-triggered restart")
+	}
+}
+
+// TestReapPathSaturatesMaxRestarts: a role whose only crash path is
+// reap-via-clean-exit still honors MaxRestarts. Once the budget is
+// exhausted, the reconciler stops respawning replacements (BackoffUntil
+// is frozen to the far future by noteCrashAndBackoff on saturation).
+func TestReapPathSaturatesMaxRestarts(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-reap-maxrst", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			MaxRestarts: 2,
+		},
+	})
+
+	// Two reap-and-respawn cycles consume the budget.
+	for i := 0; i < 2; i++ {
+		ctrl.ReconcileOnce()
+		got := store.ListSessionsByTeamRole("test-reap-maxrst", "squad", "worker")
+		if len(got) == 0 {
+			t.Fatalf("iteration %d: expected a running session", i)
+		}
+		sess := got[0]
+		killPaneAndWait(t, sess.PaneID)
+		ctrl.ReconcileOnce() // reap + bump counter
+		clock.Advance(10 * time.Minute)
+	}
+
+	rh, _ := ctrl.RoleHealthSnapshot("test-reap-maxrst", "squad", "worker")
+	if rh.RestartCount != 2 {
+		t.Fatalf("expected RestartCount=2 after two reap cycles, got %d", rh.RestartCount)
+	}
+
+	// Third cycle: respawn, kill, reap — counter must NOT bump past 2,
+	// and the reconciler must refuse to spawn a fourth replacement.
+	ctrl.ReconcileOnce()
+	got := store.ListSessionsByTeamRole("test-reap-maxrst", "squad", "worker")
+	if len(got) == 0 {
+		t.Fatal("expected a running session before saturation check")
+	}
+	sess := got[0]
+	killPaneAndWait(t, sess.PaneID)
+	ctrl.ReconcileOnce() // reap; saturation freezes BackoffUntil
+
+	rh, _ = ctrl.RoleHealthSnapshot("test-reap-maxrst", "squad", "worker")
+	if rh.RestartCount != 2 {
+		t.Fatalf("RestartCount must stay at MaxRestarts=2 after saturation, got %d", rh.RestartCount)
+	}
+	if rh.BackoffUntil != saturationFreezeUntil {
+		t.Fatalf("expected BackoffUntil frozen at saturation sentinel, got %s", rh.BackoffUntil)
+	}
+
+	// No matter how far we advance the clock, no respawn.
+	clock.Advance(24 * time.Hour)
+	ctrl.ReconcileOnce()
+	got = store.ListSessionsByTeamRole("test-reap-maxrst", "squad", "worker")
+	if len(got) != 0 {
+		t.Fatalf("expected no session after saturation, got %d", len(got))
+	}
+}
+
 // TestComputeBackoff locks in the exponential curve shape so future
 // tweaks are intentional and reviewable.
 func TestComputeBackoff(t *testing.T) {
@@ -711,6 +862,35 @@ type testClock struct {
 func newTestClock(start time.Time) *testClock { return &testClock{t: start} }
 func (c *testClock) Now() time.Time           { return c.t }
 func (c *testClock) Advance(d time.Duration)  { c.t = c.t.Add(d) }
+
+// killPaneAndWait shells out to tmux to kill a pane out-of-band (as an
+// external process would) and waits until tmux confirms the pane is gone
+// so ReapDead can observe the loss on the next reconcile tick. Mirrors
+// the Skippy repro from ArcavenAE/marvel#11: `marvel inject ... "exit"`
+// — a clean exit that vacates the pane without going through the health
+// path. Uses the same MARVEL_TMUX_SOCKET as the driver so tests stay
+// scoped to their per-package tmux server.
+func killPaneAndWait(t *testing.T, paneID string) {
+	t.Helper()
+	tmuxCmd := func(args ...string) *exec.Cmd {
+		if socket := os.Getenv("MARVEL_TMUX_SOCKET"); socket != "" {
+			return exec.Command("tmux", append([]string{"-L", socket}, args...)...)
+		}
+		return exec.Command("tmux", args...)
+	}
+	if err := tmuxCmd("kill-pane", "-t", paneID).Run(); err != nil {
+		t.Fatalf("tmux kill-pane %s: %v", paneID, err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := tmuxCmd("list-panes", "-a", "-F", "#{pane_id}").CombinedOutput()
+		if err != nil || !strings.Contains(string(out), paneID) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("tmux still reports pane %s alive after kill-pane", paneID)
+}
 
 func TestShiftSessionNaming(t *testing.T) {
 	skipIfNoTmux(t)

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -720,10 +720,19 @@ func TestReapPathBumpsRestartCount(t *testing.T) {
 	if !rh.BackoffUntil.After(clock.Now()) {
 		t.Fatalf("expected BackoffUntil after now, got %s (now=%s)", rh.BackoffUntil, clock.Now())
 	}
-	// The reconciler must NOT have immediately respawned during backoff.
+	// The reap path keeps the session in the store as a Crashed
+	// marker so operators see the transient via `marvel get sessions`,
+	// but the reconciler must NOT have respawned a live replacement
+	// during backoff.
 	got := store.ListSessionsByTeamRole("test-reap-bump", "squad", "worker")
-	if len(got) != 0 {
-		t.Fatalf("expected 0 sessions during reap backoff, got %d", len(got))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 Crashed marker during reap backoff, got %d", len(got))
+	}
+	if got[0].State != api.SessionCrashed {
+		t.Fatalf("expected Crashed state, got %s", got[0].State)
+	}
+	if got[0].PaneID != "" {
+		t.Fatalf("expected empty PaneID on crashed marker, got %q", got[0].PaneID)
 	}
 }
 
@@ -757,7 +766,10 @@ func TestReapPathRespawnsAfterBackoff(t *testing.T) {
 
 	got := store.ListSessionsByTeamRole("test-reap-respawn", "squad", "worker")
 	if len(got) != 1 {
-		t.Fatalf("expected 1 session after backoff elapsed, got %d", len(got))
+		t.Fatalf("expected 1 session after backoff elapsed (crashed marker cleared at respawn), got %d", len(got))
+	}
+	if got[0].State != api.SessionRunning {
+		t.Fatalf("expected respawn to be Running (crashed marker should be cleared), got %s", got[0].State)
 	}
 	if !got[0].CreatedAt.After(origCreatedAt) {
 		t.Fatal("expected new session with later CreatedAt after reap-triggered restart")
@@ -821,12 +833,24 @@ func TestReapPathSaturatesMaxRestarts(t *testing.T) {
 		t.Fatalf("expected BackoffUntil frozen at saturation sentinel, got %s", rh.BackoffUntil)
 	}
 
-	// No matter how far we advance the clock, no respawn.
+	// No matter how far we advance the clock, no live replacement
+	// spawns — saturation leaves at most one Crashed marker behind
+	// (the capping in ReapDead / ClearCrashedForRole keeps ghosts
+	// bounded).
 	clock.Advance(24 * time.Hour)
 	ctrl.ReconcileOnce()
 	got = store.ListSessionsByTeamRole("test-reap-maxrst", "squad", "worker")
-	if len(got) != 0 {
-		t.Fatalf("expected no session after saturation, got %d", len(got))
+	alive := 0
+	for _, s := range got {
+		if s.State.CountsAsAlive() {
+			alive++
+		}
+	}
+	if alive != 0 {
+		t.Fatalf("expected 0 alive sessions after saturation, got %d (all=%d)", alive, len(got))
+	}
+	if len(got) > 1 {
+		t.Fatalf("expected at most 1 Crashed marker after saturation, got %d", len(got))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the pair of reap-path regressions Skippy verified in alpha 0.1.0-alpha.20260418.025039.50c78ae:

- **#11**: pane-reaper path (clean exit / manual pane kill) bypassed crash-loop bookkeeping entirely — ReapDead deleted the session, reconciler spawned immediately, no backoff, no MaxRestarts cap.
- **#10**: even with reap now fast and logged, `marvel get sessions` showed nothing during the crashed/exited transient because the session was deleted from the store before an operator could see it.

## Fix

**Reap-path crash-loop bookkeeping (#11):**

Converge both crash paths on a shared `noteCrashAndBackoff` helper so the same RoleHealth state and backoff semantics apply whether a crash arrives via stale heartbeat or via pane disappearance:

- Health path (`restartSession` via `evaluateHealth`) still marks the session `Failed` on saturation without deleting, keeping it visible via `marvel get sessions`.
- Reap path (`ReconcileOnce` via `ReapDead`) now records crashes against the role's `RoleHealth` before the reconciler decides whether to spawn.
- Saturation on either path freezes `BackoffUntil` to the far future, so `reconcileRole`'s existing backoff gate refuses further spawns.

`ReapDead` now returns `[]ReapedSession` with role coordinates so the controller can attribute crashes to the right role.

**SessionCrashed transient marker (#10):**

New `SessionCrashed` state. `ReapDead` marks the session `Crashed` with `PaneID=\"\"` instead of deleting — operators see the transient via `marvel get sessions` for the full backoff window. The reconciler clears Crashed markers for a role as the last step before spawning a replacement.

- `SessionState.CountsAsAlive()` predicate: Pending/Running/CrashLoopBackOff count toward a role's replica total; Crashed/Failed/Succeeded do not. `reconcileRole` uses this for `actual`, so Crashed markers don't block the respawn logic.
- `Manager.ReapDead` caps the store at one Crashed marker per role (saturated roles can't accumulate ghosts).
- `Manager.ClearCrashedForRole` is the explicit cleanup point the team controller calls when spawning.

## Test plan

- [x] `TestReapPathBumpsRestartCount` — single pane-kill bumps RestartCount, sets backoff, leaves a Crashed marker visible
- [x] `TestReapPathRespawnsAfterBackoff` — after backoff elapses, respawn is Running and the Crashed marker is cleared
- [x] `TestReapPathSaturatesMaxRestarts` — MaxRestarts honored for reap-only crashes; no live replacement after saturation, at most one Crashed marker retained
- [x] `TestReapDead` (session pkg) — updated to assert Crashed marker semantics (not deleted)
- [x] `TestReapDeadCapsCrashedMarkers` (new) — pre-existing Crashed marker cleared when a new crash arrives
- [x] All existing health-path tests pass unchanged (`TestHealthRestartAlways`, `...BackoffHoldsReplacement`, `...BackoffSiblingMarked`, `...MaxReached`) — shared helper preserves semantics
- [x] `just ci` equivalent: gofumpt + vet + golangci-lint (0 issues) + race detector

Refs: #10, #11, aae-orc-xhk, aae-orc-8ci