### PR TITLE
feat(metrics): per-session CPU and memory from a pid-subtree sampler

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -1267,6 +1267,10 @@ func sortSessions(sessions []api.Session, ws *watchSort) {
 		switch ws.column {
 		case "context":
 			less = sessions[i].ContextPercent < sessions[j].ContextPercent
+		case "cpu":
+			less = sessions[i].CPUPercent < sessions[j].CPUPercent
+		case "rss":
+			less = sessions[i].RSSBytes < sessions[j].RSSBytes
 		case "name":
 			less = sessions[i].Name < sessions[j].Name
 		case "team":
@@ -1319,18 +1323,50 @@ func fetchSessions() ([]api.Session, error) {
 	return sessions, nil
 }
 
+// formatBytes renders a byte count in the units an operator scanning a
+// column wants: three significant figures at most, no padding.
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	value := float64(n)
+	for _, suffix := range []string{"K", "M", "G", "T"} {
+		value /= unit
+		if value < unit {
+			if value < 10 {
+				return fmt.Sprintf("%.1f%s", value, suffix)
+			}
+			return fmt.Sprintf("%.0f%s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.0fP", value/unit)
+}
+
 func renderSessionTable(sessions []api.Session) string {
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "WORKSPACE\tTEAM\tROLE\tGEN\tNAME\tSTATE\tHEALTH\tCTX%%\tDESK\tAGENT\n")
+	_, _ = fmt.Fprintf(w, "WORKSPACE\tTEAM\tROLE\tGEN\tNAME\tSTATE\tHEALTH\tCTX%%\tCPU%%\tRSS\tDESK\tAGENT\n")
 	for _, s := range sessions {
 		agent := s.Runtime.Name
 		if agent == "" {
 			agent = s.Runtime.Command
 		}
+		// CTX% has exactly one producer, the heartbeat RPC, and no
+		// runtime adapter implements it yet. Without a heartbeat there is
+		// no context reading to show, and "0%" would read as a fresh
+		// session with an empty window.
 		ctx := "-"
-		if s.ContextPercent > 0 || !s.LastHeartbeat.IsZero() {
+		if !s.LastHeartbeat.IsZero() {
 			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)
+		}
+		// Likewise for the sampler: a session the sampler has not
+		// reached (no pid, or a platform with no process table reader)
+		// shows absence rather than an idle-looking zero.
+		cpu, rss := "-", "-"
+		if !s.MetricsAt.IsZero() {
+			cpu = fmt.Sprintf("%.1f", s.CPUPercent)
+			rss = formatBytes(s.RSSBytes)
 		}
 		desk := strings.TrimPrefix(s.PaneID, "%")
 		gen := fmt.Sprintf("%d", s.Generation)
@@ -1338,8 +1374,8 @@ func renderSessionTable(sessions []api.Session) string {
 		if health == "" {
 			health = "unknown"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			s.Workspace, s.Team, s.Role, gen, s.Name, s.State, health, ctx, desk, agent)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Workspace, s.Team, s.Role, gen, s.Name, s.State, health, ctx, cpu, rss, desk, agent)
 	}
 	_ = w.Flush()
 	return buf.String()
@@ -1357,6 +1393,7 @@ func renderWatch(ws *watchSort, interval time.Duration) string {
 		fmt.Fprintf(&buf, "    w  workspace      t  team          r  role\n")
 		fmt.Fprintf(&buf, "    g  generation     n  name          s  state\n")
 		fmt.Fprintf(&buf, "    c  context        d  desk          a  agent\n")
+		fmt.Fprintf(&buf, "    p  cpu            m  memory\n")
 		fmt.Fprintf(&buf, "\n")
 		fmt.Fprintf(&buf, "    h  toggle help    q  quit\n")
 		fmt.Fprintf(&buf, "\n")
@@ -1440,6 +1477,10 @@ func watchSessionsLoop(interval time.Duration) error {
 				return nil
 			case 'c':
 				toggleSort(ws, "context", true)
+			case 'p':
+				toggleSort(ws, "cpu", true)
+			case 'm':
+				toggleSort(ws, "rss", true)
 			case 'n':
 				toggleSort(ws, "name", false)
 			case 'r':

--- a/cmd/marvel/render_test.go
+++ b/cmd/marvel/render_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1.0K"},
+		{1536, "1.5K"},
+		{100 * 1024, "100K"},
+		{4 * 1024 * 1024, "4.0M"},
+		{512 * 1024 * 1024, "512M"},
+		{3 * 1024 * 1024 * 1024, "3.0G"},
+	}
+	for _, c := range cases {
+		if got := formatBytes(c.in); got != c.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func column(t *testing.T, table, name string) string {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(table, "\n"), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("table has no rows:\n%s", table)
+	}
+	header := strings.Fields(lines[0])
+	row := strings.Fields(lines[1])
+	if len(header) != len(row) {
+		t.Fatalf("header has %d columns, row has %d:\n%s", len(header), len(row), table)
+	}
+	for i, h := range header {
+		if h == name {
+			return row[i]
+		}
+	}
+	t.Fatalf("no %s column in:\n%s", name, table)
+	return ""
+}
+
+// CTX% had one producer, the heartbeat RPC, and no runtime adapter
+// implements it. A session that has never sent one has no context
+// reading, and "0%" would read as a fresh window rather than as silence.
+func TestRenderSessionTableNoHeartbeat(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
+	}})
+	if got := column(t, table, "CTX%"); got != "-" {
+		t.Errorf("CTX%% = %q with no heartbeat, want %q", got, "-")
+	}
+}
+
+func TestRenderSessionTableWithHeartbeat(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
+		ContextPercent: 0, LastHeartbeat: time.Now().UTC(),
+	}})
+	if got := column(t, table, "CTX%"); got != "0%" {
+		t.Errorf("CTX%% = %q after a heartbeat reporting 0, want %q", got, "0%")
+	}
+}
+
+func TestRenderSessionTableUnsampled(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
+	}})
+	if got := column(t, table, "CPU%"); got != "-" {
+		t.Errorf("CPU%% = %q before the first sampler pass, want %q", got, "-")
+	}
+	if got := column(t, table, "RSS"); got != "-" {
+		t.Errorf("RSS = %q before the first sampler pass, want %q", got, "-")
+	}
+}
+
+func TestRenderSessionTableSampled(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
+		SessionMetrics: api.SessionMetrics{
+			CPUPercent: 12.75,
+			RSSBytes:   512 * 1024 * 1024,
+			MetricsAt:  time.Now().UTC(),
+		},
+	}})
+	if got := column(t, table, "CPU%"); got != "12.8" {
+		t.Errorf("CPU%% = %q, want %q", got, "12.8")
+	}
+	if got := column(t, table, "RSS"); got != "512M" {
+		t.Errorf("RSS = %q, want %q", got, "512M")
+	}
+}
+
+// An idle sampled session must be distinguishable from an unsampled one.
+func TestRenderSessionTableSampledIdle(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
+		SessionMetrics: api.SessionMetrics{MetricsAt: time.Now().UTC()},
+	}})
+	if got := column(t, table, "CPU%"); got != "0.0" {
+		t.Errorf("CPU%% = %q for a sampled idle session, want %q", got, "0.0")
+	}
+	if got := column(t, table, "RSS"); got != "0B" {
+		t.Errorf("RSS = %q for a sampled idle session, want %q", got, "0B")
+	}
+}
+
+func TestSortSessionsByCPUAndRSS(t *testing.T) {
+	sessions := []api.Session{
+		{Name: "a", SessionMetrics: api.SessionMetrics{CPUPercent: 1, RSSBytes: 300}},
+		{Name: "b", SessionMetrics: api.SessionMetrics{CPUPercent: 50, RSSBytes: 100}},
+		{Name: "c", SessionMetrics: api.SessionMetrics{CPUPercent: 10, RSSBytes: 200}},
+	}
+
+	sortSessions(sessions, &watchSort{column: "cpu", desc: true})
+	if sessions[0].Name != "b" {
+		t.Errorf("cpu desc put %q first, want b", sessions[0].Name)
+	}
+
+	sortSessions(sessions, &watchSort{column: "rss", desc: true})
+	if sessions[0].Name != "a" {
+		t.Errorf("rss desc put %q first, want a", sessions[0].Name)
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,7 @@ internal/
   session/                  Session lifecycle (create, delete, reap)
   team/                     Team controller (reconciler, shifts, health)
   tmux/                     tmux driver (subprocess, capture, send-keys)
+  procstat/                 Per-session CPU/memory rollup over a pid subtree
   otel/                     Observability (OTEL metrics)
   simulator/                Context pressure simulator + Lua scripting
   upgrade/                  Self-update (Homebrew detection, GitHub releases)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -152,10 +152,28 @@ marvel get sessions
 
 Output:
 ```
-WORKSPACE  TEAM       ROLE    GEN  NAME                   STATE    HEALTH   CTX%  DESK  AGENT
-dev        squad      worker  1    squad-worker-g1-0      running  unknown  -     1     claude
-dev        squad      worker  1    squad-worker-g1-1      running  unknown  -     2     claude
+WORKSPACE  TEAM       ROLE    GEN  NAME                   STATE    HEALTH   CTX%  CPU%   RSS   DESK  AGENT
+dev        squad      worker  1    squad-worker-g1-0      running  unknown  -     99.9   412M  1     claude
+dev        squad      worker  1    squad-worker-g1-1      running  unknown  -     0.4    380M  2     claude
 ```
+
+`CPU%` and `RSS` come from a sampler that runs every 5 seconds and rolls
+up each agent's whole process subtree, not just the process tmux started
+(that one is a shell). CPU% is per core, so a session using two cores
+reads about 200.
+
+A `-` means the value has never been measured, which is not the same as
+zero:
+
+- `CTX%` is `-` until the agent sends a heartbeat. No runtime adapter
+  implements the heartbeat yet, so today only the bundled simulator
+  reports context pressure.
+- `CPU%` and `RSS` are `-` before the first sampler pass, and on
+  platforms where marvel has no process-table reader (anything other
+  than macOS and Linux).
+
+Per-process IO counters are read on Linux only; `marvel describe session`
+reports `IOAvailable: false` elsewhere.
 
 ### Watch mode
 
@@ -163,8 +181,9 @@ dev        squad      worker  1    squad-worker-g1-1      running  unknown  -   
 marvel get sessions -w
 ```
 
-Live-updating dashboard. Sort by pressing keys: `c` (context %), `n` (name),
-`r` (role), `g` (generation), `t` (team). Press `h` for help, `q` to quit.
+Live-updating dashboard. Sort by pressing keys: `c` (context %), `p`
+(CPU), `m` (memory), `n` (name), `r` (role), `g` (generation), `t`
+(team). Press `h` for help, `q` to quit.
 
 **When to use:** Monitoring a running team, watching shifts progress,
 observing health state changes in real time.

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -407,3 +407,24 @@ func (s *Store) UpdateSessionHeartbeat(key string, contextPercent float64) error
 	sess.LastHeartbeat = time.Now().UTC()
 	return s.persistPut(bucketSessions, sess.Key(), sess)
 }
+
+// UpdateSessionMetrics records one process-sampler reading. m.MetricsAt
+// is set here so every stored reading carries the store's clock.
+//
+// Unlike UpdateSessionHeartbeat this does not persist. A reading is
+// stale the moment the daemon stops, and the sampler refreshes every
+// session within one interval of startup, so a bolt write per session
+// per interval would buy a number nobody can use. Sessions missing from
+// the store are ignored rather than reported: the sampler works from a
+// snapshot and a session can be deleted between the snapshot and the
+// write.
+func (s *Store) UpdateSessionMetrics(key string, m SessionMetrics) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[key]
+	if !ok {
+		return
+	}
+	m.MetricsAt = time.Now().UTC()
+	sess.SessionMetrics = m
+}

--- a/internal/api/store_test.go
+++ b/internal/api/store_test.go
@@ -248,3 +248,57 @@ func TestListSessionsByTeamRoleGeneration(t *testing.T) {
 		t.Fatalf("expected 3 total workers, got %d", len(all))
 	}
 }
+
+func TestUpdateSessionMetrics(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+
+	sess := &Session{
+		Name:      "agent-0",
+		Workspace: "test-ws",
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   Runtime{Name: "forestage", Command: "forestage"},
+		State:     SessionRunning,
+		PID:       4242,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	before, _ := s.GetSession("test-ws/agent-0")
+	if !before.MetricsAt.IsZero() {
+		t.Fatal("a session must start with no sampler reading so callers can render absence")
+	}
+
+	s.UpdateSessionMetrics("test-ws/agent-0", SessionMetrics{
+		CPUPercent:   17.5,
+		RSSBytes:     512 << 20,
+		IOReadBytes:  2048,
+		IOWriteBytes: 1024,
+		IOAvailable:  true,
+	})
+
+	got, _ := s.GetSession("test-ws/agent-0")
+	if got.CPUPercent != 17.5 {
+		t.Errorf("CPUPercent = %v, want 17.5", got.CPUPercent)
+	}
+	if got.RSSBytes != 512<<20 {
+		t.Errorf("RSSBytes = %d, want %d", got.RSSBytes, int64(512<<20))
+	}
+	if !got.IOAvailable || got.IOReadBytes != 2048 || got.IOWriteBytes != 1024 {
+		t.Errorf("IO = %+v, want 2048 read / 1024 write, available", got.SessionMetrics)
+	}
+	if got.MetricsAt.IsZero() {
+		t.Error("MetricsAt is zero after a write; the CLI cannot tell measured from unmeasured")
+	}
+	// Fields the sampler does not own must survive the write.
+	if got.PID != 4242 || got.State != SessionRunning {
+		t.Errorf("metrics write disturbed PID/State: %+v", got)
+	}
+
+	// A session deleted between the sampler's snapshot and its write is
+	// not an error worth reporting.
+	s.UpdateSessionMetrics("test-ws/nonexistent", SessionMetrics{CPUPercent: 1})
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -95,6 +95,10 @@ type Runtime struct {
 }
 
 // Session is the atomic unit: a tmux pane running one process (pod equivalent).
+//
+// PID is tmux's pane_pid: the shell tmux started, not the agent binary
+// it exec'd. Resource readings are therefore a rollup over the pid's
+// subtree, not a read of the pid itself. See internal/procstat.
 type Session struct {
 	Name            string       `toml:"name"`
 	Workspace       string       `toml:"workspace"`
@@ -112,6 +116,26 @@ type Session struct {
 	RestartCount    int          `toml:"-"`
 	LastHealthCheck time.Time    `toml:"-"`
 	CreatedAt       time.Time    `toml:"-"`
+	SessionMetrics  `toml:"-"`
+}
+
+// SessionMetrics is one process-sampler reading for a session, rolled up
+// over the pid subtree.
+//
+// MetricsAt separates "sampled, idle" from "never sampled": a session
+// with no PID, or one running where marvel has no process-table reader,
+// keeps MetricsAt zero and callers render absence instead of a
+// convincing 0.0.
+type SessionMetrics struct {
+	CPUPercent float64
+	RSSBytes   int64
+	// IOReadBytes and IOWriteBytes are cumulative block-layer bytes over
+	// the subtree. IOAvailable is false where the platform exposes no
+	// per-process counter (darwin today).
+	IOReadBytes  int64
+	IOWriteBytes int64
+	IOAvailable  bool
+	MetricsAt    time.Time
 }
 
 // Role declares desired state for one kind of agent within a team.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -39,6 +39,11 @@ const (
 	DefaultMRVLPort = "6785"
 	// ReconcileInterval is how often the team controller reconciles.
 	ReconcileInterval = 2 * time.Second
+	// MetricsInterval is how often the process sampler rolls up CPU and
+	// memory over each session's pid subtree. Slower than
+	// ReconcileInterval on purpose: a pass reads the whole process table,
+	// and the numbers inform an operator rather than a control decision.
+	MetricsInterval = 5 * time.Second
 )
 
 // listenNetwork returns "tcp" if the address looks like host:port,
@@ -98,6 +103,11 @@ type Daemon struct {
 	// In-memory ring of structured state-transition events.
 	// Always non-nil.
 	events *events.Ring
+
+	// metricsWarn keeps a sampler that cannot read the process table
+	// from writing the same line every interval for the life of the
+	// daemon.
+	metricsWarn sync.Once
 }
 
 // Options configures optional daemon behavior. Zero value disables
@@ -226,6 +236,16 @@ func (d *Daemon) Start(socketPath string) error {
 	go func() {
 		defer d.wg.Done()
 		d.teamCtrl.Run(ctx, ReconcileInterval)
+	}()
+
+	// Start the process sampler. Sibling of the reconcile loop rather
+	// than a step inside it: sampling reads the process table and takes
+	// no part in reconciliation, so it should not be able to slow a
+	// reconcile pass down.
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.RunMetrics(ctx, MetricsInterval)
 	}()
 
 	// Accept connections.

--- a/internal/daemon/metrics.go
+++ b/internal/daemon/metrics.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/procstat"
+)
+
+// RunMetrics samples per-session CPU and memory every interval until ctx
+// is cancelled. Exported so tests can drive the loop without starting a
+// listener.
+func (d *Daemon) RunMetrics(ctx context.Context, interval time.Duration) {
+	sampler := procstat.NewSampler()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// A first pass right away so `marvel get sessions` has numbers
+	// before the first tick. On platforms whose CPU reading is a delta
+	// between passes it also seeds the baseline.
+	d.SampleMetricsOnce(sampler)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.SampleMetricsOnce(sampler)
+		}
+	}
+}
+
+// SampleMetricsOnce runs one sampler pass and writes the results into the
+// store. Sessions with no pid are skipped, leaving MetricsAt zero so the
+// CLI renders absence rather than zero usage.
+func (d *Daemon) SampleMetricsOnce(sampler *procstat.Sampler) {
+	sessions := d.store.ListSessions()
+	pids := make([]int, 0, len(sessions))
+	for _, s := range sessions {
+		if s.PID > 0 && s.State.CountsAsAlive() {
+			pids = append(pids, s.PID)
+		}
+	}
+	if len(pids) == 0 {
+		return
+	}
+
+	samples, err := sampler.Sample(pids)
+	if err != nil {
+		d.metricsWarn.Do(func() {
+			if errors.Is(err, procstat.ErrUnsupported) {
+				log.Printf("process metrics unavailable on this platform; CPU and RSS will read as -")
+				return
+			}
+			log.Printf("process metrics: %v (further failures suppressed)", err)
+		})
+		return
+	}
+
+	for _, s := range sessions {
+		sample, ok := samples[s.PID]
+		if !ok {
+			continue
+		}
+		d.store.UpdateSessionMetrics(s.Key(), api.SessionMetrics{
+			CPUPercent:   sample.CPUPercent,
+			RSSBytes:     sample.RSSBytes,
+			IOReadBytes:  sample.IOReadBytes,
+			IOWriteBytes: sample.IOWriteBytes,
+			IOAvailable:  sample.IOAvailable,
+		})
+	}
+}

--- a/internal/daemon/metrics_test.go
+++ b/internal/daemon/metrics_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/procstat"
+)
+
+// The sampler pass is driven directly rather than through Start so the
+// test does not wait out a tick. Its own pid stands in for a session's
+// pane_pid: it is guaranteed to exist and to hold memory.
+func TestSampleMetricsOnce(t *testing.T) {
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+
+	live := &api.Session{
+		Name:      "agent-0",
+		Workspace: "metrics-ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep"},
+		State:     api.SessionRunning,
+		PID:       os.Getpid(),
+	}
+	noPID := &api.Session{
+		Name:      "agent-1",
+		Workspace: "metrics-ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep"},
+		State:     api.SessionRunning,
+	}
+	for _, s := range []*api.Session{live, noPID} {
+		if err := d.store.CreateSession(s); err != nil {
+			t.Fatalf("create session %s: %v", s.Name, err)
+		}
+	}
+
+	d.SampleMetricsOnce(procstat.NewSampler())
+
+	got, err := d.store.GetSession("metrics-ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.MetricsAt.IsZero() {
+		t.Fatal("MetricsAt is zero after a sampler pass")
+	}
+	if got.RSSBytes <= 0 {
+		t.Errorf("RSSBytes = %d for a live pid, want > 0", got.RSSBytes)
+	}
+
+	// A session with no pid must stay visibly unmeasured rather than
+	// reporting zero usage.
+	unmeasured, err := d.store.GetSession("metrics-ws/agent-1")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if !unmeasured.MetricsAt.IsZero() {
+		t.Error("a session with no PID was marked as measured")
+	}
+}
+
+// A dead pid is measured and reports nothing, which is different from
+// not being measured at all: the reconciler reaps the session shortly
+// after, and until then the operator should see the zero.
+func TestSampleMetricsOnceDeadPID(t *testing.T) {
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+
+	// pid 1 exists; a pid just below the max is almost certainly free.
+	// Any absent pid exercises the same branch.
+	if err := d.store.CreateSession(&api.Session{
+		Name:      "ghost",
+		Workspace: "metrics-ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep"},
+		State:     api.SessionRunning,
+		PID:       0x7FFFFFF0,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	d.SampleMetricsOnce(procstat.NewSampler())
+
+	got, err := d.store.GetSession("metrics-ws/ghost")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.MetricsAt.IsZero() {
+		t.Fatal("an absent pid must still count as measured")
+	}
+	if got.RSSBytes != 0 || got.CPUPercent != 0 {
+		t.Errorf("got %.1f%% CPU / %d bytes for an absent pid, want zero",
+			got.CPUPercent, got.RSSBytes)
+	}
+}

--- a/internal/procstat/proc.go
+++ b/internal/procstat/proc.go
@@ -1,0 +1,80 @@
+package procstat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// procStat is the subset of /proc/<pid>/stat marvel reads.
+type procStat struct {
+	ppid     int
+	cpuTicks uint64
+	rssPages int64
+}
+
+// parseProcStat reads /proc/<pid>/stat. Field 2 is the executable name
+// in parentheses and may itself contain spaces and parentheses, so the
+// scan starts after the LAST ')' and counts from field 3 (state).
+// Offsets used, in the proc(5) numbering: 4 ppid, 14 utime, 15 stime,
+// 24 rss (in pages). Field 24 is why this reads no statm: rss there is
+// the same number.
+func parseProcStat(data string) (procStat, error) {
+	end := strings.LastIndex(data, ")")
+	if end < 0 {
+		return procStat{}, fmt.Errorf("procstat: no comm field")
+	}
+	f := strings.Fields(data[end+1:])
+	// Highest index touched is rss at field 24, which sits at index 21
+	// once state (field 3) is index 0.
+	const rssIndex = 21
+	if len(f) <= rssIndex {
+		return procStat{}, fmt.Errorf("procstat: short stat line (%d fields after comm)", len(f))
+	}
+	ppid, err := strconv.Atoi(f[1])
+	if err != nil {
+		return procStat{}, fmt.Errorf("procstat: ppid: %w", err)
+	}
+	utime, err := strconv.ParseUint(f[11], 10, 64)
+	if err != nil {
+		return procStat{}, fmt.Errorf("procstat: utime: %w", err)
+	}
+	stime, err := strconv.ParseUint(f[12], 10, 64)
+	if err != nil {
+		return procStat{}, fmt.Errorf("procstat: stime: %w", err)
+	}
+	rss, err := strconv.ParseInt(f[rssIndex], 10, 64)
+	if err != nil {
+		return procStat{}, fmt.Errorf("procstat: rss: %w", err)
+	}
+	return procStat{ppid: ppid, cpuTicks: utime + stime, rssPages: rss}, nil
+}
+
+// parseProcIO reads /proc/<pid>/io and returns the block-layer byte
+// counters. read_bytes and write_bytes are actual storage traffic;
+// rchar and wchar (deliberately ignored) also count pipe and tty
+// traffic, which for an agent process is dominated by its own terminal
+// and says nothing about disk pressure.
+func parseProcIO(data string) (readBytes, writeBytes int64, err error) {
+	var haveRead, haveWrite bool
+	for _, line := range strings.Split(data, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		n, perr := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		if perr != nil {
+			continue
+		}
+		switch key {
+		case "read_bytes":
+			readBytes, haveRead = n, true
+		case "write_bytes":
+			writeBytes, haveWrite = n, true
+		}
+	}
+	if !haveRead || !haveWrite {
+		return 0, 0, fmt.Errorf("procstat: io counters missing")
+	}
+	return readBytes, writeBytes, nil
+}

--- a/internal/procstat/proc_test.go
+++ b/internal/procstat/proc_test.go
@@ -1,0 +1,84 @@
+package procstat
+
+import (
+	"strings"
+	"testing"
+)
+
+// Shape of a real /proc/<pid>/stat line: ppid 4200, utime 314, stime
+// 159, rss 12800 pages. Trailing fields past rsslim are dropped — the
+// parser must not require them.
+const procStatFixture = "4242 (agent) S 4200 4242 4242 34816 4242 4194304 " +
+	"12345 678 9 0 314 159 0 0 20 0 12 0 987654 4823449600 12800 18446744073709551615\n"
+
+func TestParseProcStat(t *testing.T) {
+	got, err := parseProcStat(procStatFixture)
+	if err != nil {
+		t.Fatalf("parseProcStat: %v", err)
+	}
+	if got.ppid != 4200 {
+		t.Errorf("ppid = %d, want 4200", got.ppid)
+	}
+	if got.cpuTicks != 314+159 {
+		t.Errorf("cpuTicks = %d, want %d (utime+stime)", got.cpuTicks, 314+159)
+	}
+	if got.rssPages != 12800 {
+		t.Errorf("rssPages = %d, want 12800", got.rssPages)
+	}
+}
+
+// The comm field is unquoted and unescaped, so a process named after a
+// shell invocation puts both spaces and parentheses inside field 2. This
+// is the case that breaks a naive Fields() split, and tmux-spawned
+// agents are exactly the processes with such names.
+func TestParseProcStatCommWithSpacesAndParens(t *testing.T) {
+	in := strings.Replace(procStatFixture, "(agent)", "(sh -c (forestage))", 1)
+	got, err := parseProcStat(in)
+	if err != nil {
+		t.Fatalf("parseProcStat: %v", err)
+	}
+	if got.ppid != 4200 || got.cpuTicks != 473 || got.rssPages != 12800 {
+		t.Errorf("got %+v, want ppid 4200, cpuTicks 473, rssPages 12800", got)
+	}
+}
+
+func TestParseProcStatRejectsMalformed(t *testing.T) {
+	cases := map[string]string{
+		"no comm field":  "4242 agent S 4200 4242",
+		"truncated line": "4242 (agent) S 4200 4242 4242",
+		"empty":          "",
+	}
+	for name, in := range cases {
+		if _, err := parseProcStat(in); err == nil {
+			t.Errorf("%s: parseProcStat succeeded, want error", name)
+		}
+	}
+}
+
+const procIOFixture = `rchar: 3891213
+wchar: 122880
+syscr: 1204
+syscw: 88
+read_bytes: 2097152
+write_bytes: 528384
+cancelled_write_bytes: 0
+`
+
+func TestParseProcIO(t *testing.T) {
+	r, w, err := parseProcIO(procIOFixture)
+	if err != nil {
+		t.Fatalf("parseProcIO: %v", err)
+	}
+	if r != 2097152 {
+		t.Errorf("readBytes = %d, want 2097152 (read_bytes, not rchar)", r)
+	}
+	if w != 528384 {
+		t.Errorf("writeBytes = %d, want 528384 (write_bytes, not wchar)", w)
+	}
+}
+
+func TestParseProcIOMissingCounters(t *testing.T) {
+	if _, _, err := parseProcIO("rchar: 10\nwchar: 20\n"); err == nil {
+		t.Error("parseProcIO succeeded without read_bytes/write_bytes, want error")
+	}
+}

--- a/internal/procstat/procstat.go
+++ b/internal/procstat/procstat.go
@@ -1,0 +1,187 @@
+// Package procstat samples CPU and memory for a process subtree.
+//
+// marvel rolls up a subtree rather than reading one pid because tmux
+// execs the runtime command through a shell: pane_pid is the shell, and
+// the agent binary is its child (often with children of its own). A
+// single-pid read of pane_pid reports a shell sitting idle at a few
+// kilobytes while the agent underneath it burns a core.
+//
+// The package shells out to ps on darwin and reads /proc on linux. No
+// cgo, no third-party dependency: marvel's dependency list is short on
+// purpose.
+//
+// Platform honesty, per marvel B13: the darwin path is verified against
+// binaries built by go build and go test. It has not been run from a
+// signed and notarized release build under the hardened runtime.
+// Shelling out to ps rather than calling proc_pidinfo means no
+// entitlement should be implicated, but that is an argument, not a
+// measurement, and the release build is where it gets settled.
+package procstat
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrUnsupported is returned by Sample on platforms with no process
+// table reader. Callers should treat it as "no metrics here", not as a
+// failure worth retrying.
+var ErrUnsupported = errors.New("procstat: unsupported platform")
+
+// Sample is one rollup over a session's process subtree.
+type Sample struct {
+	// Procs counts the processes rolled up, root included. Zero means
+	// the root pid was absent from the process table, which for a
+	// marvel session means the agent has exited.
+	Procs int
+
+	CPUPercent float64
+	RSSBytes   int64
+
+	// IOReadBytes and IOWriteBytes are cumulative block-layer bytes
+	// since process start, summed over the subtree. Only meaningful
+	// when IOAvailable is true, which today means linux: darwin has no
+	// per-process byte counter reachable without a privileged
+	// interface, and reporting zero there would read as "idle" rather
+	// than "not measured".
+	IOReadBytes  int64
+	IOWriteBytes int64
+	IOAvailable  bool
+}
+
+// entry is one process as read from the platform's process table.
+type entry struct {
+	pid  int
+	ppid int
+
+	// cpuPercent is a ready-made utilization estimate (darwin's ps
+	// reports the kernel's own decaying average). Used when cumulative
+	// is false.
+	cpuPercent float64
+	// cpuTicks is cumulative user+system time in clock ticks, used when
+	// cumulative is true. A percentage comes from the delta between two
+	// passes, so the first pass after daemon start reports zero.
+	cpuTicks   uint64
+	cumulative bool
+
+	rssBytes     int64
+	ioReadBytes  int64
+	ioWriteBytes int64
+	ioOK         bool
+}
+
+// clockTicksPerSecond is the divisor for cumulative CPU ticks. POSIX
+// exposes this as sysconf(_SC_CLK_TCK); reading it needs cgo, and the
+// value has been 100 on every Linux port since the kernel started
+// reporting USER_HZ-scaled times regardless of the internal HZ setting.
+const clockTicksPerSecond = 100.0
+
+// Sampler holds the state one platform needs across passes: the
+// previous cumulative CPU reading per pid. Not safe for concurrent use;
+// marvel drives it from a single goroutine.
+type Sampler struct {
+	prev   map[int]uint64
+	prevAt time.Time
+}
+
+// NewSampler returns a sampler with no history. Its first Sample call
+// reports zero CPU on platforms that only expose cumulative CPU time.
+func NewSampler() *Sampler {
+	return &Sampler{prev: make(map[int]uint64)}
+}
+
+// Sample reads the process table once and returns a rollup per root
+// pid. Roots absent from the table get a zero-valued Sample rather than
+// being omitted, so callers can tell "measured, nothing there" from
+// "not measured".
+func (s *Sampler) Sample(roots []int) (map[int]Sample, error) {
+	if len(roots) == 0 {
+		return nil, nil
+	}
+	entries, err := readProcesses()
+	if err != nil {
+		return nil, err
+	}
+	return s.rollup(roots, entries, time.Now()), nil
+}
+
+// rollup is the platform-independent half of a pass: index the process
+// table, walk each root's descendants, sum. Split out from Sample so
+// tests can drive it with a fixture process table on any platform.
+func (s *Sampler) rollup(roots []int, entries []entry, now time.Time) map[int]Sample {
+	elapsed := now.Sub(s.prevAt).Seconds()
+
+	byPID := make(map[int]entry, len(entries))
+	children := make(map[int][]int, len(entries))
+	next := make(map[int]uint64, len(entries))
+	for _, e := range entries {
+		byPID[e.pid] = e
+		if e.ppid != e.pid {
+			children[e.ppid] = append(children[e.ppid], e.pid)
+		}
+		if e.cumulative {
+			next[e.pid] = e.cpuTicks
+		}
+	}
+
+	out := make(map[int]Sample, len(roots))
+	for _, root := range roots {
+		out[root] = s.walk(root, byPID, children, elapsed)
+	}
+
+	// Replace rather than merge: pids die, and a sampler that
+	// remembered every pid it ever saw would grow for the life of the
+	// daemon.
+	s.prev = next
+	s.prevAt = now
+	return out
+}
+
+// walk sums a root and its descendants. seen guards against a parent
+// cycle, which a /proc scan can synthesize when pids are reused
+// mid-walk.
+func (s *Sampler) walk(root int, byPID map[int]entry, children map[int][]int, elapsed float64) Sample {
+	var sum Sample
+	seen := make(map[int]bool)
+	stack := []int{root}
+	for len(stack) > 0 {
+		pid := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[pid] {
+			continue
+		}
+		seen[pid] = true
+
+		e, ok := byPID[pid]
+		if !ok {
+			continue
+		}
+		sum.Procs++
+		sum.CPUPercent += s.percentFor(e, elapsed)
+		sum.RSSBytes += e.rssBytes
+		if e.ioOK {
+			sum.IOAvailable = true
+			sum.IOReadBytes += e.ioReadBytes
+			sum.IOWriteBytes += e.ioWriteBytes
+		}
+		stack = append(stack, children[pid]...)
+	}
+	return sum
+}
+
+// percentFor converts one process's CPU reading into a percentage of a
+// single core. Cumulative sources need two passes; a counter that went
+// backwards means the pid was reused, so the reading starts over.
+func (s *Sampler) percentFor(e entry, elapsed float64) float64 {
+	if !e.cumulative {
+		return e.cpuPercent
+	}
+	if elapsed <= 0 {
+		return 0
+	}
+	prev, ok := s.prev[e.pid]
+	if !ok || e.cpuTicks < prev {
+		return 0
+	}
+	return 100 * (float64(e.cpuTicks-prev) / clockTicksPerSecond) / elapsed
+}

--- a/internal/procstat/procstat_test.go
+++ b/internal/procstat/procstat_test.go
@@ -1,0 +1,206 @@
+package procstat
+
+import (
+	"math"
+	"os"
+	"testing"
+	"time"
+)
+
+// paneTree models what tmux actually leaves behind: pane_pid 100 is the
+// shell, 200 is the agent binary it exec'd, 300 is a tool the agent
+// spawned. 999 is an unrelated process that must not be counted.
+func paneTree() []entry {
+	return []entry{
+		{pid: 1, ppid: 0, cpuPercent: 0.1, rssBytes: 1 << 20},
+		{pid: 100, ppid: 1, cpuPercent: 0.5, rssBytes: 2 << 20},
+		{pid: 200, ppid: 100, cpuPercent: 12.0, rssBytes: 400 << 20},
+		{pid: 300, ppid: 200, cpuPercent: 3.5, rssBytes: 30 << 20},
+		{pid: 999, ppid: 1, cpuPercent: 90.0, rssBytes: 900 << 20},
+	}
+}
+
+func TestRollupSumsSubtree(t *testing.T) {
+	s := NewSampler()
+	got := s.rollup([]int{100}, paneTree(), time.Now())
+
+	sample, ok := got[100]
+	if !ok {
+		t.Fatal("no sample for root pid 100")
+	}
+	if sample.Procs != 3 {
+		t.Errorf("Procs = %d, want 3 (shell + agent + tool)", sample.Procs)
+	}
+	if math.Abs(sample.CPUPercent-16.0) > 0.001 {
+		t.Errorf("CPUPercent = %v, want 16.0", sample.CPUPercent)
+	}
+	if want := int64(432 << 20); sample.RSSBytes != want {
+		t.Errorf("RSSBytes = %d, want %d", sample.RSSBytes, want)
+	}
+	if sample.IOAvailable {
+		t.Error("IOAvailable is true with no IO-carrying entries")
+	}
+}
+
+// A single-pid read of pane_pid is what marvel did before this sampler
+// existed; this pins the difference the rollup buys.
+func TestRollupRootAloneIsNotTheWholeStory(t *testing.T) {
+	s := NewSampler()
+	got := s.rollup([]int{100}, paneTree(), time.Now())
+	if got[100].CPUPercent <= 0.5 {
+		t.Errorf("subtree CPU %v did not exceed the shell's own 0.5", got[100].CPUPercent)
+	}
+}
+
+func TestRollupMissingRootReportsZero(t *testing.T) {
+	s := NewSampler()
+	got := s.rollup([]int{4242}, paneTree(), time.Now())
+	sample, ok := got[4242]
+	if !ok {
+		t.Fatal("absent root omitted from result; callers cannot tell it was measured")
+	}
+	if sample.Procs != 0 || sample.CPUPercent != 0 || sample.RSSBytes != 0 {
+		t.Errorf("got %+v, want zero-valued sample", sample)
+	}
+}
+
+func TestRollupMultipleRoots(t *testing.T) {
+	s := NewSampler()
+	got := s.rollup([]int{100, 999}, paneTree(), time.Now())
+	if len(got) != 2 {
+		t.Fatalf("got %d samples, want 2", len(got))
+	}
+	if got[999].Procs != 1 {
+		t.Errorf("pid 999 Procs = %d, want 1", got[999].Procs)
+	}
+	if math.Abs(got[999].CPUPercent-90.0) > 0.001 {
+		t.Errorf("pid 999 CPUPercent = %v, want 90.0", got[999].CPUPercent)
+	}
+}
+
+// A /proc scan is not atomic: pid reuse mid-walk can produce a parent
+// edge that points back into the subtree. The walk must terminate.
+func TestRollupSurvivesParentCycle(t *testing.T) {
+	entries := []entry{
+		{pid: 100, ppid: 300, rssBytes: 1},
+		{pid: 200, ppid: 100, rssBytes: 1},
+		{pid: 300, ppid: 200, rssBytes: 1},
+	}
+	done := make(chan Sample, 1)
+	go func() {
+		s := NewSampler()
+		done <- s.rollup([]int{100}, entries, time.Now())[100]
+	}()
+	select {
+	case sample := <-done:
+		if sample.Procs != 3 {
+			t.Errorf("Procs = %d, want 3 (each process counted once)", sample.Procs)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rollup did not terminate on a cyclic parent chain")
+	}
+}
+
+// The linux reader reports cumulative ticks, so a percentage only exists
+// once two passes have been taken. 300 ticks over 3s at 100 ticks/s is
+// one full core.
+func TestRollupCumulativeCPUNeedsTwoPasses(t *testing.T) {
+	tree := func(ticks uint64) []entry {
+		return []entry{
+			{pid: 100, ppid: 1, cpuTicks: 10, cumulative: true, rssBytes: 1 << 20},
+			{pid: 200, ppid: 100, cpuTicks: ticks, cumulative: true, rssBytes: 1 << 20},
+		}
+	}
+	s := NewSampler()
+	t0 := time.Now()
+
+	first := s.rollup([]int{100}, tree(1000), t0)
+	if first[100].CPUPercent != 0 {
+		t.Errorf("first pass CPUPercent = %v, want 0 (no prior reading)", first[100].CPUPercent)
+	}
+
+	second := s.rollup([]int{100}, tree(1300), t0.Add(3*time.Second))
+	if math.Abs(second[100].CPUPercent-100.0) > 0.001 {
+		t.Errorf("second pass CPUPercent = %v, want 100.0", second[100].CPUPercent)
+	}
+}
+
+// pid reuse hands the sampler a counter lower than the one it stored.
+// Reporting a negative or wrapped percentage would be worse than
+// reporting nothing for one interval.
+func TestRollupCumulativeCPUHandlesPIDReuse(t *testing.T) {
+	s := NewSampler()
+	t0 := time.Now()
+	high := []entry{{pid: 100, ppid: 1, cpuTicks: 50000, cumulative: true}}
+	s.rollup([]int{100}, high, t0)
+
+	low := []entry{{pid: 100, ppid: 1, cpuTicks: 3, cumulative: true}}
+	got := s.rollup([]int{100}, low, t0.Add(3*time.Second))
+	if got[100].CPUPercent != 0 {
+		t.Errorf("CPUPercent = %v after counter went backwards, want 0", got[100].CPUPercent)
+	}
+}
+
+// prev must not accumulate dead pids for the life of the daemon.
+func TestRollupForgetsVanishedPIDs(t *testing.T) {
+	s := NewSampler()
+	t0 := time.Now()
+	s.rollup([]int{100}, []entry{
+		{pid: 100, ppid: 1, cpuTicks: 1, cumulative: true},
+		{pid: 200, ppid: 100, cpuTicks: 1, cumulative: true},
+	}, t0)
+	s.rollup([]int{100}, []entry{
+		{pid: 100, ppid: 1, cpuTicks: 2, cumulative: true},
+	}, t0.Add(time.Second))
+	if len(s.prev) != 1 {
+		t.Errorf("prev holds %d pids, want 1", len(s.prev))
+	}
+	if _, ok := s.prev[200]; ok {
+		t.Error("prev still holds pid 200 after it left the process table")
+	}
+}
+
+func TestRollupIO(t *testing.T) {
+	s := NewSampler()
+	entries := []entry{
+		{pid: 100, ppid: 1, ioReadBytes: 1000, ioWriteBytes: 10, ioOK: true},
+		{pid: 200, ppid: 100, ioReadBytes: 2000, ioWriteBytes: 20, ioOK: true},
+		// Owned by another uid: /proc/<pid>/io was unreadable.
+		{pid: 300, ppid: 200, ioReadBytes: 0, ioWriteBytes: 0, ioOK: false},
+	}
+	got := s.rollup([]int{100}, entries, time.Now())[100]
+	if !got.IOAvailable {
+		t.Fatal("IOAvailable is false with two readable counters")
+	}
+	if got.IOReadBytes != 3000 || got.IOWriteBytes != 30 {
+		t.Errorf("IO = %d read / %d write, want 3000 / 30", got.IOReadBytes, got.IOWriteBytes)
+	}
+}
+
+func TestSampleNoRoots(t *testing.T) {
+	s := NewSampler()
+	got, err := s.Sample(nil)
+	if err != nil {
+		t.Fatalf("Sample(nil): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Sample(nil) returned %d samples, want 0", len(got))
+	}
+}
+
+// End-to-end against the live process table: the test's own process must
+// show up with a nonzero RSS. Skipped where there is no reader.
+func TestSampleSelf(t *testing.T) {
+	s := NewSampler()
+	got, err := s.Sample([]int{os.Getpid()})
+	if err != nil {
+		t.Skipf("no process table reader on this platform: %v", err)
+	}
+	sample := got[os.Getpid()]
+	if sample.Procs < 1 {
+		t.Fatalf("Procs = %d for the running test process, want at least 1", sample.Procs)
+	}
+	if sample.RSSBytes <= 0 {
+		t.Errorf("RSSBytes = %d for the running test process, want > 0", sample.RSSBytes)
+	}
+}

--- a/internal/procstat/ps.go
+++ b/internal/procstat/ps.go
@@ -1,0 +1,49 @@
+package procstat
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parsePS reads the output of `ps -A -o pid=,ppid=,pcpu=,rss=`. The
+// trailing `=` on each column suppresses the header, so every line is
+// data. Columns are whitespace-padded to a width that depends on the
+// widest value on the machine, so fields are split on runs of space
+// rather than at fixed offsets.
+//
+// Lines that don't parse are skipped: a process can exit between ps
+// writing its header and its row, and one malformed row should not cost
+// the whole pass.
+func parsePS(out string) []entry {
+	lines := strings.Split(out, "\n")
+	entries := make([]entry, 0, len(lines))
+	for _, line := range lines {
+		f := strings.Fields(line)
+		if len(f) < 4 {
+			continue
+		}
+		pid, err := strconv.Atoi(f[0])
+		if err != nil {
+			continue
+		}
+		ppid, err := strconv.Atoi(f[1])
+		if err != nil {
+			continue
+		}
+		pcpu, err := strconv.ParseFloat(f[2], 64)
+		if err != nil {
+			continue
+		}
+		rssKiB, err := strconv.ParseInt(f[3], 10, 64)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry{
+			pid:        pid,
+			ppid:       ppid,
+			cpuPercent: pcpu,
+			rssBytes:   rssKiB * 1024,
+		})
+	}
+	return entries
+}

--- a/internal/procstat/ps_test.go
+++ b/internal/procstat/ps_test.go
@@ -1,0 +1,55 @@
+package procstat
+
+import "testing"
+
+// Captured from `ps -A -o pid=,ppid=,pcpu=,rss=` on macOS 15. Column
+// padding varies with the widest value in the table, which is the reason
+// the parser splits on fields instead of slicing offsets.
+const psFixture = `    1     0   0.2  40688
+  295  2842   0.0 159184
+18060 13043   1.3   2608
+`
+
+func TestParsePS(t *testing.T) {
+	got := parsePS(psFixture)
+	if len(got) != 3 {
+		t.Fatalf("parsePS returned %d entries, want 3", len(got))
+	}
+
+	want := []entry{
+		{pid: 1, ppid: 0, cpuPercent: 0.2, rssBytes: 40688 * 1024},
+		{pid: 295, ppid: 2842, cpuPercent: 0.0, rssBytes: 159184 * 1024},
+		{pid: 18060, ppid: 13043, cpuPercent: 1.3, rssBytes: 2608 * 1024},
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("entry %d = %+v, want %+v", i, got[i], w)
+		}
+	}
+	if got[0].cumulative {
+		t.Error("ps entries must not be marked cumulative: pcpu is already a percentage")
+	}
+}
+
+func TestParsePSSkipsUnparseableLines(t *testing.T) {
+	in := "  100    1   0.5  1024\n" +
+		"\n" +
+		"garbage line\n" +
+		"  101\n" + // truncated row, e.g. process exited mid-write
+		"  x    1   0.5  1024\n" +
+		"  102    1   nope  1024\n" +
+		"  103    1   0.5  1024\n"
+	got := parsePS(in)
+	if len(got) != 2 {
+		t.Fatalf("parsePS returned %d entries, want 2 (only pids 100 and 103 are complete)", len(got))
+	}
+	if got[0].pid != 100 || got[1].pid != 103 {
+		t.Errorf("kept pids %d and %d, want 100 and 103", got[0].pid, got[1].pid)
+	}
+}
+
+func TestParsePSEmpty(t *testing.T) {
+	if got := parsePS(""); len(got) != 0 {
+		t.Errorf("parsePS(\"\") returned %d entries, want 0", len(got))
+	}
+}

--- a/internal/procstat/read_darwin.go
+++ b/internal/procstat/read_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package procstat
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// readProcesses shells out to ps once per pass. One exec for the whole
+// table beats proc_pidinfo per pid: the syscall route needs cgo, and
+// marvel samples every managed session on the same tick anyway.
+//
+// pcpu here is the kernel's own decaying-average utilization estimate,
+// not a delta the sampler computes, so darwin readings are usable on
+// the first pass.
+func readProcesses() ([]entry, error) {
+	out, err := exec.Command("ps", "-A", "-o", "pid=,ppid=,pcpu=,rss=").Output()
+	if err != nil {
+		return nil, fmt.Errorf("procstat: ps: %w", err)
+	}
+	return parsePS(string(out)), nil
+}

--- a/internal/procstat/read_linux.go
+++ b/internal/procstat/read_linux.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package procstat
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// procRoot is a variable so tests can point the walk at a fixture tree.
+var procRoot = "/proc"
+
+// readProcesses walks /proc. Processes that vanish mid-walk are skipped
+// rather than failing the pass, which is the normal case for a scan of a
+// live process table.
+//
+// /proc/<pid>/io is owner-readable only; a session running under
+// another uid contributes no IO counters and the rollup reports IO as
+// unavailable rather than as zero.
+func readProcesses() ([]entry, error) {
+	dir, err := os.Open(procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("procstat: open %s: %w", procRoot, err)
+	}
+	defer func() { _ = dir.Close() }()
+
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("procstat: read %s: %w", procRoot, err)
+	}
+
+	pageSize := int64(os.Getpagesize())
+	entries := make([]entry, 0, len(names))
+	for _, name := range names {
+		pid, cerr := strconv.Atoi(name)
+		if cerr != nil {
+			continue
+		}
+		raw, rerr := os.ReadFile(procRoot + "/" + name + "/stat")
+		if rerr != nil {
+			continue
+		}
+		st, perr := parseProcStat(string(raw))
+		if perr != nil {
+			continue
+		}
+		e := entry{
+			pid:        pid,
+			ppid:       st.ppid,
+			cpuTicks:   st.cpuTicks,
+			cumulative: true,
+			rssBytes:   st.rssPages * pageSize,
+		}
+		if ioRaw, ierr := os.ReadFile(procRoot + "/" + name + "/io"); ierr == nil {
+			if r, w, perr := parseProcIO(string(ioRaw)); perr == nil {
+				e.ioReadBytes, e.ioWriteBytes, e.ioOK = r, w, true
+			}
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}

--- a/internal/procstat/read_linux_test.go
+++ b/internal/procstat/read_linux_test.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package procstat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// readProcesses is exercised against a fixture tree rather than the live
+// /proc so the expected values are fixed. The live path is covered by
+// TestSampleSelf.
+func TestReadProcessesFixtureTree(t *testing.T) {
+	root := t.TempDir()
+	write := func(pid string, files map[string]string) {
+		dir := filepath.Join(root, pid)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for f, content := range files {
+			if err := os.WriteFile(filepath.Join(dir, f), []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// ppid 1, utime+stime 473 ticks, rss 12800 pages.
+	write("100", map[string]string{"stat": procStatFixture})
+	write("200", map[string]string{
+		"stat": "200 (agent) S 100 200 200 0 0 0 0 0 0 0 100 100 0 0 20 0 8 0 1 100 64 0",
+		"io":   procIOFixture,
+	})
+	// Non-numeric entries in /proc (self, sys, meminfo) must be skipped.
+	write("self", map[string]string{"stat": procStatFixture})
+	if err := os.WriteFile(filepath.Join(root, "meminfo"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	old := procRoot
+	procRoot = root
+	defer func() { procRoot = old }()
+
+	entries, err := readProcesses()
+	if err != nil {
+		t.Fatalf("readProcesses: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2 (pids 100 and 200 only)", len(entries))
+	}
+
+	byPID := map[int]entry{}
+	for _, e := range entries {
+		byPID[e.pid] = e
+	}
+	shell, ok := byPID[100]
+	if !ok {
+		t.Fatal("pid 100 missing")
+	}
+	if !shell.cumulative {
+		t.Error("linux entries must be marked cumulative")
+	}
+	if want := int64(12800) * int64(os.Getpagesize()); shell.rssBytes != want {
+		t.Errorf("pid 100 rssBytes = %d, want %d", shell.rssBytes, want)
+	}
+	if shell.ioOK {
+		t.Error("pid 100 has no io file; ioOK must stay false")
+	}
+
+	agent := byPID[200]
+	if agent.ppid != 100 {
+		t.Errorf("pid 200 ppid = %d, want 100", agent.ppid)
+	}
+	if !agent.ioOK || agent.ioReadBytes != 2097152 {
+		t.Errorf("pid 200 io = %+v, want readable with 2097152 read bytes", agent)
+	}
+}

--- a/internal/procstat/read_other.go
+++ b/internal/procstat/read_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin && !linux
+
+package procstat
+
+// readProcesses has no implementation outside darwin and linux. marvel
+// builds for those two; anywhere else the sampler stays quiet instead of
+// reporting invented numbers.
+func readProcesses() ([]entry, error) {
+	return nil, ErrUnsupported
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,6 +5,7 @@ package session
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,6 +121,7 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 		for _, p := range panes {
 			if sessKey, ok := recordedByPane[p.ID]; ok {
 				adopted++
+				m.recordPanePID(sessKey, p.PID)
 				log.Printf("AdoptOrKill: adopted pane %s (session %s)", p.ID, sessKey)
 			} else {
 				if kerr := m.driver.KillPane(p.ID); kerr != nil {
@@ -136,6 +138,23 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 		log.Printf("AdoptOrKill: %d adopted, %d killed", adopted, killed)
 	}
 	return adopted, killed, nil
+}
+
+// recordPanePID commits an adopted pane's pid to the recorded session.
+// ListPanes already carries it; before this it was parsed and dropped,
+// which left Session.PID zero for every session marvel adopted across a
+// daemon restart and the process sampler with nothing to walk.
+func (m *Manager) recordPanePID(sessKey, panePID string) {
+	pid, err := strconv.Atoi(strings.TrimSpace(panePID))
+	if err != nil || pid <= 0 {
+		return
+	}
+	if err := m.store.UpdateSession(sessKey, func(live *api.Session) error {
+		live.PID = pid
+		return nil
+	}); err != nil {
+		log.Printf("AdoptOrKill: record pid %d for %s: %v", pid, sessKey, err)
+	}
 }
 
 // Create creates a new session: registers it in the store, ensures the tmux
@@ -168,18 +187,28 @@ func (m *Manager) Create(sess *api.Session) error {
 		return fmt.Errorf("create pane for %s: %w", sess.Key(), err)
 	}
 
-	// Commit PaneID + State=Running to the live session under the store
-	// lock. Also update the caller's *api.Session so returning pointers
-	// stay consistent for any downstream emission/logging that references
-	// fields on sess. Per orc finding-032, the Store is the sync boundary.
+	// A missing pid costs resource metrics for this session, nothing
+	// else, so it is logged and not treated as a failed spawn.
+	pid, perr := m.driver.PanePID(paneID)
+	if perr != nil {
+		log.Printf("session %s: pane pid unavailable: %v", sess.Key(), perr)
+	}
+
+	// Commit PaneID + PID + State=Running to the live session under the
+	// store lock. Also update the caller's *api.Session so returning
+	// pointers stay consistent for any downstream emission/logging that
+	// references fields on sess. Per orc finding-032, the Store is the
+	// sync boundary.
 	if err := m.store.UpdateSession(sess.Key(), func(live *api.Session) error {
 		live.PaneID = paneID
+		live.PID = pid
 		live.State = api.SessionRunning
 		return nil
 	}); err != nil {
 		return fmt.Errorf("update session %s post-create: %w", sess.Key(), err)
 	}
 	sess.PaneID = paneID
+	sess.PID = pid
 	sess.State = api.SessionRunning
 	log.Printf("session %s running in pane %s", sess.Key(), paneID)
 	events.Emit(m.Events, events.Event{

--- a/internal/session/pid_test.go
+++ b/internal/session/pid_test.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/tmux"
+)
+
+// Session.PID is what the process sampler walks. Before it was
+// populated, api.Session carried the field and nothing ever assigned it,
+// so every resource reading was over an empty pid set.
+func TestCreateRecordsPanePID(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-pid-spawn"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	sess := &api.Session{
+		Name:      "agent-0",
+		Workspace: ws,
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if sess.PID <= 0 {
+		t.Errorf("returned session PID = %d, want a positive pid", sess.PID)
+	}
+	stored, err := store.GetSession(ws + "/agent-0")
+	if err != nil {
+		t.Fatalf("get from store: %v", err)
+	}
+	if stored.PID != sess.PID {
+		t.Errorf("store PID = %d, returned PID = %d; the two must agree", stored.PID, sess.PID)
+	}
+
+	// The pid must be tmux's pane_pid, not marvel's own or the tmux
+	// server's.
+	panes, err := driver.ListPanes("marvel-" + ws)
+	if err != nil {
+		t.Fatalf("list panes: %v", err)
+	}
+	var want string
+	for _, p := range panes {
+		if p.ID == sess.PaneID {
+			want = p.PID
+		}
+	}
+	if want != strconv.Itoa(stored.PID) {
+		t.Errorf("stored PID %d does not match pane_pid %q", stored.PID, want)
+	}
+}
+
+// A daemon restart rehydrates sessions from bolt and adopts their panes.
+// AdoptOrKill has pane_pid in hand from ListPanes and used to drop it,
+// which left adopted sessions unsampleable for as long as they ran.
+func TestAdoptOrKillRecordsPanePID(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-pid-adopt"
+	key := ws + "/agent-0"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &api.Session{
+		Name:      "agent-0",
+		Workspace: ws,
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	spawnPID := sess.PID
+
+	// Stand in for a record written before marvel populated PID at all.
+	if err := store.UpdateSession(key, func(live *api.Session) error {
+		live.PID = 0
+		return nil
+	}); err != nil {
+		t.Fatalf("clear PID: %v", err)
+	}
+
+	adopted, _, err := mgr.AdoptOrKill()
+	if err != nil {
+		t.Fatalf("AdoptOrKill: %v", err)
+	}
+	if adopted < 1 {
+		t.Fatalf("adopted %d panes, want at least 1", adopted)
+	}
+
+	stored, err := store.GetSession(key)
+	if err != nil {
+		t.Fatalf("get from store: %v", err)
+	}
+	if stored.PID != spawnPID {
+		t.Errorf("PID after adopt = %d, want %d (the pane's pid, recovered from ListPanes)",
+			stored.PID, spawnPID)
+	}
+}

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -153,6 +154,30 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 // never saw dead panes and sessions stayed 'running/unknown' forever.
 func (d *Driver) HasPane(paneID string) bool {
 	return d.cmd("list-panes", "-t", paneID, "-F", "#{pane_id}").Run() == nil
+}
+
+// PanePID returns the pid of the process tmux started in the pane. That
+// process is a shell, not the runtime binary: tmux execs the command
+// line through one. Callers measuring resource use must walk the
+// subtree.
+//
+// list-panes rather than display-message, for the reason in HasPane:
+// display-message exits 0 for a pane that is already gone and prints an
+// empty line, which would be indistinguishable from a live pane whose
+// pid we failed to read.
+func (d *Driver) PanePID(paneID string) (int, error) {
+	out, err := d.cmd("list-panes", "-t", paneID, "-F", "#{pane_pid}").CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("pane-pid %s: %s: %w", paneID, string(out), err)
+	}
+	// A pane id resolves to exactly one pane, but take the first line
+	// defensively so an unexpected multi-line reply cannot fail parsing.
+	first := strings.TrimSpace(strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)[0])
+	pid, cerr := strconv.Atoi(first)
+	if cerr != nil {
+		return 0, fmt.Errorf("pane-pid %s: unparseable %q: %w", paneID, first, cerr)
+	}
+	return pid, nil
 }
 
 // KillPane destroys a specific pane.

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -383,3 +383,52 @@ func TestDriverConcurrentUse(t *testing.T) {
 		t.Fatalf("concurrent use produced %d failures:\n  %s", len(failures), strings.Join(failures, "\n  "))
 	}
 }
+
+func TestPanePID(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	sessionName := "marvel-test-panepid"
+	t.Cleanup(func() { _ = d.KillSession(sessionName) })
+	if err := d.NewSession(sessionName); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+
+	paneID, err := d.NewPane(sessionName, "sleep 300", "panepid-test", nil)
+	if err != nil {
+		t.Fatalf("new pane: %v", err)
+	}
+
+	pid, err := d.PanePID(paneID)
+	if err != nil {
+		t.Fatalf("pane pid: %v", err)
+	}
+	if pid <= 0 {
+		t.Fatalf("pane pid = %d, want a positive pid", pid)
+	}
+
+	// The same value ListPanes reports, since both read pane_pid.
+	panes, err := d.ListPanes(sessionName)
+	if err != nil {
+		t.Fatalf("list panes: %v", err)
+	}
+	var listed string
+	for _, p := range panes {
+		if p.ID == paneID {
+			listed = p.PID
+		}
+	}
+	if listed != fmt.Sprintf("%d", pid) {
+		t.Errorf("PanePID reported %d, ListPanes reported %q", pid, listed)
+	}
+
+	if err := d.KillPane(paneID); err != nil {
+		t.Fatalf("kill pane: %v", err)
+	}
+	if _, err := d.PanePID(paneID); err == nil {
+		t.Error("PanePID succeeded for a killed pane, want error")
+	}
+}


### PR DESCRIPTION
An operator running a marvel fleet cannot currently tell which agent is eating the machine. This adds per-session CPU and memory to `marvel get sessions`, which is also the input the admission and quota work (aae-orc-qiay) needs before it can make any decision about capacity.

Three things were missing. `api.Session.PID` existed and was never assigned. The tmux driver parsed `#{pane_pid}` in `ListPanes` and its only caller discarded it. And the one resource-ish column in the table, `CTX%`, has exactly one producer: the bundled simulator's heartbeat. No runtime adapter implements a heartbeat, so on a real fleet that column was decoration.

## What changed

`Session.PID` is populated at spawn (a `pane_pid` read after `new-window`) and at adopt (`AdoptOrKill` already had the value in hand). A sampler runs every 5 seconds as a sibling of the reconcile loop and fills `CPUPercent` and `RSSBytes`.

The sampler rolls up the pid's whole **subtree**, which is the load-bearing part: tmux execs the runtime command through a shell, so `pane_pid` is often a shell with the agent underneath it. Measured against a session whose command forks a busy child, a single-pid read of `pane_pid` reports `0.0% / 2.0M` where the subtree rollup reports `99.0% / 4.1M`.

New `internal/procstat` does the reading: `ps` on darwin, `/proc` on linux, one process-table read per pass covering every session. No cgo and no new module dependency. Linux `/proc/<pid>/io` counters ride along and surface through `marvel describe session`; darwin reports `IOAvailable: false` rather than a zero that would read as idle.

The honesty fix travels with it. `CTX%` renders `-` until a heartbeat actually arrives, and `CPU%`/`RSS` render `-` until the sampler has reached the session, so \"never measured\" is distinguishable from \"measured, idle\". Watch mode gains `p` and `m` sort keys, which is the `marvel top` shape.

## Cost of merge

Additive. No existing field changes meaning and no existing behavior changes except the `CTX%` column, which now shows `-` in the case where it previously showed a fabricated `0%`. Metrics are written to the store in memory only: a reading is stale the moment the daemon stops and is refreshed within one interval of startup, so a bolt write per session per interval buys nothing. PID does persist, in the existing session record.

## Verification

Live on darwin, four sessions with distinct load:

```
WORKSPACE  TEAM   ROLE    GEN  NAME               STATE    HEALTH   CTX%  CPU%   RSS   DESK  AGENT
metrics    squad  busy    1    squad-busy-g1-0    running  unknown  -     99.9   2.1M  1     shell
metrics    squad  busy    1    squad-busy-g1-1    running  unknown  -     100.0  2.0M  2     shell
metrics    squad  idle    1    squad-idle-g1-0    running  unknown  -     0.0    1.2M  3     shell
metrics    squad  nested  1    squad-nested-g1-0  running  unknown  -     100.0  4.1M  4     shell
```

Values survived a `kill -9` of the daemon and a restart against the same bolt file. `go build ./... && go vet ./... && go test ./...` pass, plus `GOOS=linux go vet ./...`. The linux reader is verified inside a linux container: the full `internal/procstat` suite passes there, including a fixture `/proc` tree and a live read of the test process itself.

Per marvel B13, this darwin verification ran against `go build` and `go test` binaries. The same reads have not been exercised from a signed and notarized release build under the hardened runtime. Shelling out to `ps` rather than calling `proc_pidinfo` means no entitlement should be implicated, but that is an argument rather than a measurement, and settling it on the release build is a release-gate follow-up.

## Deferred

Nothing was dropped from the ticket's scope. Two follow-ups worth naming: a `marvel top` command proper (watch mode with `p`/`m` covers the need today), and exposing the linux IO counters as table columns rather than only in `describe` output, which is waiting on a real case for them.

Refs: aae-orc-m6wf