### PR TITLE
feat: observe agents — wire runtime.Instance and the events layer into live sessions

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -314,10 +314,17 @@ func eventsCmd() *cobra.Command {
 		Short: "List recent session/team state-transition events",
 		Long: `Fetch the daemon's structured event ring and print matching events.
 
-Events are emitted from session.Manager (session created, deleted,
-crashed) and team.Controller (restart, crashloop-backoff, saturation,
-shift started/completed, health failed). Each event has a timestamp,
-kind, severity (info or warning), and session coordinates.
+Two families share the ring. Control-plane events report what marvel
+did to a session: session.created / deleted / crashed from
+session.Manager, and restart, crashloop-backoff, saturation, shift and
+health events from team.Controller. Agent events (agent.*) report what
+the agent inside a session did: session start and end with cost and
+timing, messages, tool calls and results, permission prompts. Agent
+events only appear for sessions whose runtime marvel can observe (a
+headless stream-json launch today; see examples/claude-headless.toml).
+
+Each event has a timestamp, kind, severity (info or warning), and
+session coordinates.
 
 Examples:
   marvel events                              # last 100 events
@@ -325,6 +332,8 @@ Examples:
   marvel events --workspace demo             # filter by workspace
   marvel events --session util/shell-g1-0    # filter by session key
   marvel events --kind session.crashed       # only crashes
+  marvel events --kind agent.tool.call       # what the agents are doing
+  marvel events --kind agent.session.ended   # per-session cost and timing
   marvel events --warnings                   # only warning-severity events
   marvel --cluster desk events               # remote daemon via mrvl://`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -387,7 +396,7 @@ Examples:
 	cmd.Flags().StringVar(&team, "team", "", "filter by team")
 	cmd.Flags().StringVar(&role, "role", "", "filter by role")
 	cmd.Flags().StringVar(&session, "session", "", "filter by session key (workspace/name)")
-	cmd.Flags().StringVar(&kind, "kind", "", "filter by event kind (e.g. session.crashed, health.failed)")
+	cmd.Flags().StringVar(&kind, "kind", "", "filter by event kind (e.g. session.crashed, health.failed, agent.tool.call)")
 	cmd.Flags().BoolVar(&warningsOnly, "warnings", false, "show only warning-severity events")
 	return cmd
 }

--- a/examples/claude-headless.toml
+++ b/examples/claude-headless.toml
@@ -1,0 +1,45 @@
+# Marvel example — headless Claude Code agents marvel can observe.
+#
+# Tests: runtime mode = headless, stream-json redirection into a marvel
+# FIFO, agent events landing in the daemon event ring.
+#
+# In headless mode the claude adapter runs the harness as
+#   claude --print --output-format stream-json --verbose ... '<prompt>'
+# with stdout redirected into a per-session pipe the daemon reads. Marvel
+# parses the NDJSON and emits agent.* events: session start/end, messages,
+# tool calls and results, plus the metering the harness reports at the end
+# (cost, token counts, duration, api time, ttft, turn count).
+#
+# The interactive roles in examples/claude.toml still work exactly as
+# before. Mode is per-role, so one team can mix both.
+#
+# Setup:
+#   just build
+#   ./marvel daemon &
+#   ./marvel work examples/claude-headless.toml
+#
+# Watch the agent do its work:
+#   ./marvel events --kind agent.tool.call
+#   ./marvel events --workspace ccode-headless
+#   ./marvel events --warnings          # permission prompts, errors, bad exits
+#
+# The session ends when the request does — a headless agent is a one-shot,
+# so expect the pane to close and the session to be reaped.
+
+[workspace]
+name = "ccode-headless"
+
+[[team]]
+name = "audit-squad"
+
+  [[team.role]]
+  name = "auditor"
+  replicas = 1
+  permissions = "plan"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"
+    args = ["--model", "haiku"]
+    mode = "headless"
+    prompt = "List the top-level directories in this repo and stop."

--- a/examples/claude-headless.yaml
+++ b/examples/claude-headless.yaml
@@ -1,0 +1,43 @@
+# Marvel example — headless Claude Code agents marvel can observe.
+#
+# Tests: runtime mode = headless, stream-json redirection into a marvel
+# FIFO, agent events landing in the daemon event ring.
+#
+# In headless mode the claude adapter runs the harness as
+#   claude --print --output-format stream-json --verbose ... '<prompt>'
+# with stdout redirected into a per-session pipe the daemon reads. Marvel
+# parses the NDJSON and emits agent.* events: session start/end, messages,
+# tool calls and results, plus the metering the harness reports at the end
+# (cost, token counts, duration, api time, ttft, turn count).
+#
+# The interactive roles in examples/claude.yaml still work exactly as
+# before. Mode is per-role, so one team can mix both.
+#
+# Setup:
+#   just build
+#   ./marvel daemon &
+#   ./marvel work examples/claude-headless.yaml
+#
+# Watch the agent do its work:
+#   ./marvel events --kind agent.tool.call
+#   ./marvel events --workspace ccode-headless
+#   ./marvel events --warnings          # permission prompts, errors, bad exits
+#
+# The session ends when the request does — a headless agent is a one-shot,
+# so expect the pane to close and the session to be reaped.
+
+workspace:
+  name: ccode-headless
+
+teams:
+  - name: audit-squad
+    roles:
+      - name: auditor
+        replicas: 1
+        permissions: plan
+        runtime:
+          image: claude
+          command: claude
+          args: ["--model", "haiku"]
+          mode: headless
+          prompt: List the top-level directories in this repo and stop.

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -56,10 +56,12 @@ type ManifestHealthCheck struct {
 
 // ManifestRuntime is the runtime section within a role.
 type ManifestRuntime struct {
-	Image   string   `toml:"image"          yaml:"image"`
-	Command string   `toml:"command"        yaml:"command"`
-	Args    []string `toml:"args,omitempty"  yaml:"args,omitempty"`
-	Script  string   `toml:"script,omitempty" yaml:"script,omitempty"`
+	Image   string      `toml:"image"          yaml:"image"`
+	Command string      `toml:"command"        yaml:"command"`
+	Args    []string    `toml:"args,omitempty"  yaml:"args,omitempty"`
+	Script  string      `toml:"script,omitempty" yaml:"script,omitempty"`
+	Mode    RuntimeMode `toml:"mode,omitempty"  yaml:"mode,omitempty"`
+	Prompt  string      `toml:"prompt,omitempty" yaml:"prompt,omitempty"`
 }
 
 // ManifestEndpoint is an endpoint section of a manifest.
@@ -224,6 +226,8 @@ func (m *Manifest) Apply(store *Store) error {
 				Command: mr.Runtime.Command,
 				Args:    mr.Runtime.Args,
 				Script:  mr.Runtime.Script,
+				Mode:    mr.Runtime.Mode,
+				Prompt:  mr.Runtime.Prompt,
 			}
 			if rt.Name == "" {
 				rt.Name = rt.Command

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -86,12 +86,33 @@ type Workspace struct {
 	CreatedAt time.Time `toml:"-"`
 }
 
+// RuntimeMode selects how a harness is launched within its pane.
+type RuntimeMode string
+
+const (
+	// RuntimeModeInteractive attaches the harness to the pane's tty. The
+	// zero value, so every manifest written before headless mode existed
+	// keeps its behavior.
+	RuntimeModeInteractive RuntimeMode = ""
+	// RuntimeModeHeadless runs one non-interactive request whose
+	// structured output marvel parses. Adapters that can redirect that
+	// output declare it via runtime.StreamCapable; the session manager
+	// then observes the session instead of only supervising the pane.
+	RuntimeModeHeadless RuntimeMode = "headless"
+)
+
 // Runtime is the program to execute (container image equivalent).
 type Runtime struct {
 	Name    string   `toml:"name"`
 	Command string   `toml:"command"`
 	Args    []string `toml:"args,omitempty"`
 	Script  string   `toml:"script,omitempty"`
+	// Mode is interactive (default) or headless.
+	Mode RuntimeMode `toml:"mode,omitempty"`
+	// Prompt is the request a headless launch carries. Required in
+	// headless mode: a harness given no prompt reads stdin, and stdin in
+	// a detached pane is a tty nobody types into.
+	Prompt string `toml:"prompt,omitempty"`
 }
 
 // Session is the atomic unit: a tmux pane running one process (pod equivalent).

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -33,6 +33,29 @@ const (
 	KindRoleSaturated     Kind = "role.saturated"
 )
 
+// Agent-stream kinds. These are the runtime adapter vocabulary
+// (internal/runtime/events, twelve kinds) lifted into the ring, one ring
+// kind per adapter kind, prefixed so `marvel events --kind
+// agent.tool.call` reads next to the control-plane kinds above. The
+// prefix also keeps the two namespaces from colliding as either grows.
+//
+// The kinds above report what marvel did to a session; these report what
+// the agent inside it did.
+const (
+	KindAgentSessionStarted      Kind = "agent.session.started"
+	KindAgentSessionEnded        Kind = "agent.session.ended"
+	KindAgentTurnStarted         Kind = "agent.turn.started"
+	KindAgentTurnCompleted       Kind = "agent.turn.completed"
+	KindAgentMessageDelta        Kind = "agent.message.delta"
+	KindAgentMessageCompleted    Kind = "agent.message.completed"
+	KindAgentToolCall            Kind = "agent.tool.call"
+	KindAgentToolResult          Kind = "agent.tool.result"
+	KindAgentPermissionRequested Kind = "agent.permission.requested"
+	KindAgentAuthRequired        Kind = "agent.auth.required"
+	KindAgentHealthHeartbeat     Kind = "agent.health.heartbeat"
+	KindAgentError               Kind = "agent.error"
+)
+
 // Severity mirrors the kubernetes Warning/Normal distinction. Lets
 // operators filter `marvel events --severity warning` for the things
 // that need attention.

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -19,6 +19,13 @@ type LaunchContext struct {
 	Team       *api.Team
 	Workspace  *api.Workspace
 	SocketPath string
+	// StreamPath is a sink the session manager created for this launch —
+	// a FIFO the harness's structured output can be redirected into.
+	// Empty means marvel is not observing this session's stream, either
+	// because the adapter declined SupportsStream or because the manager
+	// has no sink directory. An adapter that finds it empty must produce
+	// a working command anyway.
+	StreamPath string
 }
 
 // LaunchResult is what the adapter returns: the fully resolved command,
@@ -26,6 +33,11 @@ type LaunchContext struct {
 type LaunchResult struct {
 	Command string
 	Env     map[string]string
+	// Stream is set only when the adapter actually wired its harness's
+	// structured output into LaunchContext.StreamPath. Nil means the
+	// session produces no parseable stream and is observed by
+	// capture-pane alone.
+	Stream *StreamSpec
 }
 
 // Adapter knows how to prepare the execution environment for a specific
@@ -143,5 +155,19 @@ func resolveCommand(rt *api.Runtime) string {
 	return rt.Name
 }
 
+// redirectStdout appends a stdout redirection to a command string. Safe
+// because tmux runs a single-argument shell-command through `sh -c`,
+// which is the same property buildCommand's quoting already relies on.
+// stderr deliberately stays in the pane: it is the operator's window
+// into a harness that failed before it produced any structured output.
+func redirectStdout(cmd, path string) string {
+	return cmd + " > " + shellQuote(path)
+}
+
 // ErrNoCommand is returned when a runtime has no command or image specified.
 var ErrNoCommand = fmt.Errorf("runtime has no command or image")
+
+// ErrNoPrompt is returned when a headless launch carries no prompt. A
+// prompt-less headless harness reads stdin and hangs on a pane tty
+// nobody is typing into, so this is a manifest error, not a default.
+var ErrNoPrompt = fmt.Errorf("headless runtime has no prompt")

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -305,5 +306,124 @@ func TestForestagePrepareDangerousPermissionsDefaultOff(t *testing.T) {
 
 	if strings.Contains(result.Command, "--dangerously-skip-permissions") {
 		t.Errorf("command must NOT contain --dangerously-skip-permissions when Role.DangerousPermissions is false (default), got: %s", result.Command)
+	}
+}
+
+// headlessClaudeContext is the shape the manager builds for a
+// stream-capable launch: a headless claude runtime plus the sink path.
+func headlessClaudeContext(streamPath string) *LaunchContext {
+	ctx := testContext()
+	ctx.Session.Runtime = api.Runtime{
+		Name:    "claude",
+		Command: "claude",
+		Mode:    api.RuntimeModeHeadless,
+		Prompt:  "summarize the diff",
+	}
+	ctx.StreamPath = streamPath
+	return ctx
+}
+
+func TestClaudeSupportsStreamOnlyWhenHeadless(t *testing.T) {
+	t.Parallel()
+	c := &Claude{}
+
+	interactive := testContext()
+	interactive.Session.Runtime.Name = "claude"
+	interactive.Session.Runtime.Command = "claude"
+	if c.SupportsStream(interactive) {
+		t.Error("interactive claude should not claim a stream")
+	}
+	if !c.SupportsStream(headlessClaudeContext("")) {
+		t.Error("headless claude should claim a stream")
+	}
+}
+
+func TestClaudePrepareHeadlessRedirectsToSink(t *testing.T) {
+	t.Parallel()
+	c := &Claude{}
+	result, err := c.Prepare(headlessClaudeContext("/tmp/marvel-streams/acme-agent.ndjson"))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	for _, want := range []string{
+		"--print", "--output-format stream-json", "--verbose",
+		"> /tmp/marvel-streams/acme-agent.ndjson",
+	} {
+		if !strings.Contains(result.Command, want) {
+			t.Errorf("command missing %q: %s", want, result.Command)
+		}
+	}
+	// The prompt is positional and must be the last thing before the
+	// redirection, or claude reads it as a flag value.
+	if !strings.Contains(result.Command, "'summarize the diff' > ") {
+		t.Errorf("prompt not positioned before the redirect: %s", result.Command)
+	}
+	if result.Stream == nil {
+		t.Fatal("expected a StreamSpec")
+	}
+	if result.Stream.Format != StreamFormatClaudeCodeJSON {
+		t.Errorf("format = %q, want %q", result.Stream.Format, StreamFormatClaudeCodeJSON)
+	}
+}
+
+func TestClaudePrepareHeadlessWithoutSinkStillRuns(t *testing.T) {
+	t.Parallel()
+	c := &Claude{}
+	result, err := c.Prepare(headlessClaudeContext(""))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if strings.Contains(result.Command, ">") {
+		t.Errorf("no sink offered, so no redirect belongs in: %s", result.Command)
+	}
+	if result.Stream != nil {
+		t.Error("adapter reported a stream it was never given a sink for")
+	}
+}
+
+func TestClaudePrepareHeadlessRequiresPrompt(t *testing.T) {
+	t.Parallel()
+	c := &Claude{}
+	ctx := headlessClaudeContext("/tmp/x.ndjson")
+	ctx.Session.Runtime.Prompt = ""
+	if _, err := c.Prepare(ctx); !errors.Is(err, ErrNoPrompt) {
+		t.Fatalf("error = %v, want ErrNoPrompt", err)
+	}
+}
+
+func TestInteractiveAdaptersReportNoStream(t *testing.T) {
+	t.Parallel()
+	// Every pre-existing adapter must keep launching exactly as before,
+	// sink offered or not.
+	for _, a := range []Adapter{&Forestage{}, &Generic{}, &Claude{}} {
+		ctx := testContext()
+		ctx.StreamPath = "/tmp/should-be-ignored.ndjson"
+		ctx.Session.Runtime.Name = a.Name()
+		ctx.Session.Runtime.Command = "/usr/local/bin/" + a.Name()
+		result, err := a.Prepare(ctx)
+		if err != nil {
+			t.Fatalf("%s Prepare: %v", a.Name(), err)
+		}
+		if result.Stream != nil {
+			t.Errorf("%s reported a stream for an interactive launch", a.Name())
+		}
+		if strings.Contains(result.Command, "should-be-ignored") {
+			t.Errorf("%s redirected an interactive launch: %s", a.Name(), result.Command)
+		}
+	}
+}
+
+func TestNewStreamParserRejectsUnknownFormat(t *testing.T) {
+	t.Parallel()
+	if _, err := NewStreamParser("codex/json", StreamParserConfig{}); err == nil {
+		t.Fatal("expected an error for a format with no parser")
+	}
+	p, err := NewStreamParser(StreamFormatClaudeCodeJSON, StreamParserConfig{AgentID: "a"})
+	if err != nil {
+		t.Fatalf("claude-code parser: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected a parser")
 	}
 }

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -1,20 +1,43 @@
 package runtime
 
+import "github.com/arcavenae/marvel/internal/api"
+
 // Claude is the adapter for the bare Claude Code CLI. Medium integration:
 // permission mode injection via CLI flag, environment-based identity,
 // capture-pane fallback for observability.
+//
+// In headless mode (api.RuntimeModeHeadless) it is also the first
+// stream-capable adapter: the harness runs `--print --output-format
+// stream-json --verbose` and marvel parses the resulting NDJSON.
 type Claude struct{}
 
 func (c *Claude) Name() string { return "claude" }
+
+// SupportsStream reports whether this launch will produce a parseable
+// stream. Only headless launches do: interactive Claude Code renders a
+// TUI to the pane and has no structured output to redirect.
+func (c *Claude) SupportsStream(ctx *LaunchContext) bool {
+	return ctx.Session.Runtime.Mode == api.RuntimeModeHeadless
+}
 
 func (c *Claude) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {
 		return nil, ErrNoCommand
 	}
+	headless := ctx.Session.Runtime.Mode == api.RuntimeModeHeadless
+	if headless && ctx.Session.Runtime.Prompt == "" {
+		return nil, ErrNoPrompt
+	}
 
 	args := make([]string, len(ctx.Session.Runtime.Args))
 	copy(args, ctx.Session.Runtime.Args)
+
+	if headless {
+		// --verbose is not optional here: claude refuses stream-json
+		// output under --print without it.
+		args = append(args, "--print", "--output-format", "stream-json", "--verbose")
+	}
 
 	// Inject permission mode — claude CLI accepts this directly.
 	if ctx.Role.Permissions != "" {
@@ -29,12 +52,23 @@ func (c *Claude) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 		args = append(args, "--append-system-prompt", prompt)
 	}
 
-	env := baseEnv(ctx)
+	// The request goes last, as the positional argument.
+	if headless {
+		args = append(args, ctx.Session.Runtime.Prompt)
+	}
 
-	return &LaunchResult{
+	result := &LaunchResult{
 		Command: buildCommand(binary, args),
-		Env:     env,
-	}, nil
+		Env:     baseEnv(ctx),
+	}
+	if headless && ctx.StreamPath != "" {
+		result.Command = redirectStdout(result.Command, ctx.StreamPath)
+		result.Stream = &StreamSpec{
+			Format: StreamFormatClaudeCodeJSON,
+			Path:   ctx.StreamPath,
+		}
+	}
+	return result, nil
 }
 
 func hasFlag(args []string, flag string) bool {
@@ -48,4 +82,5 @@ func hasFlag(args []string, flag string) bool {
 
 func init() {
 	var _ Adapter = (*Claude)(nil)
+	var _ StreamCapable = (*Claude)(nil)
 }

--- a/internal/runtime/claudecode/mapping.md
+++ b/internal/runtime/claudecode/mapping.md
@@ -53,13 +53,25 @@ what claude actually emits with the sketch in
    `SessionStartedData` (useful for downstream capability inspection)
    and drop the rest — they're reachable via raw if needed later.
 
-5. **`result` carries far more fields than the spec calls out.** The
-   spec names reason/exit_code/usage; claude also ships duration_ms,
-   duration_api_ms, ttft_ms, ttft_stream_ms, num_turns, result (final
-   text), modelUsage, permission_denials, terminal_reason. We keep
-   the spec fields (Usage.In/Out/Cost, ExitCode, Reason) and drop
-   the rest. Follow-on: add duration_ms + duration_api_ms to
-   SessionEndedData once a consumer needs them.
+5. **`result` carries far more fields than the spec calls out.**
+   RESOLVED: metering is now the point, so the accounting fields are
+   promoted rather than dropped. `SessionEndedData.Metering` (additive,
+   nil when a harness reports none of it) carries duration_ms,
+   duration_api_ms, ttft_ms, ttft_stream_ms, num_turns, the two
+   prompt-cache token counts off `usage`, the per-model `modelUsage`
+   breakdown, and `permission_denials`. Cache counts live on Metering
+   rather than Usage because Usage's three fields are spec-fixed and
+   shared with turn events.
+
+   Still dropped: `result` (the final assistant text, already carried by
+   the preceding message.completed event), `terminal_reason`,
+   `api_error_status`, `time_to_request_ms`, and the `usage` sub-objects
+   (`server_tool_use`, `cache_creation`, `service_tier`, `iterations`).
+   All remain reachable via `raw`.
+
+   `permission_denials` entry shape is unverified — every fixture we
+   have carries an empty array, so the length is authoritative and
+   tool_name/tool_use_id are best-effort.
 
 6. **No timestamp field on vendor lines.** Claude Code stream-json
    does not carry per-event timestamps. The parser stamps `ts` at

--- a/internal/runtime/claudecode/parser.go
+++ b/internal/runtime/claudecode/parser.go
@@ -299,17 +299,87 @@ func boundToolResultContent(raw json.RawMessage) any {
 	return events.TruncateString(string(raw), events.MaxSummaryBytes)
 }
 
-func (p *Parser) handleResult(raw json.RawMessage, emit func(events.Event)) {
-	var body struct {
-		Subtype      string  `json:"subtype"`
-		IsError      bool    `json:"is_error"`
-		StopReason   string  `json:"stop_reason"`
-		TotalCostUSD float64 `json:"total_cost_usd"`
-		Usage        struct {
-			InputTokens  int `json:"input_tokens"`
-			OutputTokens int `json:"output_tokens"`
-		} `json:"usage"`
+// resultBody is the subset of the vendor `result` line marvel consumes.
+// Field names on the vendor side are inconsistent (snake_case at the top
+// level, camelCase inside modelUsage); the tags below mirror the wire
+// exactly rather than normalizing.
+type resultBody struct {
+	Subtype      string  `json:"subtype"`
+	IsError      bool    `json:"is_error"`
+	StopReason   string  `json:"stop_reason"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	Usage        struct {
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	} `json:"usage"`
+	DurationMS    int64 `json:"duration_ms"`
+	DurationAPIMS int64 `json:"duration_api_ms"`
+	TTFTMS        int64 `json:"ttft_ms"`
+	TTFTStreamMS  int64 `json:"ttft_stream_ms"`
+	NumTurns      int   `json:"num_turns"`
+	ModelUsage    map[string]struct {
+		InputTokens              int     `json:"inputTokens"`
+		OutputTokens             int     `json:"outputTokens"`
+		CacheReadInputTokens     int     `json:"cacheReadInputTokens"`
+		CacheCreationInputTokens int     `json:"cacheCreationInputTokens"`
+		WebSearchRequests        int     `json:"webSearchRequests"`
+		CostUSD                  float64 `json:"costUSD"`
+	} `json:"modelUsage"`
+	// Entry shape is unverified — every fixture we have carries an empty
+	// array. The length is authoritative; tool_name/tool_use_id are
+	// best-effort and stay empty when the vendor names them otherwise.
+	PermissionDenials []struct {
+		ToolName  string `json:"tool_name"`
+		ToolUseID string `json:"tool_use_id"`
+	} `json:"permission_denials"`
+}
+
+// metering lifts the accounting fields off a result line. Returns nil
+// when the line carries none of them, so consumers can tell "harness
+// did not report" from "harness reported zeros".
+func (b *resultBody) metering() *events.Metering {
+	m := events.Metering{
+		DurationMS:      b.DurationMS,
+		APIDurationMS:   b.DurationAPIMS,
+		TTFTMS:          b.TTFTMS,
+		TTFTStreamMS:    b.TTFTStreamMS,
+		NumTurns:        b.NumTurns,
+		CacheReadIn:     b.Usage.CacheReadInputTokens,
+		CacheCreationIn: b.Usage.CacheCreationInputTokens,
 	}
+	for model, u := range b.ModelUsage {
+		if m.ModelUsage == nil {
+			m.ModelUsage = make(map[string]events.ModelUsage, len(b.ModelUsage))
+		}
+		cost := u.CostUSD
+		m.ModelUsage[model] = events.ModelUsage{
+			In:                u.InputTokens,
+			Out:               u.OutputTokens,
+			CacheReadIn:       u.CacheReadInputTokens,
+			CacheCreationIn:   u.CacheCreationInputTokens,
+			WebSearchRequests: u.WebSearchRequests,
+			Cost:              &cost,
+		}
+	}
+	for _, d := range b.PermissionDenials {
+		m.PermissionDenials = append(m.PermissionDenials, events.PermissionDenial{
+			Tool:   d.ToolName,
+			CallID: d.ToolUseID,
+		})
+	}
+	empty := m.DurationMS == 0 && m.APIDurationMS == 0 && m.TTFTMS == 0 &&
+		m.TTFTStreamMS == 0 && m.NumTurns == 0 && m.CacheReadIn == 0 &&
+		m.CacheCreationIn == 0 && len(m.ModelUsage) == 0 && len(m.PermissionDenials) == 0
+	if empty {
+		return nil
+	}
+	return &m
+}
+
+func (p *Parser) handleResult(raw json.RawMessage, emit func(events.Event)) {
+	var body resultBody
 	if err := json.Unmarshal(raw, &body); err != nil {
 		emit(p.newEvent(events.KindError, events.ErrorData{
 			Kind:    events.ErrKindParse,
@@ -336,6 +406,7 @@ func (p *Parser) handleResult(raw json.RawMessage, emit func(events.Event)) {
 			Out:  body.Usage.OutputTokens,
 			Cost: &cost,
 		},
+		Metering: body.metering(),
 	}
 	emit(p.newEvent(events.KindSessionEnded, data, nil))
 }

--- a/internal/runtime/claudecode/parser_test.go
+++ b/internal/runtime/claudecode/parser_test.go
@@ -401,3 +401,92 @@ func kinds(evs []events.Event) []events.Kind {
 	}
 	return out
 }
+
+func TestParseResultPromotesMeteringFields(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "hello.ndjson")
+	ended, ok := got[len(got)-1].Data.(events.SessionEndedData)
+	if !ok {
+		t.Fatalf("last event data = %T, want SessionEndedData", got[len(got)-1].Data)
+	}
+	m := ended.Metering
+	if m == nil {
+		t.Fatal("session.ended carries no metering")
+	}
+
+	// Values are read straight off testdata/hello.ndjson.
+	if m.DurationMS != 4816 {
+		t.Errorf("duration_ms = %d, want 4816", m.DurationMS)
+	}
+	if m.APIDurationMS != 6546 {
+		t.Errorf("duration_api_ms = %d, want 6546", m.APIDurationMS)
+	}
+	if m.TTFTMS != 4775 {
+		t.Errorf("ttft_ms = %d, want 4775", m.TTFTMS)
+	}
+	if m.TTFTStreamMS != 4031 {
+		t.Errorf("ttft_stream_ms = %d, want 4031", m.TTFTStreamMS)
+	}
+	if m.NumTurns != 1 {
+		t.Errorf("num_turns = %d, want 1", m.NumTurns)
+	}
+	if m.CacheCreationIn != 22005 {
+		t.Errorf("cache_creation_in = %d, want 22005", m.CacheCreationIn)
+	}
+	if len(m.PermissionDenials) != 0 {
+		t.Errorf("permission_denials = %v, want empty", m.PermissionDenials)
+	}
+
+	// modelUsage is per-model and camelCase on the wire; the fixture
+	// routed across two models in one session.
+	if len(m.ModelUsage) != 2 {
+		t.Fatalf("model_usage has %d entries, want 2: %+v", len(m.ModelUsage), m.ModelUsage)
+	}
+	haiku, ok := m.ModelUsage["claude-haiku-4-5-20251001"]
+	if !ok {
+		t.Fatalf("model_usage missing the haiku entry: %+v", m.ModelUsage)
+	}
+	if haiku.In != 522 || haiku.Out != 13 {
+		t.Errorf("haiku usage = in %d out %d, want 522/13", haiku.In, haiku.Out)
+	}
+	if haiku.Cost == nil || *haiku.Cost != 0.000587 {
+		t.Errorf("haiku cost = %v, want 0.000587", haiku.Cost)
+	}
+}
+
+func TestParseResultWithoutMeteringLeavesItNil(t *testing.T) {
+	t.Parallel()
+	// A harness that reports none of the accounting fields must be
+	// distinguishable from one that reports zeros.
+	line := `{"type":"result","subtype":"success","is_error":false,"session_id":"s","usage":{"input_tokens":1,"output_tokens":1}}`
+	p := NewParser(Config{Clock: fixedClock()})
+	var got []events.Event
+	if err := p.Parse(context.Background(), strings.NewReader(line+"\n"), func(e events.Event) {
+		got = append(got, e)
+	}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	ended, ok := got[0].Data.(events.SessionEndedData)
+	if !ok {
+		t.Fatalf("data = %T, want SessionEndedData", got[0].Data)
+	}
+	if ended.Metering != nil {
+		t.Errorf("metering = %+v, want nil", ended.Metering)
+	}
+}
+
+func TestSessionEndedMeteringOmittedFromJSONWhenAbsent(t *testing.T) {
+	t.Parallel()
+	// Metering is additive under schema_version 1, so an event without
+	// it must serialize exactly as it did before the field existed.
+	b, err := json.Marshal(events.SessionEndedData{ExitCode: 0})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(b, []byte("metering")) {
+		t.Errorf("metering leaked into JSON: %s", b)
+	}
+}

--- a/internal/runtime/events/events.go
+++ b/internal/runtime/events/events.go
@@ -103,10 +103,68 @@ type SessionStartedData struct {
 
 // SessionEndedData — harness session terminated. ExitCode 0 = success;
 // non-zero maps to Lift() → INFORM(alert) per §3.4.
+//
+// Metering is an additive v1 field: harnesses that report per-session
+// timing and per-model accounting attach it, everything else leaves it
+// nil. Adding it does not bump SchemaVersion (per-kind `data` payloads
+// grow additively by design).
 type SessionEndedData struct {
-	Reason   string `json:"reason,omitempty"`
-	ExitCode int    `json:"exit_code"`
-	Usage    Usage  `json:"usage,omitzero"`
+	Reason   string    `json:"reason,omitempty"`
+	ExitCode int       `json:"exit_code"`
+	Usage    Usage     `json:"usage,omitzero"`
+	Metering *Metering `json:"metering,omitempty"`
+}
+
+// Metering carries the accounting a harness reports at session end
+// beyond the coarse Usage totals: wall-clock and API timings, turn
+// count, cache accounting, per-model breakdown, and the permission
+// denials accumulated over the session.
+//
+// Every field is optional. A harness that reports none of it should
+// leave SessionEndedData.Metering nil rather than attaching a zero
+// value, so consumers can distinguish "not reported" from "zero".
+type Metering struct {
+	// DurationMS is wall-clock time for the whole session.
+	DurationMS int64 `json:"duration_ms,omitempty"`
+	// APIDurationMS is time spent in provider API calls.
+	APIDurationMS int64 `json:"duration_api_ms,omitempty"`
+	// TTFTMS is time to first token.
+	TTFTMS int64 `json:"ttft_ms,omitempty"`
+	// TTFTStreamMS is time to first streamed token, which a harness may
+	// report separately from TTFTMS when it buffers ahead of the stream.
+	TTFTStreamMS int64 `json:"ttft_stream_ms,omitempty"`
+	// NumTurns counts request/response turns within the session.
+	NumTurns int `json:"num_turns,omitempty"`
+	// CacheReadIn and CacheCreationIn are prompt-cache token counts.
+	// They sit here rather than on Usage because Usage is the shared
+	// turn/session shape and its three fields are spec-fixed.
+	CacheReadIn     int `json:"cache_read_in,omitempty"`
+	CacheCreationIn int `json:"cache_creation_in,omitempty"`
+	// ModelUsage breaks the session down by model id. A session that
+	// routes across models (a small model for routing, a large one for
+	// the answer) reports one entry each.
+	ModelUsage map[string]ModelUsage `json:"model_usage,omitempty"`
+	// PermissionDenials lists tool invocations the harness refused.
+	// Length is the count; entry detail is best-effort.
+	PermissionDenials []PermissionDenial `json:"permission_denials,omitempty"`
+}
+
+// ModelUsage is per-model accounting within one session.
+type ModelUsage struct {
+	In                int      `json:"in,omitempty"`
+	Out               int      `json:"out,omitempty"`
+	CacheReadIn       int      `json:"cache_read_in,omitempty"`
+	CacheCreationIn   int      `json:"cache_creation_in,omitempty"`
+	WebSearchRequests int      `json:"web_search_requests,omitempty"`
+	Cost              *float64 `json:"cost,omitempty"`
+}
+
+// PermissionDenial names one refused tool invocation. Tool is the
+// harness's tool name; CallID correlates with the tool.call event when
+// the harness supplies one.
+type PermissionDenial struct {
+	Tool   string `json:"tool,omitempty"`
+	CallID string `json:"call_id,omitempty"`
 }
 
 // TurnData — usage delta at turn boundaries. May be zero-valued when

--- a/internal/runtime/fifo.go
+++ b/internal/runtime/fifo.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// FIFO is the byte path between a harness running in a tmux pane and the
+// daemon goroutine that parses its structured output. A named pipe is the
+// cheapest such path available: the harness needs no marvel-aware shim
+// (a shell redirection in the command string is the whole integration),
+// nothing lands on disk, and back-pressure is the kernel's problem.
+//
+// The rendezvous is deliberate. Opening the read end blocks until a
+// writer arrives, and the harness's shell blocks on its redirection
+// until the reader arrives, so the manager parks a reader before it
+// creates the pane. A launch that dies before exec still delivers EOF,
+// because the shell opens the redirection before it execs.
+type FIFO struct {
+	path string
+}
+
+// fifoMode keeps the pipe private to the daemon's user. Nothing else has
+// business reading an agent's transcript.
+const fifoMode = 0o600
+
+// NewFIFO creates a named pipe for one session under dir, deriving the
+// filename from the session key. A leftover pipe from a crashed daemon is
+// replaced rather than treated as an error — the path is derived, so a
+// collision means the previous owner is gone.
+func NewFIFO(dir, sessionKey string) (*FIFO, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create stream dir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, fifoName(sessionKey))
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("clear stale fifo %s: %w", path, err)
+	}
+	if err := syscall.Mkfifo(path, fifoMode); err != nil {
+		return nil, fmt.Errorf("mkfifo %s: %w", path, err)
+	}
+	return &FIFO{path: path}, nil
+}
+
+// fifoName flattens a session key (workspace/name) into one filename.
+func fifoName(sessionKey string) string {
+	slug := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '-'
+		}
+	}, sessionKey)
+	return slug + ".ndjson"
+}
+
+// Path is the filesystem path handed to the adapter for redirection.
+func (f *FIFO) Path() string { return f.path }
+
+// Open blocks until the harness opens the write end, then returns the
+// read side. Callers run it on a goroutine.
+func (f *FIFO) Open() (*os.File, error) {
+	file, err := os.OpenFile(f.path, os.O_RDONLY, os.ModeNamedPipe)
+	if err != nil {
+		return nil, fmt.Errorf("open fifo %s: %w", f.path, err)
+	}
+	return file, nil
+}
+
+// Poke releases a reader parked in Open by briefly becoming a writer. It
+// is the only way to retire a stream whose harness never started: the
+// blocking open is not context-cancellable. ENXIO (no reader parked)
+// means there was nothing to release, which is success.
+func (f *FIFO) Poke() {
+	w, err := os.OpenFile(f.path, os.O_WRONLY|syscall.O_NONBLOCK, fifoMode)
+	if err != nil {
+		return
+	}
+	_ = w.Close()
+}
+
+// Remove deletes the pipe. Safe to call on an already-removed path.
+func (f *FIFO) Remove() error {
+	if err := os.Remove(f.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove fifo %s: %w", f.path, err)
+	}
+	return nil
+}

--- a/internal/runtime/instance_tmux.go
+++ b/internal/runtime/instance_tmux.go
@@ -1,0 +1,304 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// PaneController is the slice of the tmux driver a TmuxInstance needs.
+// Declaring it here keeps package runtime free of a tmux dependency and
+// lets tests drive an instance without a tmux server.
+type PaneController interface {
+	NewPane(session, command, title string, envs map[string]string) (string, error)
+	KillPane(paneID string) error
+	SendKeys(paneID, text string, literal, enter bool) error
+	CapturePane(paneID string) (string, error)
+}
+
+// StreamSource pairs the sink an adapter redirected into with the parser
+// that reads it. The session manager builds one when the adapter reports
+// a StreamSpec; nil means the instance supervises a pane without
+// observing it.
+type StreamSource struct {
+	FIFO   *FIFO
+	Parser StreamParser
+}
+
+// TmuxConfig is the launch recipe for one TmuxInstance.
+type TmuxConfig struct {
+	Panes       PaneController
+	TmuxSession string
+	Title       string
+	Command     string
+	Env         map[string]string
+	Stream      *StreamSource
+	// EventBuffer bounds the channel Events returns. A full channel
+	// applies back-pressure to the parser, which applies it to the pipe,
+	// which applies it to the harness — the chain is intentional.
+	EventBuffer int
+}
+
+// DefaultEventBuffer holds a burst of tool calls without stalling the
+// harness while the daemon's ring consumer catches up.
+const DefaultEventBuffer = 256
+
+// TmuxInstance is the Instance implementation for a harness running in a
+// tmux pane. It is the seam every session goes through, whether or not
+// there is a stream to read: a pane-only session still gets Inject,
+// Capture, Kill, and State through one path.
+type TmuxInstance struct {
+	cfg    TmuxConfig
+	out    chan events.Event
+	state  atomic.Int32
+	closed sync.Once
+
+	mu     sync.Mutex
+	paneID string
+	cancel context.CancelFunc
+
+	readerG sync.WaitGroup
+}
+
+// ErrAlreadySpawned reports a second Spawn on the same instance. Restart
+// means a fresh Instance, per the Instance contract.
+var ErrAlreadySpawned = errors.New("instance already spawned")
+
+// NewTmuxInstance builds an unspawned instance.
+func NewTmuxInstance(cfg TmuxConfig) *TmuxInstance {
+	if cfg.EventBuffer <= 0 {
+		cfg.EventBuffer = DefaultEventBuffer
+	}
+	return &TmuxInstance{
+		cfg: cfg,
+		out: make(chan events.Event, cfg.EventBuffer),
+	}
+}
+
+// Spawn creates the pane. When the instance has a stream, the reader is
+// parked on the pipe first: both ends of a FIFO block until the other
+// arrives, and the harness is the end marvel cannot make wait.
+func (i *TmuxInstance) Spawn(_ context.Context) error {
+	if !i.state.CompareAndSwap(int32(StateIdle), int32(StateSpawning)) {
+		return ErrAlreadySpawned
+	}
+	if i.cfg.Stream != nil {
+		i.startReader()
+	} else {
+		// Nothing will ever be emitted; consumers should not wait for it.
+		i.closeEvents()
+	}
+
+	paneID, err := i.cfg.Panes.NewPane(i.cfg.TmuxSession, i.cfg.Command, i.cfg.Title, i.cfg.Env)
+	if err != nil {
+		i.state.Store(int32(StateFailed))
+		i.teardownStream()
+		return fmt.Errorf("spawn pane in %s: %w", i.cfg.TmuxSession, err)
+	}
+
+	i.mu.Lock()
+	i.paneID = paneID
+	i.mu.Unlock()
+	i.state.Store(int32(StateRunning))
+	return nil
+}
+
+// Kill terminates the pane and retires the stream. Safe to call on an
+// instance whose pane is already gone (the reap path does exactly that);
+// the pane error is returned but the stream is torn down either way.
+func (i *TmuxInstance) Kill(ctx context.Context) error {
+	switch State(i.state.Load()) {
+	case StateStopped, StateFailed:
+		return nil
+	}
+	i.state.Store(int32(StateStopping))
+
+	var err error
+	if paneID := i.PaneID(); paneID != "" {
+		if kerr := i.cfg.Panes.KillPane(paneID); kerr != nil {
+			err = fmt.Errorf("kill pane %s: %w", paneID, kerr)
+		}
+	}
+	i.teardownStreamCtx(ctx)
+
+	if err != nil {
+		i.state.Store(int32(StateFailed))
+		return err
+	}
+	i.state.Store(int32(StateStopped))
+	return nil
+}
+
+// Detach retires the stream without touching the pane. It is the reap
+// path's Kill: the harness is already gone, so asking tmux to kill a pane
+// that no longer exists would only produce a misleading error.
+func (i *TmuxInstance) Detach(ctx context.Context) {
+	switch State(i.state.Load()) {
+	case StateStopped, StateFailed:
+		return
+	}
+	i.state.Store(int32(StateStopping))
+	i.teardownStreamCtx(ctx)
+	i.state.Store(int32(StateStopped))
+}
+
+// Inject types input into the pane. Literal keys plus Enter: the harness
+// sees what a human at the keyboard would have sent.
+func (i *TmuxInstance) Inject(input string) error {
+	paneID := i.PaneID()
+	if paneID == "" {
+		return errors.New("inject: instance has no pane")
+	}
+	return i.cfg.Panes.SendKeys(paneID, input, true, true)
+}
+
+// Capture snapshots visible pane contents. Present for every instance,
+// stream or not — it is the fallback observation channel for harnesses
+// that emit nothing structured.
+func (i *TmuxInstance) Capture(_ context.Context) ([]byte, error) {
+	paneID := i.PaneID()
+	if paneID == "" {
+		return nil, errors.New("capture: instance has no pane")
+	}
+	out, err := i.cfg.Panes.CapturePane(paneID)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(out), nil
+}
+
+// Events returns the normalized stream. Closed when the harness's output
+// ends, after Kill, or immediately for instances with no stream.
+func (i *TmuxInstance) Events() <-chan events.Event { return i.out }
+
+// State reports the lifecycle stage.
+func (i *TmuxInstance) State() State { return State(i.state.Load()) }
+
+// PaneID is the tmux pane the instance owns, empty before Spawn.
+func (i *TmuxInstance) PaneID() string {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.paneID
+}
+
+// startReader parks a goroutine on the pipe. It owns the event channel:
+// it is the only sender, so it is also the closer.
+func (i *TmuxInstance) startReader() {
+	ctx, cancel := context.WithCancel(context.Background())
+	i.mu.Lock()
+	i.cancel = cancel
+	i.mu.Unlock()
+	i.readerG.Add(1)
+	go func() {
+		defer i.readerG.Done()
+		defer i.closeEvents()
+
+		f, err := i.cfg.Stream.FIFO.Open()
+		if err != nil {
+			i.emitTransportError(ctx, err)
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		perr := i.cfg.Stream.Parser.Parse(ctx, f, func(ev events.Event) {
+			i.emit(ctx, ev)
+		})
+		if perr != nil && !errors.Is(perr, context.Canceled) && !errors.Is(perr, io.EOF) {
+			i.emitTransportError(ctx, perr)
+		}
+	}()
+}
+
+// emit hands an event to the consumer, abandoning it if the instance is
+// being torn down. Dropping on cancellation is correct: the alternative
+// is a goroutine parked forever on a channel nobody will read again.
+func (i *TmuxInstance) emit(ctx context.Context, ev events.Event) {
+	select {
+	case i.out <- ev:
+	case <-ctx.Done():
+	}
+}
+
+func (i *TmuxInstance) emitTransportError(ctx context.Context, err error) {
+	i.emit(ctx, events.Event{
+		SchemaVersion: events.SchemaVersion,
+		Event:         events.KindError,
+		TS:            time.Now().UTC(),
+		Data: events.ErrorData{
+			Kind:    events.ErrKindTransport,
+			Message: err.Error(),
+		},
+	})
+}
+
+func (i *TmuxInstance) closeEvents() {
+	i.closed.Do(func() { close(i.out) })
+}
+
+// streamTeardownGrace bounds the wait for a reader to notice it is done.
+// The timeout keeps a wedged pipe from holding up session deletion.
+const streamTeardownGrace = 2 * time.Second
+
+// streamPokeInterval is how often teardown retries the release. One poke
+// is not enough: a reader that has not yet reached its blocking open
+// cannot be released, and there is no way to observe the moment it parks.
+const streamPokeInterval = 20 * time.Millisecond
+
+func (i *TmuxInstance) teardownStream() {
+	ctx, cancel := context.WithTimeout(context.Background(), streamTeardownGrace)
+	defer cancel()
+	i.teardownStreamCtx(ctx)
+}
+
+// teardownStreamCtx retires the pipe and waits for the reader to leave.
+// It does not close the event channel: the reader is the only sender, so
+// the reader is the only safe closer. A wait that times out therefore
+// leaves the channel open — the alternative is a panic on a closed
+// channel, and a lingering consumer is the cheaper failure.
+func (i *TmuxInstance) teardownStreamCtx(ctx context.Context) {
+	if i.cfg.Stream == nil {
+		return
+	}
+	i.mu.Lock()
+	cancel := i.cancel
+	i.mu.Unlock()
+	if cancel != nil {
+		// Stops the parse loop at its next line boundary.
+		cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		i.readerG.Wait()
+		close(done)
+	}()
+
+	deadline := time.NewTimer(streamTeardownGrace)
+	defer deadline.Stop()
+	tick := time.NewTicker(streamPokeInterval)
+	defer tick.Stop()
+	for {
+		// Release a reader parked in the blocking open. Cancellation
+		// cannot reach it; only a writer arriving can.
+		i.cfg.Stream.FIFO.Poke()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		case <-deadline.C:
+		case <-tick.C:
+			continue
+		}
+		break
+	}
+	_ = i.cfg.Stream.FIFO.Remove()
+}
+
+func init() {
+	var _ Instance = (*TmuxInstance)(nil)
+}

--- a/internal/runtime/instance_tmux_test.go
+++ b/internal/runtime/instance_tmux_test.go
@@ -1,0 +1,323 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// fixtureStream is a two-line stand-in for a claude-code session: init
+// then result. The real fixtures live in runtime/claudecode/testdata; the
+// instance only needs enough bytes to prove the pipe reaches the parser.
+const fixtureStream = `{"type":"system","subtype":"init","session_id":"sess-1","cwd":"/tmp","model":"claude-haiku-4-5"}
+{"type":"result","subtype":"success","is_error":false,"session_id":"sess-1","duration_ms":1200,"num_turns":1,"total_cost_usd":0.002,"usage":{"input_tokens":10,"output_tokens":3}}
+`
+
+// fakePanes records what a TmuxInstance asked tmux to do and, when
+// writeOnSpawn is set, plays a harness that writes to the FIFO.
+type fakePanes struct {
+	mu           sync.Mutex
+	command      string
+	env          map[string]string
+	killed       []string
+	keys         []string
+	captured     string
+	newPaneErr   error
+	writeOnSpawn string // path; empty means the harness writes nothing
+	payload      string
+	wrote        chan struct{}
+}
+
+func (f *fakePanes) NewPane(session, command, title string, envs map[string]string) (string, error) {
+	f.mu.Lock()
+	f.command = command
+	f.env = envs
+	f.mu.Unlock()
+	if f.newPaneErr != nil {
+		return "", f.newPaneErr
+	}
+	if f.writeOnSpawn != "" {
+		go func() {
+			w, err := os.OpenFile(f.writeOnSpawn, os.O_WRONLY, 0o600)
+			if err != nil {
+				return
+			}
+			_, _ = w.WriteString(f.payload)
+			_ = w.Close()
+			close(f.wrote)
+		}()
+	}
+	return "%7", nil
+}
+
+func (f *fakePanes) KillPane(paneID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.killed = append(f.killed, paneID)
+	return nil
+}
+
+func (f *fakePanes) SendKeys(paneID, text string, literal, enter bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.keys = append(f.keys, text)
+	return nil
+}
+
+func (f *fakePanes) CapturePane(paneID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.captured, nil
+}
+
+func newStreamedInstance(t *testing.T, payload string) (*TmuxInstance, *fakePanes) {
+	t.Helper()
+	fifo, err := NewFIFO(t.TempDir(), "acme/agent-0")
+	if err != nil {
+		t.Fatalf("new fifo: %v", err)
+	}
+	panes := &fakePanes{writeOnSpawn: fifo.Path(), payload: payload, wrote: make(chan struct{})}
+	parser, err := NewStreamParser(StreamFormatClaudeCodeJSON, StreamParserConfig{
+		AgentID:   "acme/agent-0",
+		Workspace: "acme",
+	})
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	inst := NewTmuxInstance(TmuxConfig{
+		Panes:       panes,
+		TmuxSession: "marvel-acme",
+		Title:       "agent-0",
+		Command:     "harness > " + fifo.Path(),
+		Stream:      &StreamSource{FIFO: fifo, Parser: parser},
+	})
+	return inst, panes
+}
+
+// drain collects events until the channel closes or the deadline passes.
+func drain(t *testing.T, ch <-chan events.Event, timeout time.Duration) []events.Event {
+	t.Helper()
+	var got []events.Event
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got = append(got, ev)
+		case <-deadline:
+			t.Fatalf("timed out after %d events", len(got))
+			return got
+		}
+	}
+}
+
+func TestTmuxInstanceStreamsFIFOThroughParser(t *testing.T) {
+	inst, panes := newStreamedInstance(t, fixtureStream)
+
+	if err := inst.Spawn(context.Background()); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if inst.State() != StateRunning {
+		t.Fatalf("state = %s, want running", inst.State())
+	}
+	if inst.PaneID() != "%7" {
+		t.Fatalf("pane id = %q, want %%7", inst.PaneID())
+	}
+
+	got := drain(t, inst.Events(), 5*time.Second)
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2: %+v", len(got), got)
+	}
+	if got[0].Event != events.KindSessionStarted {
+		t.Errorf("first event = %s, want session.started", got[0].Event)
+	}
+	if got[0].AgentID != "acme/agent-0" || got[0].Workspace != "acme" {
+		t.Errorf("identity not stamped: agent=%q workspace=%q", got[0].AgentID, got[0].Workspace)
+	}
+	ended, ok := got[1].Data.(events.SessionEndedData)
+	if !ok {
+		t.Fatalf("second event data = %T, want SessionEndedData", got[1].Data)
+	}
+	if ended.Metering == nil {
+		t.Fatal("expected metering on session.ended")
+	}
+	if ended.Metering.DurationMS != 1200 || ended.Metering.NumTurns != 1 {
+		t.Errorf("metering = %+v, want duration 1200 turns 1", ended.Metering)
+	}
+	// Sequence numbers must be monotonic across the whole stream.
+	if got[0].Seq != 1 || got[1].Seq != 2 {
+		t.Errorf("seq = %d,%d — want 1,2", got[0].Seq, got[1].Seq)
+	}
+
+	<-panes.wrote
+	if err := inst.Kill(context.Background()); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if inst.State() != StateStopped {
+		t.Fatalf("state = %s, want stopped", inst.State())
+	}
+	panes.mu.Lock()
+	killed := len(panes.killed)
+	panes.mu.Unlock()
+	if killed != 1 {
+		t.Errorf("killed %d panes, want 1", killed)
+	}
+}
+
+func TestTmuxInstanceKillReleasesReaderWithNoWriter(t *testing.T) {
+	// The failure this guards: a harness that never opens its end of the
+	// pipe leaves the reader parked in a blocking open, which no context
+	// cancellation can interrupt.
+	fifo, err := NewFIFO(t.TempDir(), "acme/never-writes")
+	if err != nil {
+		t.Fatalf("new fifo: %v", err)
+	}
+	parser, err := NewStreamParser(StreamFormatClaudeCodeJSON, StreamParserConfig{})
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	inst := NewTmuxInstance(TmuxConfig{
+		Panes:   &fakePanes{},
+		Command: "true",
+		Stream:  &StreamSource{FIFO: fifo, Parser: parser},
+	})
+	if err := inst.Spawn(context.Background()); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- inst.Kill(context.Background()) }()
+	select {
+	case kerr := <-done:
+		if kerr != nil {
+			t.Fatalf("kill: %v", kerr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Kill did not return: reader still parked on the pipe")
+	}
+
+	if _, statErr := os.Stat(fifo.Path()); !os.IsNotExist(statErr) {
+		t.Errorf("fifo survived teardown: %v", statErr)
+	}
+	if _, ok := <-inst.Events(); ok {
+		t.Error("expected a closed event channel after Kill")
+	}
+}
+
+func TestTmuxInstanceWithoutStreamClosesEventsImmediately(t *testing.T) {
+	panes := &fakePanes{captured: "pane text"}
+	inst := NewTmuxInstance(TmuxConfig{Panes: panes, Command: "sleep 300", Title: "shell"})
+
+	if err := inst.Spawn(context.Background()); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if got := drain(t, inst.Events(), 2*time.Second); len(got) != 0 {
+		t.Fatalf("got %d events from a pane-only instance, want 0", len(got))
+	}
+
+	if err := inst.Inject("hello"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	out, err := inst.Capture(context.Background())
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if string(out) != "pane text" {
+		t.Errorf("capture = %q, want %q", out, "pane text")
+	}
+	panes.mu.Lock()
+	keys := panes.keys
+	panes.mu.Unlock()
+	if len(keys) != 1 || keys[0] != "hello" {
+		t.Errorf("send-keys = %v, want [hello]", keys)
+	}
+}
+
+func TestTmuxInstanceSecondSpawnRefused(t *testing.T) {
+	inst := NewTmuxInstance(TmuxConfig{Panes: &fakePanes{}, Command: "true"})
+	if err := inst.Spawn(context.Background()); err != nil {
+		t.Fatalf("first spawn: %v", err)
+	}
+	if err := inst.Spawn(context.Background()); !errors.Is(err, ErrAlreadySpawned) {
+		t.Fatalf("second spawn error = %v, want ErrAlreadySpawned", err)
+	}
+}
+
+func TestTmuxInstanceSpawnFailureRetiresSink(t *testing.T) {
+	fifo, err := NewFIFO(t.TempDir(), "acme/doomed")
+	if err != nil {
+		t.Fatalf("new fifo: %v", err)
+	}
+	parser, err := NewStreamParser(StreamFormatClaudeCodeJSON, StreamParserConfig{})
+	if err != nil {
+		t.Fatalf("new parser: %v", err)
+	}
+	inst := NewTmuxInstance(TmuxConfig{
+		Panes:   &fakePanes{newPaneErr: errors.New("tmux said no")},
+		Command: "true",
+		Stream:  &StreamSource{FIFO: fifo, Parser: parser},
+	})
+	if err := inst.Spawn(context.Background()); err == nil {
+		t.Fatal("expected spawn to fail")
+	}
+	if inst.State() != StateFailed {
+		t.Errorf("state = %s, want failed", inst.State())
+	}
+	if _, statErr := os.Stat(fifo.Path()); !os.IsNotExist(statErr) {
+		t.Errorf("fifo survived a failed spawn: %v", statErr)
+	}
+}
+
+func TestFIFONameFlattensSessionKey(t *testing.T) {
+	dir := t.TempDir()
+	fifo, err := NewFIFO(dir, "acme/squad-worker-g1-0")
+	if err != nil {
+		t.Fatalf("new fifo: %v", err)
+	}
+	want := filepath.Join(dir, "acme-squad-worker-g1-0.ndjson")
+	if fifo.Path() != want {
+		t.Errorf("path = %q, want %q", fifo.Path(), want)
+	}
+	info, err := os.Stat(fifo.Path())
+	if err != nil {
+		t.Fatalf("stat fifo: %v", err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Errorf("mode = %v, want a named pipe", info.Mode())
+	}
+
+	// A leftover pipe from a crashed daemon must not block a fresh one.
+	if _, err := NewFIFO(dir, "acme/squad-worker-g1-0"); err != nil {
+		t.Fatalf("recreate over stale fifo: %v", err)
+	}
+}
+
+func TestTmuxInstanceDetachLeavesPaneAlone(t *testing.T) {
+	// The reap path's shape: the pane is already gone, so Detach must
+	// retire the stream without asking tmux to kill anything.
+	inst, panes := newStreamedInstance(t, fixtureStream)
+	if err := inst.Spawn(context.Background()); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	<-panes.wrote
+	drain(t, inst.Events(), 5*time.Second)
+
+	inst.Detach(context.Background())
+	if inst.State() != StateStopped {
+		t.Errorf("state = %s, want stopped", inst.State())
+	}
+	panes.mu.Lock()
+	killed := panes.killed
+	panes.mu.Unlock()
+	if len(killed) != 0 {
+		t.Errorf("Detach killed panes %v", killed)
+	}
+}

--- a/internal/runtime/stream.go
+++ b/internal/runtime/stream.go
@@ -1,0 +1,75 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/runtime/claudecode"
+	"github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// StreamFormat names the wire format a harness writes to the sink
+// marvel hands it. It is the only thing the session manager needs to
+// know about a harness's telemetry — the manager creates a sink,
+// passes the path down, and asks for a parser by format. Adding a
+// harness means adding a format and a parser constructor, not
+// teaching the manager anything new.
+type StreamFormat string
+
+// StreamFormatClaudeCodeJSON is the NDJSON stream Claude Code writes
+// under `--output-format stream-json --verbose`.
+const StreamFormatClaudeCodeJSON StreamFormat = "claude-code/stream-json"
+
+// StreamSpec is an adapter's report that it wired its harness's
+// structured output to Path. The adapter fills this in only when the
+// LaunchContext carried a StreamPath it could use.
+type StreamSpec struct {
+	Format StreamFormat
+	Path   string
+}
+
+// StreamCapable is the optional capability an Adapter implements when
+// it can redirect its harness's structured output to a marvel-provided
+// sink. The session manager calls SupportsStream before doing any
+// setup work, so adapters that never stream (and adapters asked to
+// launch an interactive session) cost nothing.
+//
+// SupportsStream is called with a LaunchContext whose StreamPath is
+// still empty: the answer must depend on the runtime and role, not on
+// the sink.
+type StreamCapable interface {
+	SupportsStream(ctx *LaunchContext) bool
+}
+
+// StreamParser consumes a harness's telemetry stream and emits
+// normalized events until r hits EOF or ctx is cancelled.
+type StreamParser interface {
+	Parse(ctx context.Context, r io.Reader, emit func(events.Event)) error
+}
+
+// StreamParserConfig is the marvel-side identity stamped onto every
+// event a parser emits. Clock is for tests; nil means wall clock.
+type StreamParserConfig struct {
+	AgentID   string
+	Workspace string
+	Clock     func() time.Time
+}
+
+// NewStreamParser returns the parser for a stream format. Unknown
+// formats are an error rather than a silent no-op — an adapter that
+// declares a format marvel cannot read is a wiring bug, and the
+// session should surface it instead of running blind.
+func NewStreamParser(format StreamFormat, cfg StreamParserConfig) (StreamParser, error) {
+	switch format {
+	case StreamFormatClaudeCodeJSON:
+		return claudecode.NewParser(claudecode.Config{
+			AgentID:   cfg.AgentID,
+			Workspace: cfg.Workspace,
+			Clock:     cfg.Clock,
+		}), nil
+	default:
+		return nil, fmt.Errorf("no parser for stream format %q", format)
+	}
+}

--- a/internal/session/bridge.go
+++ b/internal/session/bridge.go
@@ -1,0 +1,183 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/arcavenae/marvel/internal/events"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// coords is the session identity stamped onto every agent event. Held by
+// value so the bridge goroutine does not read an *api.Session that the
+// store may be mutating underneath it.
+type coords struct {
+	Workspace string
+	Team      string
+	Role      string
+	Session   string
+}
+
+// bridgeEvent lifts one normalized adapter event into a ring event. The
+// adapter vocabulary is rich and typed; the ring is a flat operator log,
+// so the payload becomes a one-line summary. Detail that operators need
+// verbatim (full tool inputs, message bodies) is not the ring's job — it
+// stays in the adapter stream for consumers that subscribe to it.
+func bridgeEvent(c coords, ev rtevents.Event) events.Event {
+	kind, sev := ringKind(ev)
+	return events.Event{
+		Timestamp: ev.TS,
+		Kind:      kind,
+		Severity:  sev,
+		Workspace: c.Workspace,
+		Team:      c.Team,
+		Role:      c.Role,
+		Session:   c.Session,
+		Message:   summarize(ev),
+	}
+}
+
+// ringKind maps an adapter kind to its ring kind and severity. An
+// unrecognized adapter kind still lands in the ring, tagged as an agent
+// error, rather than disappearing.
+func ringKind(ev rtevents.Event) (events.Kind, events.Severity) {
+	switch ev.Event {
+	case rtevents.KindSessionStarted:
+		return events.KindAgentSessionStarted, events.SeverityInfo
+	case rtevents.KindSessionEnded:
+		if d, ok := ev.Data.(rtevents.SessionEndedData); ok && d.ExitCode != 0 {
+			return events.KindAgentSessionEnded, events.SeverityWarning
+		}
+		return events.KindAgentSessionEnded, events.SeverityInfo
+	case rtevents.KindTurnStarted:
+		return events.KindAgentTurnStarted, events.SeverityInfo
+	case rtevents.KindTurnCompleted:
+		return events.KindAgentTurnCompleted, events.SeverityInfo
+	case rtevents.KindMessageDelta:
+		return events.KindAgentMessageDelta, events.SeverityInfo
+	case rtevents.KindMessageCompleted:
+		return events.KindAgentMessageCompleted, events.SeverityInfo
+	case rtevents.KindToolCall:
+		return events.KindAgentToolCall, events.SeverityInfo
+	case rtevents.KindToolResult:
+		if d, ok := ev.Data.(rtevents.ToolResultData); ok && !d.OK {
+			return events.KindAgentToolResult, events.SeverityWarning
+		}
+		return events.KindAgentToolResult, events.SeverityInfo
+	case rtevents.KindPermissionRequested:
+		return events.KindAgentPermissionRequested, events.SeverityWarning
+	case rtevents.KindAuthRequired:
+		return events.KindAgentAuthRequired, events.SeverityWarning
+	case rtevents.KindHealthHeartbeat:
+		return events.KindAgentHealthHeartbeat, events.SeverityInfo
+	case rtevents.KindError:
+		return events.KindAgentError, events.SeverityWarning
+	default:
+		return events.KindAgentError, events.SeverityWarning
+	}
+}
+
+// maxRingMessage keeps one event to one terminal line in `marvel events`.
+const maxRingMessage = 160
+
+func summarize(ev rtevents.Event) string {
+	switch d := ev.Data.(type) {
+	case rtevents.SessionStartedData:
+		s := "model " + orUnknown(d.Model)
+		if d.Cwd != "" {
+			s += " in " + d.Cwd
+		}
+		if d.Resumed {
+			s += " (resumed)"
+		}
+		return oneLine(s)
+	case rtevents.SessionEndedData:
+		return oneLine(sessionEndedSummary(d))
+	case rtevents.TurnData:
+		return oneLine(fmt.Sprintf("tokens in=%d out=%d", d.UsageDelta.In, d.UsageDelta.Out))
+	case rtevents.MessageData:
+		if d.Text == "" {
+			return oneLine(d.Role)
+		}
+		return oneLine(d.Role + ": " + d.Text)
+	case rtevents.ToolCallData:
+		s := d.Tool
+		if d.CallID != "" {
+			s += " (" + d.CallID + ")"
+		}
+		return oneLine(s)
+	case rtevents.ToolResultData:
+		verdict := "ok"
+		if !d.OK {
+			verdict = "error"
+		}
+		if d.CallID != "" {
+			return oneLine(verdict + " (" + d.CallID + ")")
+		}
+		return verdict
+	case rtevents.PermissionRequestedData:
+		s := d.Action
+		if d.Detail != "" {
+			s += ": " + d.Detail
+		}
+		return oneLine(s)
+	case rtevents.AuthRequiredData:
+		return oneLine(d.Hint)
+	case rtevents.HealthHeartbeatData:
+		return oneLine(d.State)
+	case rtevents.ErrorData:
+		if d.Message != "" {
+			return oneLine(d.Kind + ": " + d.Message)
+		}
+		return oneLine(d.Kind)
+	default:
+		return string(ev.Event)
+	}
+}
+
+// sessionEndedSummary is the metering line. Promoting the vendor's
+// accounting fields into the vocabulary is only useful if an operator can
+// see them, so cost, timings, and turn count go on the one line that
+// `marvel events` shows.
+func sessionEndedSummary(d rtevents.SessionEndedData) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit %d", d.ExitCode)
+	if d.Reason != "" {
+		fmt.Fprintf(&b, " (%s)", d.Reason)
+	}
+	fmt.Fprintf(&b, " tokens in=%d out=%d", d.Usage.In, d.Usage.Out)
+	if d.Usage.Cost != nil {
+		fmt.Fprintf(&b, " cost=$%.4f", *d.Usage.Cost)
+	}
+	if m := d.Metering; m != nil {
+		if m.NumTurns > 0 {
+			fmt.Fprintf(&b, " turns=%d", m.NumTurns)
+		}
+		if m.DurationMS > 0 {
+			fmt.Fprintf(&b, " dur=%dms", m.DurationMS)
+		}
+		if m.APIDurationMS > 0 {
+			fmt.Fprintf(&b, " api=%dms", m.APIDurationMS)
+		}
+		if m.TTFTMS > 0 {
+			fmt.Fprintf(&b, " ttft=%dms", m.TTFTMS)
+		}
+		if n := len(m.PermissionDenials); n > 0 {
+			fmt.Fprintf(&b, " denials=%d", n)
+		}
+	}
+	return b.String()
+}
+
+// oneLine collapses whitespace and clips to one terminal line. Adapter
+// payloads are already bounded at 64 KiB; the ring wants far less.
+func oneLine(s string) string {
+	return rtevents.TruncateString(strings.Join(strings.Fields(s), " "), maxRingMessage)
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/internal/session/bridge_test.go
+++ b/internal/session/bridge_test.go
@@ -1,0 +1,160 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/events"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+func testCoords() coords {
+	return coords{Workspace: "acme", Team: "squad", Role: "worker", Session: "acme/squad-worker-g1-0"}
+}
+
+func TestBridgeEventTagsSessionCoordinates(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindToolCall,
+		TS:    ts,
+		Data:  rtevents.ToolCallData{Tool: "Bash", CallID: "toolu_1"},
+	})
+
+	if got.Kind != events.KindAgentToolCall {
+		t.Errorf("kind = %q, want %q", got.Kind, events.KindAgentToolCall)
+	}
+	if got.Workspace != "acme" || got.Team != "squad" || got.Role != "worker" {
+		t.Errorf("coordinates lost: %+v", got)
+	}
+	if got.Session != "acme/squad-worker-g1-0" {
+		t.Errorf("session = %q", got.Session)
+	}
+	if !got.Timestamp.Equal(ts) {
+		t.Errorf("timestamp = %v, want %v", got.Timestamp, ts)
+	}
+	if got.Message != "Bash (toolu_1)" {
+		t.Errorf("message = %q", got.Message)
+	}
+}
+
+func TestBridgeEventKindAndSeverity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		in       rtevents.Event
+		wantKind events.Kind
+		wantSev  events.Severity
+	}{
+		{
+			name:     "session started",
+			in:       rtevents.Event{Event: rtevents.KindSessionStarted, Data: rtevents.SessionStartedData{Model: "haiku"}},
+			wantKind: events.KindAgentSessionStarted,
+			wantSev:  events.SeverityInfo,
+		},
+		{
+			name:     "clean exit is info",
+			in:       rtevents.Event{Event: rtevents.KindSessionEnded, Data: rtevents.SessionEndedData{ExitCode: 0}},
+			wantKind: events.KindAgentSessionEnded,
+			wantSev:  events.SeverityInfo,
+		},
+		{
+			name:     "nonzero exit is a warning",
+			in:       rtevents.Event{Event: rtevents.KindSessionEnded, Data: rtevents.SessionEndedData{ExitCode: 1}},
+			wantKind: events.KindAgentSessionEnded,
+			wantSev:  events.SeverityWarning,
+		},
+		{
+			name:     "failed tool result is a warning",
+			in:       rtevents.Event{Event: rtevents.KindToolResult, Data: rtevents.ToolResultData{CallID: "t1", OK: false}},
+			wantKind: events.KindAgentToolResult,
+			wantSev:  events.SeverityWarning,
+		},
+		{
+			name:     "permission request is a warning",
+			in:       rtevents.Event{Event: rtevents.KindPermissionRequested, Data: rtevents.PermissionRequestedData{Action: "tool.Bash"}},
+			wantKind: events.KindAgentPermissionRequested,
+			wantSev:  events.SeverityWarning,
+		},
+		{
+			name:     "auth required is a warning",
+			in:       rtevents.Event{Event: rtevents.KindAuthRequired, Data: rtevents.AuthRequiredData{Hint: "run /login"}},
+			wantKind: events.KindAgentAuthRequired,
+			wantSev:  events.SeverityWarning,
+		},
+		{
+			name:     "adapter error is a warning",
+			in:       rtevents.Event{Event: rtevents.KindError, Data: rtevents.ErrorData{Kind: rtevents.ErrKindParse, Message: "bad line"}},
+			wantKind: events.KindAgentError,
+			wantSev:  events.SeverityWarning,
+		},
+		{
+			name:     "unknown adapter kind still lands",
+			in:       rtevents.Event{Event: rtevents.Kind("message.thinking")},
+			wantKind: events.KindAgentError,
+			wantSev:  events.SeverityWarning,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bridgeEvent(testCoords(), tc.in)
+			if got.Kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", got.Kind, tc.wantKind)
+			}
+			if got.Severity != tc.wantSev {
+				t.Errorf("severity = %q, want %q", got.Severity, tc.wantSev)
+			}
+		})
+	}
+}
+
+func TestBridgeSessionEndedSummaryCarriesMetering(t *testing.T) {
+	t.Parallel()
+	cost := 0.0421
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindSessionEnded,
+		Data: rtevents.SessionEndedData{
+			Reason:   "end_turn",
+			ExitCode: 0,
+			Usage:    rtevents.Usage{In: 11368, Out: 13, Cost: &cost},
+			Metering: &rtevents.Metering{
+				DurationMS:        4816,
+				APIDurationMS:     6546,
+				TTFTMS:            4775,
+				NumTurns:          1,
+				PermissionDenials: []rtevents.PermissionDenial{{Tool: "Bash"}},
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"exit 0", "(end_turn)", "in=11368", "out=13", "cost=$0.0421",
+		"turns=1", "dur=4816ms", "api=6546ms", "ttft=4775ms", "denials=1",
+	} {
+		if !strings.Contains(got.Message, want) {
+			t.Errorf("message missing %q: %s", want, got.Message)
+		}
+	}
+}
+
+func TestBridgeMessageSummaryIsOneClippedLine(t *testing.T) {
+	t.Parallel()
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindMessageCompleted,
+		Data: rtevents.MessageData{
+			Role: "assistant",
+			Text: "first line\nsecond line " + strings.Repeat("x", 400),
+		},
+	})
+	if strings.ContainsAny(got.Message, "\n\r") {
+		t.Errorf("message spans lines: %q", got.Message)
+	}
+	if len(got.Message) > maxRingMessage {
+		t.Errorf("message is %d bytes, want at most %d", len(got.Message), maxRingMessage)
+	}
+	if !strings.HasPrefix(got.Message, "assistant: first line second line") {
+		t.Errorf("message lost its head: %q", got.Message)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -3,9 +3,13 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/arcavenae/marvel/internal/api"
@@ -25,11 +29,32 @@ type Manager struct {
 	// and callers that don't care about the event stream don't need to
 	// wire a ring.
 	Events events.Emitter
+	// StreamDir holds the per-session FIFOs marvel reads agent output
+	// from. Defaults to a per-process temp directory; the pipes carry no
+	// content at rest, so there is nothing to preserve across restarts.
+	StreamDir string
+
+	// instances tracks the live Instance per session key. Sessions
+	// adopted from a previous daemon have no entry: their pane predates
+	// this process, so marvel supervises them without observing them.
+	imu       sync.Mutex
+	instances map[string]*runtime.TmuxInstance
 }
 
 // NewManager creates a session manager with the default runtime adapter registry.
 func NewManager(store *api.Store, driver *tmux.Driver) *Manager {
-	return &Manager{store: store, driver: driver, adapters: runtime.NewRegistry()}
+	return &Manager{
+		store:     store,
+		driver:    driver,
+		adapters:  runtime.NewRegistry(),
+		StreamDir: defaultStreamDir(),
+		instances: make(map[string]*runtime.TmuxInstance),
+	}
+}
+
+// defaultStreamDir keeps one daemon's pipes away from another's.
+func defaultStreamDir() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("marvel-streams-%d", os.Getpid()))
 }
 
 // marvelSessionPrefix is the tmux session name prefix marvel owns.
@@ -153,20 +178,29 @@ func (m *Manager) Create(sess *api.Session) error {
 		return fmt.Errorf("ensure tmux session %s: %w", tmuxSess, err)
 	}
 
-	cmd, envs := m.resolveRuntime(sess)
+	plan := m.planLaunch(sess)
 
 	// Log the exact command line we're about to exec so post-hoc
 	// debugging has the argv — operators otherwise had to guess what
 	// tmux new-window was actually running when a pane died quickly.
 	// See ArcavenAE/marvel#9.
-	log.Printf("session %s exec: %s", sess.Key(), cmd)
+	log.Printf("session %s exec: %s", sess.Key(), plan.command)
 
-	paneID, err := m.driver.NewPane(tmuxSess, cmd, sess.Name, envs)
-	if err != nil {
+	inst := runtime.NewTmuxInstance(runtime.TmuxConfig{
+		Panes:       m.driver,
+		TmuxSession: tmuxSess,
+		Title:       sess.Name,
+		Command:     plan.command,
+		Env:         plan.env,
+		Stream:      plan.stream,
+	})
+	if err := inst.Spawn(context.Background()); err != nil {
 		// Clean up store on failure.
 		_ = m.store.DeleteSession(sess.Key())
 		return fmt.Errorf("create pane for %s: %w", sess.Key(), err)
 	}
+	paneID := inst.PaneID()
+	m.attachInstance(sess, inst)
 
 	// Commit PaneID + State=Running to the live session under the store
 	// lock. Also update the caller's *api.Session so returning pointers
@@ -193,9 +227,21 @@ func (m *Manager) Create(sess *api.Session) error {
 	return nil
 }
 
-// resolveRuntime uses the adapter registry when team/role context is available,
-// falling back to direct command construction for ad-hoc sessions.
-func (m *Manager) resolveRuntime(sess *api.Session) (string, map[string]string) {
+// launchPlan is what one session needs to come up: the shell command,
+// its environment, and (when the adapter wired one) the stream marvel
+// reads its output from.
+type launchPlan struct {
+	command string
+	env     map[string]string
+	stream  *runtime.StreamSource
+}
+
+// planLaunch uses the adapter registry when team/role context is
+// available, falling back to direct command construction for ad-hoc
+// sessions. When the resolved adapter declares it can redirect its
+// harness's structured output, planLaunch creates the sink first and
+// hands the path down; the adapter reports back whether it used it.
+func (m *Manager) planLaunch(sess *api.Session) launchPlan {
 	// Look up team and role for full adapter context. Store returns
 	// snapshots — taking addresses of these locals is safe because the
 	// adapter is read-only and the LaunchContext doesn't outlive this
@@ -203,7 +249,7 @@ func (m *Manager) resolveRuntime(sess *api.Session) (string, map[string]string) 
 	team, teamErr := m.store.GetTeam(fmt.Sprintf("%s/%s", sess.Workspace, sess.Team))
 	if teamErr != nil {
 		// Ad-hoc session or team not found — use direct command.
-		return m.directCommand(sess)
+		return m.directPlan(sess)
 	}
 
 	var role *api.Role
@@ -214,33 +260,172 @@ func (m *Manager) resolveRuntime(sess *api.Session) (string, map[string]string) 
 		}
 	}
 	if role == nil {
-		return m.directCommand(sess)
+		return m.directPlan(sess)
 	}
 
 	ws, wsErr := m.store.GetWorkspace(sess.Workspace)
 	if wsErr != nil {
-		return m.directCommand(sess)
+		return m.directPlan(sess)
 	}
 
 	adapter := m.adapters.Resolve(sess.Runtime.Name)
-	result, err := adapter.Prepare(&runtime.LaunchContext{
+	lctx := &runtime.LaunchContext{
 		Session:    sess,
 		Role:       role,
 		Team:       &team,
 		Workspace:  &ws,
 		SocketPath: m.SocketPath,
-	})
+	}
+
+	// Ask before building: an adapter that never streams (or one asked
+	// for an interactive launch) should cost no filesystem work.
+	fifo := m.openSink(sess, adapter, lctx)
+	if fifo != nil {
+		lctx.StreamPath = fifo.Path()
+	}
+
+	result, err := adapter.Prepare(lctx)
 	if err != nil {
 		log.Printf("adapter %s prepare failed for %s, falling back: %v", adapter.Name(), sess.Key(), err)
-		return m.directCommand(sess)
+		discardSink(fifo)
+		return m.directPlan(sess)
+	}
+
+	plan := launchPlan{command: result.Command, env: result.Env}
+	switch {
+	case result.Stream != nil && fifo != nil:
+		parser, perr := runtime.NewStreamParser(result.Stream.Format, runtime.StreamParserConfig{
+			AgentID:   sess.Key(),
+			Workspace: sess.Workspace,
+		})
+		if perr != nil {
+			// The adapter named a format marvel cannot read. The session
+			// still runs; it just runs unobserved, which is better than
+			// refusing to launch over a telemetry gap.
+			log.Printf("session %s: %v — launching without stream", sess.Key(), perr)
+			discardSink(fifo)
+			break
+		}
+		plan.stream = &runtime.StreamSource{FIFO: fifo, Parser: parser}
+		log.Printf("session %s streaming %s via %s", sess.Key(), result.Stream.Format, result.Stream.Path)
+	case fifo != nil:
+		// Sink offered, adapter declined it.
+		discardSink(fifo)
 	}
 
 	log.Printf("session %s using %s adapter", sess.Key(), adapter.Name())
-	return result.Command, result.Env
+	return plan
 }
 
-// directCommand builds the command string directly — the pre-adapter path
+// openSink creates the FIFO for a stream-capable adapter, or returns nil.
+// A sink that cannot be created is logged and skipped: an unobservable
+// session is still a working session.
+func (m *Manager) openSink(sess *api.Session, adapter runtime.Adapter, lctx *runtime.LaunchContext) *runtime.FIFO {
+	streamer, ok := adapter.(runtime.StreamCapable)
+	if !ok || m.StreamDir == "" || !streamer.SupportsStream(lctx) {
+		return nil
+	}
+	fifo, err := runtime.NewFIFO(m.StreamDir, sess.Key())
+	if err != nil {
+		log.Printf("session %s: no stream sink: %v", sess.Key(), err)
+		return nil
+	}
+	return fifo
+}
+
+func discardSink(fifo *runtime.FIFO) {
+	if fifo == nil {
+		return
+	}
+	if err := fifo.Remove(); err != nil {
+		log.Printf("warning: %v", err)
+	}
+}
+
+// attachInstance records the instance and drains its event stream into
+// the ring. The goroutine ends when the harness's output ends, so its
+// lifetime is the session's.
+func (m *Manager) attachInstance(sess *api.Session, inst *runtime.TmuxInstance) {
+	m.imu.Lock()
+	m.instances[sess.Key()] = inst
+	m.imu.Unlock()
+
+	c := coords{
+		Workspace: sess.Workspace,
+		Team:      sess.Team,
+		Role:      sess.Role,
+		Session:   sess.Key(),
+	}
+	go func() {
+		for ev := range inst.Events() {
+			events.Emit(m.Events, bridgeEvent(c, ev))
+		}
+	}()
+}
+
+// takeInstance removes and returns the instance for a session key.
+func (m *Manager) takeInstance(key string) *runtime.TmuxInstance {
+	m.imu.Lock()
+	defer m.imu.Unlock()
+	inst := m.instances[key]
+	delete(m.instances, key)
+	return inst
+}
+
+// Instance returns the live instance for a session key, or nil when
+// marvel has none (an adopted pane, or a session created before this
+// daemon started).
+func (m *Manager) Instance(key string) runtime.Instance {
+	m.imu.Lock()
+	defer m.imu.Unlock()
+	inst, ok := m.instances[key]
+	if !ok {
+		return nil
+	}
+	return inst
+}
+
+// instanceTeardownGrace bounds how long session teardown waits on a
+// harness stream that has not noticed it is finished.
+const instanceTeardownGrace = 3 * time.Second
+
+// retireInstance kills the instance for a key if marvel holds one, and
+// reports whether it did. The pane-kill error is logged rather than
+// returned: by the time a session is being retired the pane is often
+// already gone, and that is not a failure of the retirement.
+func (m *Manager) retireInstance(key string) bool {
+	inst := m.takeInstance(key)
+	if inst == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), instanceTeardownGrace)
+	defer cancel()
+	if err := inst.Kill(ctx); err != nil {
+		log.Printf("warning: retire instance %s: %v", key, err)
+	}
+	return true
+}
+
+// detachInstance retires the stream of a session whose pane already
+// vanished. Distinct from retireInstance so the reap path does not log a
+// kill-pane failure for a pane it knows is gone.
+func (m *Manager) detachInstance(key string) {
+	inst := m.takeInstance(key)
+	if inst == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), instanceTeardownGrace)
+	defer cancel()
+	inst.Detach(ctx)
+}
+
+// directPlan builds the command string directly — the pre-adapter path
 // used for ad-hoc sessions or when the adapter can't resolve.
+func (m *Manager) directPlan(sess *api.Session) launchPlan {
+	cmd, env := m.directCommand(sess)
+	return launchPlan{command: cmd, env: env}
+}
+
 func (m *Manager) directCommand(sess *api.Session) (string, map[string]string) {
 	cmd := sess.Runtime.Command
 	for _, arg := range sess.Runtime.Args {
@@ -263,7 +448,10 @@ func (m *Manager) Delete(key string) error {
 		return err
 	}
 
-	if sess.PaneID != "" {
+	// Prefer the instance: it kills the pane and retires the stream in
+	// one step. Sessions with no instance (adopted panes) fall back to
+	// the driver.
+	if !m.retireInstance(key) && sess.PaneID != "" {
 		if err := m.driver.KillPane(sess.PaneID); err != nil {
 			log.Printf("warning: kill pane %s: %v", sess.PaneID, err)
 		}
@@ -324,6 +512,10 @@ func (m *Manager) ReapDead() []ReapedSession {
 		if !m.driver.HasPane(sess.PaneID) {
 			log.Printf("session %s: pane %s gone, marking crashed", sess.Key(), sess.PaneID)
 			lostPane := sess.PaneID
+			// The harness is gone; its stream has nothing left to say.
+			// Detaching here keeps a crashed session from leaving a pipe
+			// and a parked reader behind.
+			m.detachInstance(sess.Key())
 			m.clearStaleCrashed(sessions, sess.Workspace, sess.Team, sess.Role, sess.Key())
 			if err := m.store.UpdateSession(sess.Key(), func(live *api.Session) error {
 				live.State = api.SessionCrashed

--- a/internal/session/stream_test.go
+++ b/internal/session/stream_test.go
@@ -1,0 +1,247 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	"github.com/arcavenae/marvel/internal/tmux"
+)
+
+// streamFixture is the claude-code stream-json a stub harness replays. It
+// mirrors the shape of runtime/claudecode/testdata/hello.ndjson, trimmed
+// to the three lines this test asserts on.
+const streamFixture = `{"type":"system","subtype":"init","session_id":"fixture-1","cwd":"/tmp","model":"claude-haiku-4-5"}
+{"type":"assistant","session_id":"fixture-1","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+{"type":"result","subtype":"success","is_error":false,"session_id":"fixture-1","duration_ms":4816,"duration_api_ms":6546,"ttft_ms":4775,"num_turns":1,"stop_reason":"end_turn","total_cost_usd":0.0421,"usage":{"input_tokens":11368,"output_tokens":13},"modelUsage":{"claude-haiku-4-5":{"inputTokens":522,"outputTokens":13,"costUSD":0.000587}},"permission_denials":[]}
+`
+
+// stubHarness writes a canned stream-json transcript to stdout and exits,
+// which is all a stream-capable adapter's command needs to do. It ignores
+// the flags the adapter appends, exactly as a harness would accept them.
+func stubHarness(t *testing.T, transcript string) string {
+	t.Helper()
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "transcript.ndjson")
+	if err := os.WriteFile(fixture, []byte(transcript), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	script := filepath.Join(dir, "stub-claude")
+	body := fmt.Sprintf("#!/bin/sh\nexec cat %q\n", fixture)
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return script
+}
+
+// headlessTeam registers the workspace and team a stream-capable session
+// needs: the adapter path only runs with full team/role context.
+func headlessTeam(t *testing.T, store *api.Store, ws, command, prompt string) {
+	t.Helper()
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	rt := api.Runtime{
+		Name:    "claude",
+		Command: command,
+		Mode:    api.RuntimeModeHeadless,
+		Prompt:  prompt,
+	}
+	err := store.CreateTeam(&api.Team{
+		Name:      "squad",
+		Workspace: ws,
+		Roles:     []api.Role{{Name: "worker", Replicas: 1, Runtime: rt}},
+	})
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+}
+
+// waitForKind polls the ring until an event of kind k arrives.
+func waitForKind(t *testing.T, ring *events.Ring, k events.Kind, timeout time.Duration) events.Event {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		snap := ring.Snapshot(events.Filter{Kind: k}, 0)
+		if len(snap) > 0 {
+			return snap[len(snap)-1]
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("no %s event within %s; ring holds %+v", k, timeout, ring.Snapshot(events.Filter{}, 0))
+	return events.Event{}
+}
+
+// TestManagerStreamsAgentEventsIntoRing is the wiring test for the whole
+// byte path: adapter redirect → FIFO → parser → instance → ring.
+func TestManagerStreamsAgentEventsIntoRing(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	ring := events.NewRing(200)
+	mgr := NewManager(store, driver)
+	mgr.Events = ring
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-stream-wiring"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+	headlessTeam(t, store, ws, stubHarness(t, streamFixture), "say ok")
+
+	sess := &api.Session{
+		Name:      "squad-worker-g1-0",
+		Workspace: ws,
+		Team:      "squad",
+		Role:      "worker",
+		Runtime: api.Runtime{
+			Name:    "claude",
+			Command: stubHarness(t, streamFixture),
+			Mode:    api.RuntimeModeHeadless,
+			Prompt:  "say ok",
+		},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if mgr.Instance(sess.Key()) == nil {
+		t.Fatal("expected the manager to hold an instance for a stream-capable session")
+	}
+
+	started := waitForKind(t, ring, events.KindAgentSessionStarted, 15*time.Second)
+	if started.Workspace != ws || started.Team != "squad" || started.Role != "worker" {
+		t.Errorf("agent event not tagged with role coordinates: %+v", started)
+	}
+	if started.Session != sess.Key() {
+		t.Errorf("session = %q, want %q", started.Session, sess.Key())
+	}
+
+	ended := waitForKind(t, ring, events.KindAgentSessionEnded, 15*time.Second)
+	for _, want := range []string{"exit 0", "turns=1", "dur=4816ms", "cost=$0.0421"} {
+		if !strings.Contains(ended.Message, want) {
+			t.Errorf("session.ended message missing %q: %s", want, ended.Message)
+		}
+	}
+
+	// The assistant message rides the same path.
+	msg := waitForKind(t, ring, events.KindAgentMessageCompleted, 5*time.Second)
+	if msg.Message != "assistant: ok" {
+		t.Errorf("message = %q, want %q", msg.Message, "assistant: ok")
+	}
+
+	// Deleting the session retires the pipe with it.
+	fifoPath := filepath.Join(mgr.StreamDir, ws+"-"+sess.Name+".ndjson")
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	if _, statErr := os.Stat(fifoPath); !os.IsNotExist(statErr) {
+		t.Errorf("fifo %s survived session deletion: %v", fifoPath, statErr)
+	}
+	if mgr.Instance(sess.Key()) != nil {
+		t.Error("instance outlived its session")
+	}
+}
+
+// TestManagerInteractiveSessionHasNoStream pins the no-regression half:
+// an interactive runtime still launches, still gets an instance, and gets
+// no pipe and no agent events.
+func TestManagerInteractiveSessionHasNoStream(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	ring := events.NewRing(50)
+	mgr := NewManager(store, driver)
+	mgr.Events = ring
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-stream-interactive"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	sess := &api.Session{
+		Name:      "shell-0",
+		Workspace: ws,
+		Team:      "util",
+		Role:      "shell",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"60"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if sess.State != api.SessionRunning || sess.PaneID == "" {
+		t.Fatalf("session did not come up: state=%s pane=%q", sess.State, sess.PaneID)
+	}
+	if _, statErr := os.Stat(mgr.StreamDir); statErr == nil {
+		t.Error("a non-streaming session created a stream directory")
+	}
+	if len(ring.Snapshot(events.Filter{Kind: events.KindAgentSessionStarted}, 0)) != 0 {
+		t.Error("a non-streaming session produced agent events")
+	}
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+}
+
+// TestManagerSmokeRealClaude runs one short live request through the
+// whole path. Off by default: it costs money, needs local auth, and its
+// latency is the provider's, not ours. MARVEL_SMOKE=1 opts in.
+func TestManagerSmokeRealClaude(t *testing.T) {
+	if os.Getenv("MARVEL_SMOKE") != "1" {
+		t.Skip("set MARVEL_SMOKE=1 to run the live claude smoke")
+	}
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	ring := events.NewRing(500)
+	mgr := NewManager(store, driver)
+	mgr.Events = ring
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-stream-smoke"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+	headlessTeam(t, store, ws, "claude", "Reply with the single word: ok")
+
+	sess := &api.Session{
+		Name:      "squad-worker-g1-0",
+		Workspace: ws,
+		Team:      "squad",
+		Role:      "worker",
+		Runtime: api.Runtime{
+			Name:    "claude",
+			Command: "claude",
+			Args:    []string{"--model", "haiku"},
+			Mode:    api.RuntimeModeHeadless,
+			Prompt:  "Reply with the single word: ok",
+		},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	waitForKind(t, ring, events.KindAgentSessionStarted, 60*time.Second)
+	ended := waitForKind(t, ring, events.KindAgentSessionEnded, 120*time.Second)
+	t.Logf("live session.ended: %s", ended.Message)
+	if !strings.Contains(ended.Message, "exit 0") {
+		t.Errorf("live run did not exit clean: %s", ended.Message)
+	}
+	if !strings.Contains(ended.Message, "dur=") {
+		t.Errorf("live run reported no metering: %s", ended.Message)
+	}
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+}


### PR DESCRIPTION
Marvel could spawn agents and watch their panes, but it could not see what they did. This makes it an observer: `marvel events` now shows tool calls, messages, and per-session cost and timing as they happen, which is the signal every downstream feature (readycheck, work routing, convergence metrics, fleet cost accounting) has been waiting on.

The pieces already existed and were imported by nothing. Commit 6626c95 landed the twelve-kind event vocabulary, the `Instance` interface, and a fixture-tested claude-code stream-json parser; `internal/session/manager.go` still launched panes the old way. This connects them via the cheapest byte path available.

## The byte path

A role whose runtime is `mode = "headless"` runs `claude --print --output-format stream-json --verbose '<prompt>'` with stdout redirected into a per-session FIFO. A daemon goroutine parses the NDJSON and the events land in the ring tagged with workspace, team, role, and session. No shim, no control mode, no substrate decision: whichever substrate wins later, the byte path still terminates in `Instance.Events()`.

See `examples/claude-headless.toml` for the manifest shape.

## Design decisions

- **`TmuxInstance` lives in package `runtime`** over a four-method `PaneController` interface, so `runtime` gains no tmux dependency and tests drive an instance without a tmux server.
- **Every session goes through `Instance`, stream or not.** Spawn for a pane-only session is the same `NewPane` call it always was, so interactive launches are byte-identical; Inject, Capture, Kill, and State now have one path instead of two.
- **The adapter declares the byte path, not the manager.** `SupportsStream` gates sink creation; the adapter reports back a `StreamSpec` naming the format it wired. The manager only creates a pipe and asks for a parser by format. Adding a harness means adding a format plus a parser constructor, not teaching the manager anything.
- **Headless is a runtime field (`mode` + `prompt`), not inference from args.** Interactive is the zero value, so existing manifests are unchanged, and mode is per-role so one team can mix both.
- **Failure to observe never fails a launch.** An unwritable sink, an unknown stream format, or an adapter that declines the sink all degrade to an unobserved session with a log line.
- **Ring kinds are the twelve adapter kinds prefixed `agent.`**, keeping the control-plane namespace (what marvel did to a session) apart from the agent namespace (what the agent did). The events RPC and CLI filters needed no changes.

## Metering

The parser read six accounting fields off every result line and dropped them, which was right when nothing consumed them. `SessionEndedData` now carries a nil-able `Metering` sibling with duration_ms, duration_api_ms, ttft_ms, ttft_stream_ms, num_turns, both prompt-cache token counts, per-model usage keyed by model id, and permission denials. Nil means the harness reported none of it, distinguishable from reporting zeros. Additive under schema_version 1: v1 kinds are untouched and an event without metering serializes exactly as before. `mapping.md` divergence 5 is resolved and now names what is still dropped and why.

## The one sharp edge

A reader parked in a blocking FIFO open cannot be cancelled, only released by a writer arriving, and there is no way to observe the moment it parks. Teardown retries the release on a 20ms tick under a 2s ceiling. One poke is not enough; a test pins that.

## Cost of merge

Additive to the manifest schema and the ring vocabulary. Interactive forestage, claude, and generic launches produce the identical command string and no pipe, covered by a test that offers each adapter a sink and asserts it ignores it.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), and `go test -count=1 ./...` all pass; the touched packages also pass under `-race`. New tests cover the FIFO-to-parser path with a fake pane controller (stream, no-writer teardown, pane-only instance, double spawn, failed spawn, detach), the adapter headless/interactive matrix, the bridge kind and severity table, the metering summary, and a manager-level wiring test that runs a stub harness through real tmux and asserts tagged events in the ring.

A live `claude -p --model haiku` smoke sits behind `MARVEL_SMOKE=1`. It passed locally in 4.1s:

```
live session.ended: exit 0 (end_turn) tokens in=10 out=46 cost=$0.0478 turns=1 dur=3671ms api=6016ms ttft=3498ms
```

## Deferred

- The daemon's inject and capture RPCs still call the tmux driver directly. They expose per-call flags (literal, enter, line ranges) the `Instance` contract does not carry; narrowing them to `Instance` would lose capability, so that seam waits for a second Instance implementation.
- Sessions adopted from a previous daemon get no stream: their pane predates the process, so marvel supervises them without observing them.
- `turn.*` and `message.delta` still have no source in `-p` mode (`mapping.md` divergences 1 and 3). The bridge maps them, so they will appear the moment `--include-partial-messages` support lands.

Refs: aae-orc-x2qj. Covers the claude-code slice of aae-orc-pw1l's first cut.