### PR TITLE
fix: make graceful stop as recoverable as kill -9, and persist crash-loop state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,8 @@ marvel scale <workspace/team> --role <r> --replicas N  # scale a role within a t
 marvel shift <workspace/team> [--role <r>]             # rolling shift (replace sessions with fresh ones)
 marvel run <command> [args...] --role <r>             # run a one-off agent session
 marvel kill <session-key>                            # kill a session
-marvel stop                                          # stop daemon, clean up all resources
+marvel stop                                          # stop daemon, agents keep running (restart adopts them)
+marvel stop --teardown                               # stop daemon, delete sessions, kill panes
 marvel daemon                                        # start the daemon (foreground)
 
 # future: logs, attach, exec, drain, top, pack management

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ marvel get sessions -w
 marvel shift demo/squad
 
 # Clean up
-marvel stop
+marvel stop --teardown
 ```
 
 ## Resource Model
@@ -134,7 +134,8 @@ marvel scale <ws/team> --role <r> --replicas N       # scale a role
 marvel shift <ws/team> [--role <r>]                  # rolling shift
 marvel run <cmd> [args...] --role <r>                # one-off session
 marvel kill <session-key>                            # kill a session
-marvel stop                                          # stop daemon
+marvel stop                                          # stop daemon, leave agents running
+marvel stop --teardown                               # stop daemon, end every agent
 ```
 
 ## Shifts

--- a/_kos/nodes/frontier/question-marvel-graceful-stop.yaml
+++ b/_kos/nodes/frontier/question-marvel-graceful-stop.yaml
@@ -79,6 +79,32 @@ content: |
   integration test that asserts the sequence happens in the right
   order. Implementation can follow once the design has been reviewed.
 
+  ## Partially answered (aae-orc-1aoe, 2026-07-31)
+
+  One sub-question is closed: self-update vs graceful stop are
+  different verbs, and the recommendation in this node ("self-update
+  should preserve agents, graceful stop should drain them") is now
+  the shipped shape, with the default flipped toward preservation.
+
+  - `Daemon.Detach()` stops the reconciler and listeners, checkpoints
+    L2, releases the bolt file, and touches no pane. SIGINT, SIGTERM,
+    and plain `marvel stop` all take this path, so the next start
+    adopts the live panes via AdoptOrKill.
+  - `Daemon.Stop()` keeps the old destroy-everything behavior behind
+    `marvel stop --teardown`, the hard-stop variant this node asked
+    for.
+  - `Store.Checkpoint()` gained its first caller (both shutdown paths,
+    just before CloseBolt). `Daemon.Checkpoint()` is the named seam
+    for the syscall.Exec self-update in aae-orc-zk5r.
+
+  Still open, and the reason this node stays frontier: the drain
+  sequence itself. Nothing here sends a graceful-shutdown signal to
+  an agent, waits out a grace period, or orders roles by priority.
+  Detach preserves agents instead of draining them, which sidesteps
+  the question rather than answering it. Priority semantics,
+  per-role `graceful_period_seconds`, and the forestage preStop
+  equivalent are untouched.
+
 edges:
   - target: question-marvel-transaction-log
     type: supports

--- a/_kos/nodes/frontier/question-marvel-transaction-log.yaml
+++ b/_kos/nodes/frontier/question-marvel-transaction-log.yaml
@@ -76,6 +76,15 @@ content: |
   "Local state (bbolt)") so future shim work, if it happens, doesn't
   collide.
 
+  Sub-item closed (aae-orc-qdew, 2026-07-31): role health counters are
+  durable. The `role_health` bucket the L2 spike reserved is now written
+  through on every crash-loop state change and read back by
+  `team.Controller.RehydrateRoleHealth` at daemon start, so a backoff
+  window (including the MaxRestarts saturation freeze) survives a
+  restart instead of handing the role a free respawn. It is the one
+  bucket with no in-memory mirror in the Store: the controller's map is
+  the live copy.
+
   Needs a probe: a 1–2-day spike that adds a bbolt transaction log
   behind the existing api.Store, exercises the WAL pattern, and
   switches CleanupOrphanTmux from kill-all to adopt-or-kill based on

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -220,12 +220,15 @@ Examples:
 				}
 			}
 
-			// Wait for signal.
+			// Wait for signal. A signal detaches: agents keep running
+			// and the next start adopts their panes. Tearing them down
+			// is an explicit operator act (`marvel stop --teardown`),
+			// not something a package upgrade or a stray Ctrl-C does.
 			sig := make(chan os.Signal, 1)
 			signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 			<-sig
-			fmt.Println("\nshutting down...")
-			d.Stop()
+			fmt.Println("\ndetaching, agents keep running (marvel stop --teardown to end them)")
+			d.Detach()
 			return nil
 		},
 	}
@@ -1226,21 +1229,42 @@ func nameArg(name string) string {
 }
 
 func stopCmd() *cobra.Command {
-	return &cobra.Command{
+	var teardown bool
+	cmd := &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the marvel daemon and clean up all resources",
+		Short: "Stop the marvel daemon, leaving agents running",
+		Long: `Stop the marvel daemon.
+
+By default this detaches: the daemon checkpoints its state and exits
+while every agent keeps running in its tmux pane. The next
+'marvel daemon' start reads that state back and adopts the live panes,
+so a restart or an upgrade costs no agent context.
+
+Use --teardown when you want the machine clean. Every session is
+deleted and every workspace tmux session killed before the daemon
+exits; nothing is left to adopt.`,
+		Example: `  marvel stop              # detach, agents keep running
+  marvel stop --teardown   # end every agent, then stop`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resp, err := send(daemon.Request{Method: "stop"})
+			params, _ := json.Marshal(map[string]bool{"teardown": teardown})
+			resp, err := send(daemon.Request{Method: "stop", Params: params})
 			if err != nil {
 				return err
 			}
 			if resp.Error != "" {
 				return fmt.Errorf("%s", resp.Error)
 			}
-			fmt.Println("marvel daemon stopping")
+			if teardown {
+				fmt.Println("marvel daemon stopping, agents torn down")
+			} else {
+				fmt.Println("marvel daemon detaching, agents keep running")
+			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&teardown, "teardown", false,
+		"delete every session and kill its tmux session before stopping")
+	return cmd
 }
 
 // --- Watch mode ---

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -89,8 +89,26 @@ marvel daemon --log-file /var/log/marvel.log # systemd-friendly path
 
 Stop with:
 ```bash
-marvel stop
+marvel stop              # detach: agents keep running
+marvel stop --teardown   # end every agent, then stop
 ```
+
+### Detach vs teardown
+
+`marvel stop`, SIGINT, and SIGTERM all *detach*: the daemon
+checkpoints its state file and exits while every agent keeps running
+in its tmux pane. The next `marvel daemon` reads that state back and
+adopts the live panes, so restarts and upgrades cost no agent context.
+Agents whose panes died while no daemon was running are reaped on the
+first reconcile pass, exactly as if the daemon had never left.
+
+`marvel stop --teardown` is the clean-machine variant: every session
+is deleted and every workspace tmux session killed before the daemon
+exits, leaving nothing to adopt.
+
+Detach relies on the state file. With `--state-bolt=""` there is no
+recorded intent to come back to, so the next start kills every
+`marvel-*` pane it finds.
 
 ## SSH key management
 
@@ -290,7 +308,7 @@ A CI job runs agents for automated code review or testing.
     echo "${{ secrets.CI_SSH_PUBKEY }}" | marvel keys authorize /dev/stdin
     marvel work manifests/review-team.yaml
     sleep 300  # let agents work
-    marvel stop
+    marvel stop --teardown
 ```
 
 **Why:** Ephemeral agent fleets for automated tasks. The daemon starts,

--- a/docs/spec/stories.md
+++ b/docs/spec/stories.md
@@ -79,7 +79,8 @@ Tasks:
 - [x] `marvel describe <type> <name>` — detail view
 - [x] `marvel delete <type> <name>` — remove resource
 - [x] `marvel scale <team> --replicas N` — adjust replicas
-- [x] `marvel stop` — shut down daemon and clean up tmux
+- [x] `marvel stop`: shut down daemon, leaving agents running for the next start to adopt
+- [x] `marvel stop --teardown`: shut down daemon and clean up tmux
 
 ## Epic 6: Just Interface
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,8 +15,11 @@ marvel work examples/claude.yaml
 # See what's running
 marvel get sessions
 
-# Stop everything
+# Stop the daemon, leaving agents running (restart adopts them)
 marvel stop
+
+# Or end the agents too
+marvel stop --teardown
 ```
 
 ## Writing manifests

--- a/internal/api/bolt.go
+++ b/internal/api/bolt.go
@@ -18,14 +18,14 @@ import (
 //
 // Persisted: Workspaces, Teams (incl. Roles + ShiftState), Sessions
 // (incl. PaneID, State, Generation, Runtime, restart counters, CreatedAt),
-// Endpoints. Volatile session fields (LastHeartbeat, ContextPercent,
-// HealthState, LastHealthCheck, PID) are persisted with the rest of
-// the struct but treated as may-be-stale on rehydrate — the reconciler
-// refreshes them.
+// Endpoints, RoleHealth. Volatile session fields (LastHeartbeat,
+// ContextPercent, HealthState, LastHealthCheck, PID) are persisted with
+// the rest of the struct but treated as may-be-stale on rehydrate; the
+// reconciler refreshes them.
 //
-// Not yet persisted (Session-2 work in aae-orc-k4e4):
-//   - RoleHealth (lives in team.Controller, not Store; needs separate
-//     hooks). Bucket exists for forward compatibility.
+// RoleHealth is the one bucket with no in-memory mirror here: its live
+// copy is team.Controller's roleHealth map, and the Store is only the
+// write-through record. See RoleHealthRecord.
 //
 // See orc question-marvel-transaction-log + finding-048 for the
 // architectural reasoning.
@@ -147,7 +147,10 @@ func (s *Store) CloseBolt() error {
 }
 
 // Checkpoint forces an fsync of pending writes without closing the DB.
-// Called at graceful-shutdown points and before syscall.Exec self-update.
+// Called from daemon shutdown (both the detach and teardown paths, just
+// before CloseBolt) and from Daemon.Checkpoint, the seam a future
+// syscall.Exec self-update uses to flush before handing the process
+// over. Safe to call when bolt was never opened.
 func (s *Store) Checkpoint() error {
 	if s.bolt == nil {
 		return nil
@@ -257,6 +260,73 @@ func (s *Store) persistDelete(bucket []byte, key string) error {
 		}
 		return bumpVersion(tx)
 	})
+}
+
+// RoleHealthRecord is the durable form of a role's crash-loop state:
+// restart count, last restart, and the deadline before which the
+// reconciler refuses to spawn a replacement. Key is workspace/team/role,
+// matching team.Controller's map key.
+//
+// Unlike every other persisted type, RoleHealth has no in-memory mirror
+// inside the Store. The controller's map is the live copy and this
+// bucket is what it writes through to. So the three methods below read
+// and write bbolt directly instead of a Store map, and rehydrate()
+// leaves this bucket alone: the controller pulls it in via
+// RehydrateRoleHealth at daemon start.
+//
+// Without this, a role frozen at MaxRestarts saturation came back from
+// a daemon restart with an empty counter and got a free respawn: the
+// gap bolt.go's package doc used to list as the L2 leftover.
+type RoleHealthRecord struct {
+	Key           string    `json:"key"`
+	RestartCount  int       `json:"restart_count"`
+	LastRestartAt time.Time `json:"last_restart_at"`
+	BackoffUntil  time.Time `json:"backoff_until"`
+}
+
+// PersistRoleHealth writes one role's crash-loop state. No-op when bolt
+// is not open.
+func (s *Store) PersistRoleHealth(rec RoleHealthRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.persistPut(bucketRoleHealth, rec.Key, rec)
+}
+
+// ListRoleHealth returns every persisted role-health record. Returns nil
+// when bolt is not open, so a caller in in-memory-only mode starts with
+// an empty map, the pre-L2 behavior.
+func (s *Store) ListRoleHealth() ([]RoleHealthRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.bolt == nil {
+		return nil, nil
+	}
+	var out []RoleHealthRecord
+	if err := s.bolt.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketRoleHealth).ForEach(func(k, v []byte) error {
+			var rec RoleHealthRecord
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return fmt.Errorf("unmarshal role health %s: %w", string(k), err)
+			}
+			if rec.Key == "" {
+				rec.Key = string(k)
+			}
+			out = append(out, rec)
+			return nil
+		})
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DeleteRoleHealth removes one role's crash-loop state. The controller's
+// cascade-clear paths call this so a re-applied manifest doesn't inherit
+// a frozen backoff window from a prior generation of the same role name.
+func (s *Store) DeleteRoleHealth(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.persistDelete(bucketRoleHealth, key)
 }
 
 // ResourceVersion returns the current monotonic version counter — the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -146,6 +146,13 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	}
 	sessMgr := session.NewManager(store, driver)
 	teamCtrl := team.NewController(store, sessMgr)
+	// Must follow OpenBolt: the controller reads its crash-loop state
+	// out of the same bolt file. Before this, a role frozen at
+	// MaxRestarts respawned on the first reconcile tick after restart.
+	// See aae-orc-qdew.
+	if rerr := teamCtrl.RehydrateRoleHealth(); rerr != nil {
+		return nil, fmt.Errorf("rehydrate role health: %w", rerr)
+	}
 
 	buf := opts.LogBuffer
 	if buf == nil {
@@ -270,8 +277,36 @@ func (d *Daemon) StartMRVL(addr string) error {
 	return srv.Start(addr)
 }
 
-// Stop shuts down the daemon, cleaning up all resources.
-func (d *Daemon) Stop() {
+// Detach shuts the daemon down and leaves every agent it manages
+// running. The reconciler and listeners stop, durable state is
+// checkpointed and the bolt file released, and no tmux pane is touched,
+// so the next daemon start rehydrates the same recorded intent and
+// AdoptOrKill reclaims the live panes. This is the SIGINT/SIGTERM path
+// and what plain `marvel stop` does.
+//
+// Detaching rather than tearing down is what makes the graceful path as
+// recoverable as an ungraceful one: before this split, Stop deleted
+// every session and killed every pane before closing bolt, so adoption
+// could only ever fire after a kill -9. See aae-orc-1aoe.
+//
+// Detach is also the first half of in-place self-update
+// (aae-orc-zk5r): checkpoint, release the bolt file, then syscall.Exec
+// the replacement binary, which comes back up and adopts. Nothing here
+// assumes the process is about to exit.
+func (d *Daemon) Detach() { d.shutdown(false) }
+
+// Stop shuts the daemon down and destroys what it manages: every
+// workspace's sessions are deleted and its tmux session killed before
+// durable state is closed. This is `marvel stop --teardown`, for the
+// operator who wants the machine clean, and the path tests use.
+func (d *Daemon) Stop() { d.shutdown(true) }
+
+// Checkpoint flushes durable state to disk without stopping anything.
+// The seam for a self-update that execs without a full Detach
+// (aae-orc-zk5r). No-op when persistence is disabled.
+func (d *Daemon) Checkpoint() error { return d.store.Checkpoint() }
+
+func (d *Daemon) shutdown(teardown bool) {
 	if d.cancel != nil {
 		d.cancel()
 	}
@@ -287,16 +322,20 @@ func (d *Daemon) Stop() {
 	}
 	d.wg.Wait()
 
-	// Clean up all workspaces.
-	for _, ws := range d.store.ListWorkspaces() {
-		if err := d.sessMgr.CleanupWorkspace(ws.Name); err != nil {
-			log.Printf("cleanup workspace %s: %v", ws.Name, err)
+	if teardown {
+		for _, ws := range d.store.ListWorkspaces() {
+			if err := d.sessMgr.CleanupWorkspace(ws.Name); err != nil {
+				log.Printf("cleanup workspace %s: %v", ws.Name, err)
+			}
 		}
 	}
 
-	// Close the L2 bolt store (no-op if not opened). The workspace
-	// cleanup above already deleted every workspace + session from
-	// the bolt file; this just flushes and releases the file handle.
+	// Flush before releasing the file handle: on the detach path the
+	// records written here are exactly what the next start adopts from.
+	// Both calls are no-ops when persistence is disabled.
+	if err := d.store.Checkpoint(); err != nil {
+		log.Printf("checkpoint state: %v", err)
+	}
 	if err := d.store.CloseBolt(); err != nil {
 		log.Printf("close bolt: %v", err)
 	}
@@ -308,7 +347,11 @@ func (d *Daemon) Stop() {
 	if d.pidFile != "" {
 		_ = os.Remove(d.pidFile)
 	}
-	log.Println("marvel daemon stopped")
+	if teardown {
+		log.Println("marvel daemon stopped, agents torn down")
+		return
+	}
+	log.Printf("marvel daemon detached, %d session(s) left running", len(d.store.ListSessions()))
 }
 
 // writePidFile creates/overwrites pidfile with the current PID.
@@ -393,7 +436,7 @@ func (d *Daemon) dispatch(req Request) Response {
 	case "capture":
 		return d.handleCapture(req.Params)
 	case "stop":
-		return d.handleStop()
+		return d.handleStop(req.Params)
 	case "logs":
 		return d.handleLogs(req.Params)
 	case "events":
@@ -878,13 +921,48 @@ func (d *Daemon) handleCapture(params json.RawMessage) Response {
 	return Response{Result: result}
 }
 
-func (d *Daemon) handleStop() Response {
+// Stop params
+type stopParams struct {
+	// Teardown selects agent destruction over detach: delete every
+	// session and kill every workspace tmux session before exiting.
+	// Default (false) detaches: agents keep running and the next
+	// daemon start adopts them.
+	Teardown bool `json:"teardown,omitempty"`
+}
+
+// stopMode decodes the stop params into the shutdown mode. Absent or
+// empty params mean detach; a client that predates the flag must not
+// get a teardown.
+func stopMode(params json.RawMessage) (teardown bool, mode string, err error) {
+	var p stopParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return false, "", err
+		}
+	}
+	if p.Teardown {
+		return true, "teardown", nil
+	}
+	return false, "detach", nil
+}
+
+func (d *Daemon) handleStop(params json.RawMessage) Response {
+	teardown, mode, err := stopMode(params)
+	if err != nil {
+		return Response{Error: fmt.Sprintf("bad params: %v", err)}
+	}
+	// Shut down off the request goroutine: the client is still reading
+	// this connection, and the listener closes inside shutdown.
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		d.Stop()
+		if teardown {
+			d.Stop()
+		} else {
+			d.Detach()
+		}
 		os.Exit(0)
 	}()
-	result, _ := json.Marshal(map[string]string{"status": "stopping"})
+	result, _ := json.Marshal(map[string]string{"status": "stopping", "mode": mode})
 	return Response{Result: result}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -631,3 +631,214 @@ func TestDaemonTCP(t *testing.T) {
 		t.Fatalf("TCP response error: %s", resp.Error)
 	}
 }
+
+// TestDetachThenRestartAdoptsSessions is the recovery contract for
+// aae-orc-1aoe: a graceful stop must leave as much behind as a kill -9
+// does. The daemon detaches, its agent's pane keeps running, and the
+// next daemon start over the same state file adopts that pane instead of
+// spawning a replacement.
+//
+// Before the detach/teardown split, Stop deleted every session and
+// killed every pane before closing bolt, so this scenario could only
+// ever be reached by killing the daemon ungracefully.
+func TestDetachThenRestartAdoptsSessions(t *testing.T) {
+	skipIfNoTmux(t)
+
+	boltPath := filepath.Join(t.TempDir(), "marvel.bolt")
+	ws := "test-detach-adopt"
+	manifest := `
+[workspace]
+name = "` + ws + `"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+
+    [team.role.runtime]
+    command = "sleep"
+    args = ["300"]
+`
+
+	d1, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon #1: %v", err)
+	}
+	sock1 := filepath.Join(os.TempDir(), "marvel-test-detach-1.sock")
+	if err := d1.Start(sock1); err != nil {
+		t.Fatalf("start daemon #1: %v", err)
+	}
+	// Whatever happens below, don't leave the workspace's panes behind
+	// for sibling tests.
+	t.Cleanup(func() {
+		_ = d1.driver.KillSession("marvel-" + ws)
+		_ = os.Remove(sock1)
+	})
+
+	resp, err := SendRequest(sock1, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(manifest)}),
+	})
+	if err != nil || resp.Error != "" {
+		t.Fatalf("apply: err=%v resp.Error=%q", err, resp.Error)
+	}
+	time.Sleep(600 * time.Millisecond)
+
+	before := d1.store.ListSessionsByTeam(ws, "squad")
+	if len(before) != 1 {
+		t.Fatalf("expected 1 session before detach, got %d", len(before))
+	}
+	sessKey := before[0].Key()
+	paneID := before[0].PaneID
+	if paneID == "" {
+		t.Fatal("expected the session to have a pane before detach")
+	}
+
+	d1.Detach()
+
+	// The pane the agent runs in must be untouched: this is the whole
+	// difference between detach and teardown.
+	if !d1.driver.HasPane(paneID) {
+		t.Fatalf("pane %s was killed by Detach", paneID)
+	}
+
+	d2, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon #2: %v", err)
+	}
+	sock2 := filepath.Join(os.TempDir(), "marvel-test-detach-2.sock")
+	t.Cleanup(func() {
+		d2.Stop()
+		_ = os.Remove(sock2)
+	})
+
+	// Rehydrated intent must name the same pane, or AdoptOrKill has
+	// nothing to match on and kills it.
+	rehydrated, err := d2.store.GetSession(sessKey)
+	if err != nil {
+		t.Fatalf("session %s did not survive detach: %v", sessKey, err)
+	}
+	if rehydrated.PaneID != paneID {
+		t.Fatalf("rehydrated PaneID: want %s, got %s", paneID, rehydrated.PaneID)
+	}
+
+	if err := d2.Start(sock2); err != nil {
+		t.Fatalf("start daemon #2: %v", err)
+	}
+	if !d2.driver.HasPane(paneID) {
+		t.Fatalf("pane %s was killed on restart instead of adopted", paneID)
+	}
+
+	// Give the reconciler a few ticks: the adopted session already
+	// satisfies the role's replica count, so nothing new should spawn.
+	time.Sleep(3 * ReconcileInterval)
+	after := d2.store.ListSessionsByTeam(ws, "squad")
+	if len(after) != 1 {
+		t.Fatalf("expected 1 session after restart, got %d: %+v", len(after), after)
+	}
+	if after[0].PaneID != paneID {
+		t.Fatalf("session was replaced rather than adopted: pane %s -> %s", paneID, after[0].PaneID)
+	}
+	if !d2.driver.HasPane(paneID) {
+		t.Fatalf("pane %s died during reconciliation after adoption", paneID)
+	}
+}
+
+// TestStopTeardownStillDestroys guards the escape hatch: --teardown
+// keeps the old behavior, so an operator who wants the machine clean
+// still gets it and a restart has nothing to adopt.
+func TestStopTeardownStillDestroys(t *testing.T) {
+	skipIfNoTmux(t)
+
+	boltPath := filepath.Join(t.TempDir(), "marvel.bolt")
+	ws := "test-teardown"
+	manifest := `
+[workspace]
+name = "` + ws + `"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+
+    [team.role.runtime]
+    command = "sleep"
+    args = ["300"]
+`
+
+	d, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	sock := filepath.Join(os.TempDir(), "marvel-test-teardown.sock")
+	if err := d.Start(sock); err != nil {
+		t.Fatalf("start daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = d.driver.KillSession("marvel-" + ws)
+		_ = os.Remove(sock)
+	})
+
+	resp, err := SendRequest(sock, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(manifest)}),
+	})
+	if err != nil || resp.Error != "" {
+		t.Fatalf("apply: err=%v resp.Error=%q", err, resp.Error)
+	}
+	time.Sleep(600 * time.Millisecond)
+
+	sessions := d.store.ListSessionsByTeam(ws, "squad")
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	paneID := sessions[0].PaneID
+
+	d.Stop()
+
+	if d.driver.HasPane(paneID) {
+		t.Fatalf("pane %s survived teardown", paneID)
+	}
+	if d.driver.HasSession("marvel-" + ws) {
+		t.Fatal("workspace tmux session survived teardown")
+	}
+	if got := len(d.store.ListSessions()); got != 0 {
+		t.Fatalf("expected 0 sessions after teardown, got %d", got)
+	}
+}
+
+// TestStopModeDefaultsToDetach pins the RPC surface: a client that
+// sends no params, including any built before the flag existed, gets a
+// detach, never a teardown. handleStop itself is not called here; its
+// goroutine exits the process, so the two tests above cover it.
+func TestStopModeDefaultsToDetach(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		params   json.RawMessage
+		teardown bool
+		mode     string
+	}{
+		{"absent", nil, false, "detach"},
+		{"empty object", json.RawMessage(`{}`), false, "detach"},
+		{"explicit false", json.RawMessage(`{"teardown":false}`), false, "detach"},
+		{"explicit true", json.RawMessage(`{"teardown":true}`), true, "teardown"},
+	}
+	for _, tc := range cases {
+		teardown, mode, err := stopMode(tc.params)
+		if err != nil {
+			t.Errorf("%s: stopMode: %v", tc.name, err)
+			continue
+		}
+		if teardown != tc.teardown || mode != tc.mode {
+			t.Errorf("%s: got (%v, %q), want (%v, %q)", tc.name, teardown, mode, tc.teardown, tc.mode)
+		}
+	}
+	if _, _, err := stopMode(json.RawMessage(`{`)); err == nil {
+		t.Error("expected an error on malformed params")
+	}
+}

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -32,6 +32,10 @@ type Controller struct {
 	// pre-fix implementation reset the counter on every rebuild, which
 	// made the backoff and max-restart caps impossible to enforce.
 	// See ArcavenAE/marvel#11.
+	//
+	// This map is the live copy; the store's role_health bucket is its
+	// durable mirror, written through on every change and read back by
+	// RehydrateRoleHealth at daemon start. See aae-orc-qdew.
 	roleHealth map[string]*RoleHealth
 
 	// now is an injection point for tests; nil means time.Now().UTC().
@@ -94,6 +98,55 @@ func (c *Controller) getRoleHealth(key string) *RoleHealth {
 	return rh
 }
 
+// RehydrateRoleHealth loads persisted crash-loop state into the
+// controller's map. Called at daemon start after Store.OpenBolt has
+// rehydrated the rest of L2, so a role sitting in a backoff window (or
+// frozen at MaxRestarts saturation) stays held back across a daemon
+// restart instead of getting a free respawn on the first reconcile tick.
+// No-op when persistence is disabled. See aae-orc-qdew.
+func (c *Controller) RehydrateRoleHealth() error {
+	recs, err := c.store.ListRoleHealth()
+	if err != nil {
+		return fmt.Errorf("load role health: %w", err)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, rec := range recs {
+		c.roleHealth[rec.Key] = &RoleHealth{
+			RestartCount:  rec.RestartCount,
+			LastRestartAt: rec.LastRestartAt,
+			BackoffUntil:  rec.BackoffUntil,
+		}
+	}
+	if len(recs) > 0 {
+		log.Printf("role health: rehydrated %d role(s) from durable state", len(recs))
+	}
+	return nil
+}
+
+// persistRoleHealth mirrors one role's state into the store. A failed
+// write costs the backoff window across the next restart, not
+// correctness now, so it logs rather than propagating. Caller holds
+// c.mu.
+func (c *Controller) persistRoleHealth(key string, rh *RoleHealth) {
+	if err := c.store.PersistRoleHealth(api.RoleHealthRecord{
+		Key:           key,
+		RestartCount:  rh.RestartCount,
+		LastRestartAt: rh.LastRestartAt,
+		BackoffUntil:  rh.BackoffUntil,
+	}); err != nil {
+		log.Printf("persist role health %s: %v", key, err)
+	}
+}
+
+// forgetRoleHealth drops one role's durable state, paired with the
+// in-memory delete in the cascade-clear helpers. Caller holds c.mu.
+func (c *Controller) forgetRoleHealth(key string) {
+	if err := c.store.DeleteRoleHealth(key); err != nil {
+		log.Printf("delete role health %s: %v", key, err)
+	}
+}
+
 // RoleHealthSnapshot returns the current restart state for a role,
 // useful for tests and for `marvel describe team` observability.
 // Returns (nil, false) if the role has no recorded crash-loop history.
@@ -129,6 +182,7 @@ func (c *Controller) ClearRoleHealthForTeam(workspace, team string) {
 	for k := range c.roleHealth {
 		if strings.HasPrefix(k, prefix) {
 			delete(c.roleHealth, k)
+			c.forgetRoleHealth(k)
 		}
 	}
 }
@@ -143,6 +197,7 @@ func (c *Controller) ClearRoleHealthForWorkspace(workspace string) {
 	for k := range c.roleHealth {
 		if strings.HasPrefix(k, prefix) {
 			delete(c.roleHealth, k)
+			c.forgetRoleHealth(k)
 		}
 	}
 }
@@ -219,6 +274,7 @@ func (c *Controller) noteCrashAndBackoff(workspace, team, role string, maxRestar
 	rh := c.getRoleHealth(roleKey)
 	if maxRestarts > 0 && rh.RestartCount >= maxRestarts {
 		rh.BackoffUntil = saturationFreezeUntil
+		c.persistRoleHealth(roleKey, rh)
 		return false
 	}
 	now := c.nowUTC()
@@ -226,6 +282,7 @@ func (c *Controller) noteCrashAndBackoff(workspace, team, role string, maxRestar
 	rh.LastRestartAt = now
 	nextBackoff := computeBackoff(rh.RestartCount + 1)
 	rh.BackoffUntil = now.Add(nextBackoff)
+	c.persistRoleHealth(roleKey, rh)
 	return true
 }
 

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -3,6 +3,7 @@ package team
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1107,5 +1108,179 @@ func TestShiftSessionNaming(t *testing.T) {
 	}
 	if !strings.Contains(gen2[0].Name, "-g2-") {
 		t.Fatalf("expected g2 in name, got %s", gen2[0].Name)
+	}
+}
+
+// setupWithBolt is setup() against a persistence-backed store, for the
+// tests that assert crash-loop state survives a store reopen. The
+// caller supplies the bolt path so a second call can reopen the same
+// file as a fresh daemon would. See aae-orc-qdew.
+func setupWithBolt(t *testing.T, boltPath string) (*api.Store, *Controller, func()) {
+	t.Helper()
+	store := api.NewStore()
+	if err := store.OpenBolt(boltPath); err != nil {
+		t.Fatalf("OpenBolt %s: %v", boltPath, err)
+	}
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	sessMgr := session.NewManager(store, driver)
+	ctrl := NewController(store, sessMgr)
+	if err := ctrl.RehydrateRoleHealth(); err != nil {
+		t.Fatalf("RehydrateRoleHealth: %v", err)
+	}
+
+	cleanup := func() {
+		for _, ws := range store.ListWorkspaces() {
+			_ = sessMgr.CleanupWorkspace(ws.Name)
+		}
+		_ = store.CloseBolt()
+	}
+	return store, ctrl, cleanup
+}
+
+// TestRoleHealthRoundTripsThroughStore covers the bucket wiring:
+// noteCrashAndBackoff writes through to the store, a fresh controller
+// reads the same values back, and the cascade-clear helpers remove the
+// durable row as well as the in-memory one. No tmux needed: this is
+// the persistence contract, not the reconciler.
+func TestRoleHealthRoundTripsThroughStore(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "marvel.bolt")
+
+	store1 := api.NewStore()
+	if err := store1.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #1: %v", err)
+	}
+	ctrl1 := NewController(store1, nil)
+	clock := newTestClock(time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC))
+	ctrl1.now = clock.Now
+
+	if !ctrl1.noteCrashAndBackoff("ws1", "squad", "worker", 0) {
+		t.Fatal("first crash should be recorded")
+	}
+	if !ctrl1.noteCrashAndBackoff("ws1", "squad", "reviewer", 0) {
+		t.Fatal("sibling role crash should be recorded")
+	}
+	want, ok := ctrl1.RoleHealthSnapshot("ws1", "squad", "worker")
+	if !ok {
+		t.Fatal("expected in-memory role health for worker")
+	}
+	if err := store1.CloseBolt(); err != nil {
+		t.Fatalf("CloseBolt: %v", err)
+	}
+
+	store2 := api.NewStore()
+	if err := store2.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #2: %v", err)
+	}
+	t.Cleanup(func() { _ = store2.CloseBolt() })
+	ctrl2 := NewController(store2, nil)
+	if err := ctrl2.RehydrateRoleHealth(); err != nil {
+		t.Fatalf("RehydrateRoleHealth: %v", err)
+	}
+
+	got, ok := ctrl2.RoleHealthSnapshot("ws1", "squad", "worker")
+	if !ok {
+		t.Fatal("worker role health did not survive the reopen")
+	}
+	if got.RestartCount != want.RestartCount {
+		t.Fatalf("RestartCount after reopen: want %d, got %d", want.RestartCount, got.RestartCount)
+	}
+	if !got.BackoffUntil.Equal(want.BackoffUntil) {
+		t.Fatalf("BackoffUntil after reopen: want %s, got %s", want.BackoffUntil, got.BackoffUntil)
+	}
+	if !got.LastRestartAt.Equal(want.LastRestartAt) {
+		t.Fatalf("LastRestartAt after reopen: want %s, got %s", want.LastRestartAt, got.LastRestartAt)
+	}
+	if _, ok := ctrl2.RoleHealthSnapshot("ws1", "squad", "reviewer"); !ok {
+		t.Fatal("reviewer role health did not survive the reopen")
+	}
+
+	// Cascade clear must reach the durable row too, or a re-applied
+	// manifest inherits the prior generation's backoff. See marvel#29.
+	ctrl2.ClearRoleHealthForTeam("ws1", "squad")
+	recs, err := store2.ListRoleHealth()
+	if err != nil {
+		t.Fatalf("ListRoleHealth: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected no durable role-health rows after cascade clear, got %+v", recs)
+	}
+}
+
+// TestSaturatedRoleStaysFrozenAcrossRestart is the behavioral half: a
+// role that exhausted MaxRestarts must still refuse to spawn after the
+// daemon restarts, no matter how far the clock has moved. Before
+// RoleHealth was persisted the fresh controller started with an empty
+// map and handed the saturated role a free respawn. See aae-orc-qdew.
+func TestSaturatedRoleStaysFrozenAcrossRestart(t *testing.T) {
+	skipIfNoTmux(t)
+	path := filepath.Join(t.TempDir(), "marvel.bolt")
+
+	store1, ctrl1, cleanup1 := setupWithBolt(t, path)
+	clock := newTestClock(time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC))
+	ctrl1.now = clock.Now
+
+	ws := "test-rh-frozen"
+	createTeamFixture(t, store1, ws, "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			MaxRestarts: 1,
+		},
+	})
+
+	// Burn the single restart, then saturate on the next crash.
+	for i := 0; i < 2; i++ {
+		ctrl1.ReconcileOnce()
+		got := store1.ListSessionsByTeamRole(ws, "squad", "worker")
+		if len(got) == 0 {
+			t.Fatalf("iteration %d: expected a running session", i)
+		}
+		killPaneAndWait(t, got[0].PaneID)
+		ctrl1.ReconcileOnce() // reap + crash bookkeeping
+		clock.Advance(10 * time.Minute)
+	}
+
+	rh, ok := ctrl1.RoleHealthSnapshot(ws, "squad", "worker")
+	if !ok {
+		t.Fatal("expected role health after saturation")
+	}
+	if rh.BackoffUntil != saturationFreezeUntil {
+		t.Fatalf("expected saturation freeze before restart, got BackoffUntil=%s count=%d",
+			rh.BackoffUntil, rh.RestartCount)
+	}
+
+	// Simulate the daemon restart: release the bolt file without
+	// touching panes (what Detach does), then reopen into fresh
+	// in-memory state.
+	cleanup1()
+
+	store2, ctrl2, cleanup2 := setupWithBolt(t, path)
+	t.Cleanup(cleanup2)
+	clock2 := newTestClock(time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC))
+	ctrl2.now = clock2.Now
+
+	rh2, ok := ctrl2.RoleHealthSnapshot(ws, "squad", "worker")
+	if !ok {
+		t.Fatal("saturated role health did not survive the restart")
+	}
+	if rh2.BackoffUntil != saturationFreezeUntil {
+		t.Fatalf("expected saturation freeze after restart, got %s", rh2.BackoffUntil)
+	}
+
+	// A day later the reconciler must still refuse to spawn.
+	clock2.Advance(24 * time.Hour)
+	ctrl2.ReconcileOnce()
+	alive := 0
+	for _, s := range store2.ListSessionsByTeamRole(ws, "squad", "worker") {
+		if s.State.CountsAsAlive() {
+			alive++
+		}
+	}
+	if alive != 0 {
+		t.Fatalf("saturated role respawned after restart: %d alive session(s)", alive)
 	}
 }

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ start-bg: build
 
 # Stop the daemon and clean up all tmux sessions
 stop:
+    ./bin/marvel stop --teardown || true
+
+# Stop the daemon but leave agents running; the next `just daemon` adopts them
+detach:
     ./bin/marvel stop || true
 
 # Load the demo manifest


### PR DESCRIPTION
Restarting the marvel daemon should not cost you your agents. Today it does, and only on the graceful path: `kill -9` leaves the panes running and the next start adopts them, while Ctrl-C, `marvel stop`, or a SIGTERM from a package upgrade tears every agent down first. This PR makes the graceful path honest, and makes crash-loop state survive the restart it was supposed to outlive.

## Graceful stop is a detach (aae-orc-1aoe)

`daemon.Stop()` iterated workspaces calling `CleanupWorkspace`, which deleted each session from bolt and killed its pane, and only then closed the bolt file. Since `cmd/marvel` wired SIGINT and SIGTERM straight to `Stop()`, the AdoptOrKill path added by the L2 spike could only ever fire after an ungraceful death. `Store.Checkpoint()` had zero callers despite a doc comment claiming graceful-shutdown and pre-exec call sites.

Shutdown now splits:

- `Daemon.Detach()` stops the reconciler and listeners, checkpoints L2, releases the bolt file, and touches no pane. Signals and plain `marvel stop` take this path, so the next start rehydrates the same intent and adopts the live panes.
- `Daemon.Stop()` keeps the destroy-everything behavior behind `marvel stop --teardown`, for the operator who wants the machine clean.

The stop RPC defaults to detach, so a client built before the flag cannot ask for a teardown by omission. `Store.Checkpoint()` now runs on both shutdown paths just before `CloseBolt`, and `Daemon.Checkpoint()` is the named seam for the `syscall.Exec` self-update in aae-orc-zk5r. No self-update logic here.

## RoleHealth is durable (aae-orc-qdew)

The `role_health` bucket the L2 spike reserved was never written or read. Crash-loop state lived only in the team controller's in-memory map, so a role correctly frozen at MaxRestarts saturation came back from a restart with an empty counter and got a free respawn. The Store gains `PersistRoleHealth` / `ListRoleHealth` / `DeleteRoleHealth`; the controller writes through on every state change, drops the durable row alongside the in-memory one in both cascade-clear paths, and rehydrates at daemon start.

RoleHealth is the one bucket with no in-memory mirror in the Store, since the controller's map is the live copy. That asymmetry is documented where the methods live.

## Tests

Four new tests, and each one fails if the change it covers is reverted:

- detach leaves the pane alive, and a second daemon over the same state file adopts it rather than spawning a replacement
- `--teardown` still destroys sessions, panes, and the workspace tmux session
- RoleHealth round-trips through close and reopen, including cascade clear reaching the durable row
- a saturated role still refuses to spawn a day after the restart

`go build`, `go vet`, `golangci-lint`, and `go test ./... -race` all pass.

## Deferred

The KEP-style drain sequence stays out of scope. Nothing here signals an agent to shut down, waits out a grace period, or orders roles by priority; detach preserves agents instead of draining them, which sidesteps that question rather than answering it. Priority semantics, per-role grace periods, and the forestage preStop equivalent are untouched, and `_kos/nodes/frontier/question-marvel-graceful-stop.yaml` stays frontier for exactly that reason.

## Cost of merge

One behavior change to call out: `marvel stop` no longer tears agents down. Callers that relied on it as cleanup need `--teardown`, which is what the README, both guides, the CI recipe in the admin guide, and `just stop` now use. `just detach` is the new recipe for the other half.

Refs: aae-orc-1aoe, aae-orc-qdew