### PR TITLE
feat(ssh): include client IP in connection log

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -345,7 +345,7 @@ session dev/squad-worker-g1-0 using forestage adapter    # adapter selection
 session dev/squad-worker-g1-0 running in pane %5         # session created
 health: session ... failed (restart_policy=always)       # health failure
 shift: initiated for dev/squad gen 1→2                   # shift started
-ssh: client connected: michael (SHA256:abc...)           # remote connection
+ssh: client connected: michael@10.0.0.42 (SHA256:abc...) # remote connection
 inject: dev/squad-worker-g1-0 <- 42 bytes                # executive injection
 ```
 

--- a/internal/daemon/sshserver.go
+++ b/internal/daemon/sshserver.go
@@ -106,7 +106,11 @@ func (s *SSHServer) handleConnection(conn net.Conn) {
 	if sshConn.Permissions != nil {
 		fp = sshConn.Permissions.Extensions["pubkey-fp"]
 	}
-	log.Printf("ssh: client connected: %s (%s)", sshConn.User(), fp)
+	host := conn.RemoteAddr().String()
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	log.Printf("ssh: client connected: %s@%s (%s)", sshConn.User(), host, fp)
 
 	// Discard global requests (keepalive, etc.)
 	go ssh.DiscardRequests(reqs)


### PR DESCRIPTION
## Summary

- `ssh: client connected` log line now reads `user@ip (fingerprint)` instead of `user (fingerprint)`
- Ephemeral source port is intentionally dropped — would defeat logbuf dedup for every connection burst and provides no useful operator signal
- Falls back to raw `RemoteAddr().String()` if `net.SplitHostPort` fails (defensive; mrvl:// is always TCP today)

## Motivation

Multiple hosts in the fleet-bootstrap workflow share the same operator key. When one of them connects to a daemon, the log line currently reveals nothing beyond `michael.pursifull (SHA256:...)`. Adding the IP lets the operator correlate a connection to the machine it came from.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/daemon/...`
- [x] `golangci-lint run ./internal/daemon/...` (0 issues)
- [x] `go test -race ./...` (pre-push hook)
- [ ] Verify against live daemon after deploy — log line reads `user@10.x.x.x (SHA256:...)`

## Observed during testing

While polling Skippy's desk daemon, noticed that PR #26 logbuf dedup doesn't actually collapse Skippy's original `aae-orc-1d2` scenario — Go's `log.Printf` timestamp prefix (second granularity) is part of the deduplicated string, so identical lines logged in different seconds never match. Filing separately.