### PR TITLE
harvest: kxce substrate ratified — tmux for terminal, shim for supervision

### DIFF
--- a/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
+++ b/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
@@ -7,23 +7,41 @@ content: |
   check, capture output — all via tmux. Simple, observable, already
   works on every Unix system the platform targets.
 
-  This is settled by use (MVP functional with tmux driver) but is
-  under active reconsideration via `aae-orc-kxce` ("T3b: marvel
-  substrate-of-tmux frontier question — lift B2 from substrate to
-  frontier"). The reconsideration question: is tmux the *right*
-  substrate, or just the *first* substrate? Alternative substrates
-  worth probing include containerd/podman pods, kubectl exec,
-  systemd-nspawn, plain process supervision without tmux.
+  RESOLVED 2026-07-31 (aae-orc-kxce, operator-ratified; decision brief
+  `_kos/probes/decision-brief-kxce-substrate.md`). The reconsideration
+  ("is tmux the right substrate or just the first?") split into two
+  questions, and measurement answered both:
 
-  Until the reconsideration question is probed and resolved, B2
-  remains bedrock — it's load-bearing for the current implementation
-  and changing it touches every adapter.
+  - **tmux is load-bearing for terminal emulation and the human view,
+    and NOT load-bearing for process lifetime or supervision.**
+    finding-004 signal 4b: a shim-in-pane survives the loss of its tmux
+    pane with the child alive and controllable. finding-004 signal 5h:
+    a PTY is necessary but not sufficient — something must answer
+    DA1-class terminal queries, and that responder is open-ended per
+    harness and version, so anything that drops tmux inherits being a
+    terminal emulator. So candidates that replace tmux and own the PTY
+    directly are rejected.
+  - **Observation does not require owning the PTY.** finding-005: a FIFO
+    carries a harness's own bytes at 100% coverage, zero loss, ANSI
+    intact; the attachment path does not constrain the substrate.
 
-  Evidence: MVP functional with tmux driver across sessions 008-026.
+  Committed direction: tmux stays as the terminal-emulation and
+  human-view layer; a Go shim-in-pane (finding-004 candidate e) is the
+  process-supervision and injectable-tee layer, phased in when a
+  concrete need pulls it (race-free inject, exact per-child PID/metrics,
+  or one-process structured+rendered output). The near-term demo runs
+  on the FIFO attachment path on plain tmux with no shim. In-house
+  terminal multiplexing is graveyarded; a Go control-mode client is
+  reference-only (tmux-cmc is Rust, unusable from Go without breaking
+  the zero-CGo posture).
+
+  Evidence: MVP functional with tmux driver across sessions 008-026;
+  finding-004 (shim-in-pane spike), finding-005 (stream-attachment
+  probe), both 2026-07-31.
 edges:
   - target: aae-orc::elem-tmux-cmc
     type: derives
-    note: "substrate realized on tmux; tmux-cmc is the planned control-mode client (roadmap M7 adoption)"
+    note: "substrate realized on tmux; tmux-cmc is reference-only for any control-mode client marvel writes (Rust crate, unusable from Go without breaking zero-CGo), not a planned dependency unless question-marvel-language-fit resolves toward Rust (kxce, 2026-07-31)"
   - target: aae-orc::val-composability
     type: implements
 provenance:

--- a/_kos/nodes/frontier/question-stream-attachment.yaml
+++ b/_kos/nodes/frontier/question-stream-attachment.yaml
@@ -63,6 +63,18 @@ content: |
   attachment path does not constrain the substrate. finding-004 (shim-in-pane
   spike, on spike/shim-in-pane) filled the shim-PTY-tee row that finding-005
   left blank. Both are addressed to the substrate decision aae-orc-kxce.
+
+  DIRECTION SETTLED 2026-07-31 (aae-orc-kxce ratified; decision brief
+  `_kos/probes/decision-brief-kxce-substrate.md`). Per-harness attachment
+  bindings: Claude Code / Codex / OpenCode structured stream over FIFO;
+  Crush FIFO text + sqlite for tokens pending a socket probe; Gemini CLI
+  structured stream over FIFO, gated on re-verifying #9009/#13561;
+  unknown/non-cooperative harness capture-pane history scrape with a
+  high-water mark; adopted session pipe-pane. This node stays frontier
+  because the bindings for Codex/OpenCode/Crush are not yet exercised
+  against live model turns and Gemini is graph-only; the DIRECTION is
+  fixed, per-harness VERIFICATION remains. Cursor is out of scope
+  (SpaceX acquisition; not a target harness).
 edges:
   - target: elem-runtime-adapter-framework
     type: derives

--- a/_kos/probes/decision-brief-kxce-substrate.md
+++ b/_kos/probes/decision-brief-kxce-substrate.md
@@ -1,0 +1,115 @@
+# Decision brief: marvel substrate + attachment (aae-orc-kxce)
+
+**Status:** RATIFIED by the operator 2026-07-31 (marvel roadmap-triage session).
+Recorded as a marvel-native decision (ratified brief + bedrock node
+`elem-tmux-session-substrate`); marvel records load-bearing decisions in the
+charter/graph rather than a separate ADR dir, which the orc uses.
+**Date:** 2026-07-31
+**Inputs:** finding-004-shim-in-pane-spike (aae-orc-e35c),
+finding-005-stream-attachment-probe (aae-orc-3cp). Both measured on kinu,
+macOS 26.5.2, tmux 3.7b, against Claude Code 2.1.220, codex 0.146.0,
+crush 0.67.0, opencode 1.18.5.
+**Decides:** aae-orc-kxce (substrate) and the attachment half of
+question-stream-attachment.
+
+## The question, split
+
+kxce asked "is tmux the right substrate, or just the first?" The two findings
+show the question was really two:
+
+1. **Attachment** — how marvel observes agent output. Answered by measurement,
+   and the answer does not constrain the substrate.
+2. **Substrate** — what owns the terminal and the process. Answered by a
+   boundary: tmux is load-bearing for terminal emulation and the human view,
+   and not load-bearing for process lifetime or supervision.
+
+## What the evidence settled
+
+**Observation never required owning the PTY.** The old stream-attachment node
+ruled out the PTY-owned strategy on the circular ground that tmux was bedrock.
+finding-005 measured the paths instead: a FIFO carries a harness's own bytes at
+100% coverage, zero loss, ANSI intact, at 2.6M lines/s, and every target
+harness except Crush emits newline-delimited JSON in headless mode. The FIFO
+path already shipped in wave 1 (PR #76, the Instance stitch), and a real
+claude -p stream-json turn was observed end to end through it. So marvel can
+already observe agents today, on the current tmux substrate, with no shim.
+
+**The shim-in-pane candidate has no blocker.** finding-004 built candidate (e)
+and passed all five pre-declared signals: byte-identical render of real claude
+and codex under the shim, 25 MB/s stream tee with zero loss, race-free
+concurrent inject with no send-keys, survival of pane loss with the child alive
+and controllable, and the TTY-hang falsification. Cost: 25-40µs added round
+trip, one dependency (creack/pty), and two named bounds (drain grace, lag
+ceiling) that want surfacing before real agents ride it.
+
+**Replacing tmux and owning the PTY directly (candidates b/g) has direct
+evidence against it, cheaply.** Signal 5h: a shim running headless with pipe
+stdio gives its child a real TTY, and a terminal-capability query still hangs,
+because a PTY is necessary but not sufficient. Something must answer DA1-class
+queries, and that responder is open-ended per harness and per harness version
+(tmux 3.7b answers DA1, declines the kitty query). Whoever drops tmux takes on
+being a terminal emulator, and the falsification set is where that cost turns
+from arguable to visible. finding-065's Cursor TTY-hang is the same class in
+the wild.
+
+**In-house multiplexing (candidate d) wins nothing the shim does not** and
+costs more; recommend graveyarding it with this reasoning.
+
+## Recommendation
+
+**Substrate: tmux stays, as the terminal-emulation and human-view layer.
+Adopt the shim-in-pane (candidate e) as the process-supervision and
+injectable-tee layer, phased in when a concrete need pulls it — not now.**
+
+The near-term demo does not need the shim: the FIFO attachment path already
+observes agents on plain tmux. The shim earns its place when one of these
+becomes load-bearing:
+
+- race-free inject into a live agent (the send-keys race, aae-orc-qtkj, is the
+  cheap stopgap until then),
+- exact per-child process metrics and lifetime control without pane-pid
+  guessing (it hands marvel the child PID directly, wait4/rusage for free),
+- carrying structured and rendered output from one process (the one path that
+  could beat the FIFO; unmeasured until the shim lands in the daemon).
+
+So: keep (a) status quo for the demo, commit to (e) as the direction, reject
+(b)/(g), graveyard (d), and keep (f) Go-control-mode as a reference-only note
+(tmux-cmc is Rust; unusable from Go without breaking the zero-CGo posture).
+
+**Attachment binding, per harness** (none requires owning the PTY):
+
+| Harness | Binding | Confidence |
+|---|---|---|
+| Claude Code | structured stream over FIFO (`-p --output-format stream-json`) | verified end to end |
+| Codex | structured stream over FIFO (`codex exec --json`) | flags + TTY verified; live turn not exercised |
+| OpenCode | structured stream, server-first (`serve`+`attach`, or `run --format json`) | flags verified |
+| Crush | FIFO capture of opaque text + `.crush/crush.db` for tokens; probe its unix socket first | no structured mode exists |
+| Gemini CLI | structured stream over FIFO, GATED on re-verifying #9009/#13561 | graph-only, not installed |
+| unknown / non-cooperative | `capture-pane` history scrape, `-S -` + high-water mark, publish ceiling = visible_rows × poll_hz | measured capacity rule |
+| adopted (marvel didn't launch it) | `pipe-pane` (byte-faithful, strip CR) | measured |
+
+## If ratified, the harvest
+
+- Promote the boundary ("tmux: terminal yes, supervision no") into marvel
+  bedrock; supersede the circular PTY rule-out in question-stream-attachment
+  with the measured result.
+- Write an ADR (substrate direction) since this is a load-bearing architecture
+  decision, per ADR-007's "ratified, written decision" bar.
+- Close kxce; open a follow-on for the shim's daemon integration (promote the
+  spike's cmd/marvel-shim from draft PR #75 when a puller need lands).
+- Two shipped-code bugs finding-005 flagged become tickets: `Driver.CapturePane`
+  is the visible-region variant (0.48% coverage) where the generic adapter
+  wants `CapturePaneRange` + high-water mark; nothing sets `history-limit`, so
+  scrapes inherit the 2000-line default (20% coverage vs 100%).
+
+## What would change the read
+
+A Linux re-run (B13: PTY and signal behavior differ) and one shim inject
+exercised under the alternate screen + bracketed paste, neither of which the
+spike covered.
+
+(Cursor CLI verification was named as a gap in finding-004; it is void as of
+this ratification. Cursor is out of the target set entirely following its
+SpaceX acquisition, so its TTY-hang, cited as the falsification class, remains
+a valid mechanism example but is no longer a harness marvel supports. The
+target set is Claude Code, Codex, Gemini CLI, Crush, OpenCode.)


### PR DESCRIPTION
Records the operator-ratified substrate decision so the graph stops carrying "tmux is under active reconsideration" now that the reconsideration is settled by measurement.

The question split into two and both came back clean. tmux is load-bearing for terminal emulation and the human view, not for process lifetime (finding-004 signal 4b: a shim-in-pane survives losing its pane with the child alive and controllable). Observation does not require owning the PTY (finding-005: FIFO carries the harness's own bytes at 100%, zero loss). Dropping tmux and owning the PTY directly is rejected because a PTY is necessary but not sufficient (signal 5h: a capability query still hangs; whoever drops tmux inherits being the terminal-query responder, open-ended per harness and version).

Direction: tmux stays as the terminal/human-view layer; a Go shim-in-pane is the supervision + injectable-tee layer, phased in on concrete need; in-house multiplexing graveyarded; tmux-cmc reference-only (Rust vs Go zero-CGo posture). Cursor dropped from the target set (SpaceX acquisition).

Nodes only (bedrock substrate node + stream-attachment direction note + the ratified decision brief); no code changes.