### PR TITLE
ci: drop release workflow token to least privilege

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,16 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     name: GoReleaser
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      # Creates the GitHub release and uploads archives.
+      contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -43,6 +46,9 @@ jobs:
     if: vars.SIGNING_ENABLED == 'true'
     runs-on: macos-latest
     environment: release
+    permissions:
+      # Re-uploads (--clobber) signed/notarized artifacts onto the release.
+      contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
Top-level `GITHUB_TOKEN` permission becomes `contents: read`; the `goreleaser` and `sign-release` jobs get job-level `contents: write` (they create the release and `--clobber` signed artifacts onto it). The `attest` job already had scoped permissions. Fixes the scorecard Token-Permissions warning — a top-level write zeroes the check.