### PR TITLE
docs: de-drift front-door docs to match the shipped binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ agent sessions across tmux panes — local or remote via switchboard.
 
 ## Build / Run / Test
 
-Requires: Go 1.22+, `just`, `tmux`.
+Requires: Go 1.25+, `just`, `tmux`.
 
 ```sh
 just build          # go build ./cmd/...
@@ -157,69 +157,63 @@ name = "review-squad"
 
 ## Architecture
 
+This tree reflects the packages that exist today. Several resource
+types in the model above (Pack, Volume, Gateway, Schedule) are not yet
+implemented as their own packages; they live in the model, not the code.
+
 ```
-cmd/marvel/                 Entry point
+cmd/marvel/                 CLI entry point (cobra commands) + table rendering
 
 internal/
-  api/                      Resource types (Workspace, Session, Team, etc.)
-    types.go                Core type definitions
-    manifest.go             TOML manifest parsing and validation
+  api/                      Resource types + store
+    types.go                Core type definitions (Workspace, Session, Team, ...)
+    manifest.go             Manifest parsing and validation (TOML + YAML)
+    store.go                Resource store interface
+    bolt.go                 BoltDB-backed store (persistence across restarts)
 
-  scheduler/                Session scheduling and placement
-    scheduler.go            Assign sessions to hosts/panes
-    reconciler.go           Desired state → actual state reconciliation loop
+  daemon/                   Daemon process + RPC surface
+    daemon.go               Reconciliation loop, lifecycle, adopt-on-restart
+    sshserver.go            SSH transport for remote clients
+    metrics.go              Daemon-level metrics
 
-  runtime/                  BYOA console runtime management
-    runtime.go              Runtime interface (start, stop, attach)
-    forestage.go            forestage-specific runtime
-    claude.go               Bare claude CLI runtime
-    generic.go              Generic runtime (any CLI that accepts stdin)
+  team/                     Team (deployment) controller
+    controller.go           Reconcile desired replicas vs actual; shifts, health
 
   session/                  Session lifecycle
     manager.go              Create, monitor, restart, teardown sessions
-    health.go               Healthcheck and readycheck execution
-    state.go                Session state machine (pending → running → done)
+    bridge.go               Stream bridge between agent runtime and daemon
+
+  runtime/                  BYOA console runtime adapters (the adapter framework)
+    adapter.go              Runtime adapter interface + Instance layer
+    forestage.go            forestage adapter (deep integration)
+    claude.go               Bare claude CLI adapter
+    generic.go              Generic adapter (any CLI that accepts stdin)
+    instance.go             Running-instance abstraction
+    instance_tmux.go        tmux-backed instance
+    fifo.go                 Named-pipe cooperative stream
+    stream.go               Stream observation
+    claudecode/             Claude Code stream-json parser + event mapping
+    codex/                  Codex adapter notes
+    opencode/               opencode adapter notes
+    events/                 Runtime → director event envelopes
 
   tmux/                     tmux substrate
-    session.go              tmux session/pane CRUD
-    attach.go               Attach/detach/send-keys
-    capture.go              Capture pane output for monitoring
+    driver.go               tmux session/pane CRUD, send-keys, capture-pane
 
-  team/                     Team (deployment) controller
-    controller.go           Reconcile desired replicas vs actual
-    scaling.go              Scale up/down, shift changes
-    rolling.go              Rolling updates (new config without downtime)
+  procstat/                 Per-session process stats (CPU%, RSS) via pid-subtree sampler
+    procstat.go, proc.go, ps.go
+    read_darwin.go, read_linux.go, read_other.go   platform samplers
 
-  pack/                     Content pack management
-    registry.go             Pack discovery, versioning
-    router.go               Artifact type → filesystem routing
-    scope.go                4-scope resolution (repo → shared → user → system)
-    manifest.go             pack.yaml parsing
-
-  volume/                   Workspace storage
-    worktree.go             Git worktree create/cleanup
-    sandbox.go              Temp directory lifecycle
-    shared.go               Shared volume management
-
-  config/                   Configuration resolution
-    resolve.go              Merge chain: defaults → pack → scope → override
-    vault.go                Auth delegation references
-
-  gateway/                  External access
-    switchboard.go          Switchboard integration (remote tmux)
-    director.go             Director integration (inter-agent comms)
-
-  otel/                     Observability
-    collector.go            OTEL span/metric collection from sessions
-    export.go               Forward to self-hosted collector or stdout
-    metrics.go              Marvel-level metrics (sessions, restarts, health)
-
-  protocol/                 Agent communication protocol
-    message.go              Message types (task, result, heartbeat, signal)
-    transport.go            Transport interface
-    fifo.go                 Named pipe transport (local, simple)
-    tmux.go                 tmux send-keys transport (fallback)
-    switchboard.go          Switchboard relay transport (remote)
+  events/                   Structured event ring (control-plane + agent.* events)
+  keys/                     SSH client keypair management (~/.marvel/keys)
+  knownhosts/               Host-key trust (~/.marvel/known_hosts)
+  config/                   Named-cluster config (~/.marvel/config.yaml)
+  paths/                    ~/.marvel/ path resolution
+  logbuf/                   In-memory log buffer
+  rlog/                     Structured request/run logging
+  otel/                     Observability metrics
+  upgrade/                  Self-upgrade (Homebrew / direct binary)
+  simulator/                Context-pressure simulation for testing without real agents
 ```
 
 ## Process Management
@@ -301,9 +295,20 @@ marvel kill <session-key>                            # kill a session
 marvel stop                                          # stop daemon, agents keep running (restart adopts them)
 marvel stop --teardown                               # stop daemon, delete sessions, kill panes
 marvel daemon                                        # start the daemon (foreground)
+marvel events                                        # structured event ring (control-plane + agent.*)
+marvel capture <session-key>                         # capture a session's pane content
+marvel inject <session-key> <keys>                   # send keystrokes to a pane
+marvel config <add-cluster|list|current|use-cluster|remove-cluster>   # named-cluster config
+marvel keys <generate|show|list|trust|authorize|authorized|revoke|doctor>  # SSH client keys
+marvel version                                       # print version and channel
+marvel upgrade                                        # self-upgrade
 
 # future: logs, attach, exec, drain, top, pack management
 ```
+
+The `logs` verb is not yet implemented; `marvel events` covers the agent
+observability surface today (see charter B8 for the runtime adapter
+framework that feeds it).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ agent sessions across tmux panes.
 ### Option 1: Homebrew
 
 ```bash
-brew install ArcavenAE/tap/marvel
+brew tap arcavenae/tap                # one-time (Homebrew >= 6.0 needs the tap trusted first)
+brew install arcavenae/tap/marvel
 ```
 
 The tap's `marvel` formula currently tracks the latest alpha release. A dedicated stable formula will be added when the first `v*` release ships.
@@ -124,19 +125,60 @@ name = "review-squad"
 ## CLI
 
 ```sh
+# Daemon and manifests
 marvel daemon                                        # start the daemon
-marvel work <manifest.toml>                          # load manifest
-marvel get sessions                                  # list sessions (-w for watch mode)
+marvel work <manifest.toml|.yaml>                    # load manifest, reconcile desired state
+marvel stop                                          # stop daemon, detach (agents keep running, adopted on restart)
+marvel stop --teardown                               # stop daemon and end every agent
+
+# Inspect
+marvel get sessions                                  # list sessions (-w for watch mode); shows CPU% and RSS per session
 marvel get teams                                     # list teams and roles
 marvel get workspaces                                # list workspaces
+marvel get endpoints                                 # list endpoints
 marvel describe session <key>                        # session details
+marvel events                                        # recent session/team state-transition events (incl. agent.* for observed runtimes)
+
+# Lifecycle
 marvel scale <ws/team> --role <r> --replicas N       # scale a role
 marvel shift <ws/team> [--role <r>]                  # rolling shift
 marvel run <cmd> [args...] --role <r>                # one-off session
-marvel kill <session-key>                            # kill a session
-marvel stop                                          # stop daemon, leave agents running
-marvel stop --teardown                               # stop daemon, end every agent
+marvel kill <session-key>                            # kill a session (alias: delete session)
+marvel delete <resource> <key>                       # delete a session, team, or workspace
+
+# Session interaction
+marvel capture <session-key>                         # capture a session's pane content
+marvel inject <session-key> <keys>                   # send keystrokes to a pane (executive privilege)
+
+# Remote daemons (named clusters)
+marvel config add-cluster <name> ...                 # add or update a cluster
+marvel config list                                   # list configured clusters
+marvel config current                                # show the current cluster
+marvel config use-cluster <name>                     # switch the current cluster
+marvel config remove-cluster <name>                  # remove a cluster
+
+# SSH keys (client auth to a daemon)
+marvel keys generate                                 # generate a client keypair
+marvel keys show                                     # print a client public key to share with a daemon admin
+marvel keys list                                     # list local client keypairs
+marvel keys trust <cluster>                          # record a cluster's host key in known_hosts
+marvel keys authorize <pubkey>                       # authorize a client's key on this daemon
+marvel keys authorized                               # list clients authorized on this daemon
+marvel keys revoke <fingerprint>                     # revoke a client
+marvel keys doctor                                   # audit (and optionally fix) permissions under ~/.marvel/
+
+# Version and self-upgrade
+marvel version                                       # print version and channel
+marvel upgrade                                        # upgrade to the latest release
 ```
+
+`stop` defaults to detach: the daemon checkpoints state and exits while
+agents keep running; the next `marvel daemon` adopts the live panes. Use
+`--teardown` to end every agent and leave the machine clean.
+
+`marvel events` includes `agent.*` events (session start/end with cost and
+timing, tool calls, permission prompts) for runtimes marvel can observe,
+today a headless `stream-json` launch (see `examples/claude-headless.toml`).
 
 ## Shifts
 
@@ -221,6 +263,6 @@ the agent is — it manages the process lifecycle.
 
 ## Requirements
 
-- Go 1.22+
+- Go 1.25+
 - tmux
 - `just` (command runner)

--- a/charter.md
+++ b/charter.md
@@ -208,17 +208,6 @@ receivers that dispatch work to running agent teams? Or CLI-only access for now,
 deferring external API until there's a concrete use case?
 Cross-ref: orchestrator F2.
 
-### F9: Runtime Adapter Framework
-`internal/runtime/` is empty. This is the integration keystone — marvel can't
-launch real BYOA workloads without runtime adapters. Three needed: forestage
-(deep: persona, heartbeat, cooperative stream), bare-claude (medium: env vars,
-capture-pane fallback), generic-stdin (minimal: any CLI, capture-pane only).
-Each adapter constructs the execution environment (settings.local.json, env vars,
-volumes) and exposes capabilities (spawn, kill, inject, capture).
-Blocks: forestage+marvel integration, permission model, everything downstream.
-Depends on: aae-orc-vpq (tmux driver decision).
-kos node: question-runtime-adapter.
-
 ### F10: Permission Model — Environment Construction + Internal Capabilities
 Two complementary layers: (1) environment construction — marvel writes
 settings.local.json with the role's CC permission mode, controls filesystem

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -322,7 +322,7 @@ marvel upgrade
 
 If installed via Homebrew:
 ```
-Installed via Homebrew. Running: brew upgrade ArcavenAE/tap/marvel
+Installed via Homebrew. Running: brew upgrade arcavenae/tap/marvel
 ```
 
 If installed as a direct binary:

--- a/docs/spec/design.md
+++ b/docs/spec/design.md
@@ -1,5 +1,21 @@
 # Marvel MVP — Software Design (IEEE 1016, abbreviated)
 
+> **SUPERSEDED: frozen MVP probe record.** This document describes the
+> original MVP design and no longer matches the shipped binary. It is kept
+> as the probe record, not as current documentation. For current behavior
+> see [charter.md](../../charter.md), [CLAUDE.md](../../CLAUDE.md), and
+> [user-guide.md](../user-guide.md).
+>
+> Stale claims to be aware of:
+> - The CLI verb is `marvel work`, not `marvel apply`.
+> - There are not just two built-in runtimes (`top`/`shell`). Runtimes are
+>   a runtime-adapter framework: forestage, bare-claude, generic-stdin,
+>   plus Claude Code stream observation (`internal/runtime/`).
+> - The API/store is no longer in-memory only; a BoltDB store persists
+>   state across restarts (`internal/api/bolt.go`).
+> - The daemon exposes an SSH transport for remote clients, not only a
+>   local unix socket.
+
 Probe: marvel-mvp-probe | Confidence: frontier
 
 ## 1. Architecture Overview

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -1,5 +1,21 @@
 # Marvel MVP — Software Requirements (ISO/IEC/IEEE 29148, abbreviated)
 
+> **SUPERSEDED: frozen MVP probe record.** This document describes the
+> original MVP probe and no longer matches the shipped binary. It is kept
+> as the probe record, not as current documentation. For current behavior
+> see [charter.md](../../charter.md), [README.md](../../README.md), and
+> [user-guide.md](../user-guide.md).
+>
+> Stale claims to be aware of:
+> - The CLI verb is `marvel work`, not `marvel apply`.
+> - Manifests are accepted in TOML **and** YAML, not TOML-only.
+> - State is no longer purely in-memory; a BoltDB store persists state
+>   across daemon restarts (`internal/api/bolt.go`), and `stop` detaches
+>   and adopts live panes on restart.
+> - The runtime set is a runtime-adapter framework (forestage, claude,
+>   generic, plus Claude Code stream observation), not the `top`/`shell`
+>   demo runtimes.
+
 Probe: marvel-mvp-probe | Confidence: frontier
 
 ## 1. Purpose

--- a/docs/spec/stories.md
+++ b/docs/spec/stories.md
@@ -1,5 +1,19 @@
 # Marvel MVP — Epics, Stories, Tasks
 
+> **SUPERSEDED: frozen MVP probe record.** This document tracks the
+> original MVP epics and stories and no longer matches the shipped binary.
+> It is kept as the probe record, not as current documentation. For current
+> behavior see [charter.md](../../charter.md), [README.md](../../README.md),
+> and [user-guide.md](../user-guide.md).
+>
+> Stale claims to be aware of:
+> - Stories reference `marvel apply`; the shipped verb is `marvel work`.
+> - The runtime set has grown from the `top`/`shell` demo runtimes to a
+>   runtime-adapter framework (forestage, claude, generic, plus Claude Code
+>   stream observation).
+> - State persistence (BoltDB), SSH remote clients, named clusters, keys,
+>   events, capture, and inject all shipped after this MVP scope was frozen.
+
 Probe: marvel-mvp-probe | Confidence: frontier
 
 ## Epic 1: Resource Model

--- a/internal/runtime/claudecode/doc.go
+++ b/internal/runtime/claudecode/doc.go
@@ -8,7 +8,7 @@
 // internal/runtime/events. Process spawning, tmux attachment, stdin
 // injection, and the full Instance implementation are follow-on work.
 //
-// The mapping sketch in docs/design/director-envelope-and-adapter-events.md
+// The mapping sketch in aae-orc/docs/design/director-envelope-and-adapter-events.md
 // §3.3 was verified against real fixtures from claude 2.1.201 (see
 // testdata/); divergences from that sketch are documented in
 // mapping.md alongside this package.

--- a/internal/runtime/claudecode/mapping.md
+++ b/internal/runtime/claudecode/mapping.md
@@ -3,7 +3,7 @@
 Verified against real fixtures from claude 2.1.201 on 2026-07-05
 (see `testdata/hello.ndjson` and `testdata/tool_call.ndjson`). Compares
 what claude actually emits with the sketch in
-`docs/design/director-envelope-and-adapter-events.md` §3.3.
+`aae-orc/docs/design/director-envelope-and-adapter-events.md` §3.3.
 
 ## Verified mappings
 

--- a/internal/runtime/codex/doc.go
+++ b/internal/runtime/codex/doc.go
@@ -5,7 +5,7 @@
 //
 // Not implemented in this slice — this file exists so the intended
 // shape is visible in the package tree. Design mapping (per
-// docs/design/director-envelope-and-adapter-events.md §3.3):
+// aae-orc/docs/design/director-envelope-and-adapter-events.md §3.3):
 //
 //   - task/turn items          → turn.started / turn.completed
 //   - exec command begin/end   → tool.call / tool.result

--- a/internal/runtime/events/events.go
+++ b/internal/runtime/events/events.go
@@ -6,7 +6,7 @@
 // ring). Both use the type name Event; callers importing both should alias.
 //
 // The vocabulary and frame are specified in
-// docs/design/director-envelope-and-adapter-events.md §3.
+// aae-orc/docs/design/director-envelope-and-adapter-events.md §3.
 // The pointer-not-payload discipline (64 KiB soft cap on data summaries)
 // is inherited from the co-designed director envelope; large content
 // should be summarized here and referenced by pointer in a lifted envelope.
@@ -60,7 +60,7 @@ const (
 )
 
 // Event is the normalized frame every adapter emits. JSON tags match the
-// spec in docs/design/director-envelope-and-adapter-events.md §3.1
+// spec in aae-orc/docs/design/director-envelope-and-adapter-events.md §3.1
 // verbatim (snake_case). `data` is a typed value per Kind; callers
 // serialize with encoding/json in the usual way.
 type Event struct {

--- a/internal/runtime/opencode/doc.go
+++ b/internal/runtime/opencode/doc.go
@@ -3,7 +3,7 @@
 //
 // Not implemented in this slice — this file exists so the intended
 // shape is visible in the package tree. Design mapping (per
-// docs/design/director-envelope-and-adapter-events.md §3.3):
+// aae-orc/docs/design/director-envelope-and-adapter-events.md §3.3):
 //
 //   - session lifecycle endpoints  → session.started / session.ended
 //   - SSE message parts            → message.delta / message.completed

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -105,7 +105,7 @@ func upgradeViaHomebrew(channel string) error {
 	// threedoors-a, jr-a), route the alpha channel back here.
 	// The `channel` parameter is retained for that future fork.
 	_ = channel
-	formula := "ArcavenAE/tap/marvel"
+	formula := "arcavenae/tap/marvel"
 
 	fmt.Printf("Installed via Homebrew. Running: brew upgrade %s\n", formula)
 


### PR DESCRIPTION
Several of marvel's front-door docs still describe the frozen MVP shape rather than the wave-1 binary, so anyone who reads them before running the tool gets a wrong mental model (wrong install command, a CLI that looks smaller than it is, an architecture tree of directories that no longer exist).

This is docs-and-comments de-drift only. No behavior changes beyond lowercasing the Homebrew formula string so the binary's upgrade output matches the docs.

**What changed**

- **README** — `brew install` lowercased to `arcavenae/tap/marvel` with a one-time tap-trust line (aae-orc-2d9y, marvel slice). CLI section grown from a subset to the full verb set (events, capture, inject, config, keys, version, upgrade, delete) and annotated with the wave-1 surfaces: per-session CPU%/RSS columns in `get sessions`, detach-vs-teardown `stop` behavior, and headless stream observation for `agent.*` events. Go requirement `1.22+` corrected to `1.25+` (go.mod is 1.25.4).
- **admin-guide + internal/upgrade** — `brew upgrade` string lowercased in both the doc and the binary that prints it, so they agree.
- **CLAUDE.md** — architecture tree rewritten to the packages that exist. Dropped `scheduler/`, `pack/`, `volume/`, `gateway/`, `protocol/`, and the stale `session/{health,state}.go`, `tmux/{session,attach,capture}.go`, `otel/{collector,export}.go`. Added `procstat/`, the `runtime/` adapter framework and its subpackages (`claudecode`, `codex`, `opencode`, `events`), plus `daemon/`, `events/`, `keys/`, `knownhosts/`, `config/`, `paths/`, `logbuf/`, `rlog/`, `upgrade/`, `simulator/`. CLI list and Go version updated to match.
- **docs/spec/{requirements,design,stories}** — added a SUPERSEDED banner to each pointing at charter.md and the current docs, with the top stale claims per file (`apply` vs `work`, TOML-only, in-memory-only, `top`/`shell` runtimes). The MVP probe record is otherwise left intact.
- **charter.md** — removed the stale duplicate F9 body (`internal/runtime/ is empty`), kept the `RESOLVED -> B8` pointer. Minimal hand-edit; the subrepo renderer is not generalized yet (aae-orc-gezz).
- **internal/runtime/{claudecode,codex,opencode,events}** — the `director-envelope-and-adapter-events.md` references now carry the `aae-orc/` prefix, marking them orchestrator-level docs (the file lives in the orc, not marvel).

**Verification**: `go build ./...`, `go vet ./...`, `go test ./...` all pass; `kos validate` reports 0 parse errors (no node files changed).