### PR TITLE
feat(marvel): re-exec daemon in place to self-update without stopping agents

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -257,7 +257,42 @@ Examples:
 		"cap total disk usage across --log-file and archives in MiB (0 disables)")
 
 	cmd.AddCommand(daemonLogsCmd())
+	cmd.AddCommand(daemonReexecCmd())
 	return cmd
+}
+
+// daemonReexecCmd tells the running daemon to re-exec its own process
+// image in place, adopting the live panes so agents keep running. This
+// is the "self-update via exec" step: it adopts a binary that is already
+// installed on disk. It is distinct from `marvel upgrade` (which fetches
+// and installs a new binary) so the two compose rather than collide;
+// `marvel upgrade --daemon` runs both in sequence.
+func daemonReexecCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reexec",
+		Short: "Re-exec the running daemon in place to adopt a freshly installed binary",
+		Long: `Re-exec the running daemon in place.
+
+The daemon checkpoints its state, releases its state file, and replaces
+its own process image (same PID) with a fresh exec of the marvel binary
+at its current path. Every agent keeps running in its tmux pane; the new
+process re-opens the same state file, re-binds the same socket, and
+adopts those panes.
+
+Use this after installing a new binary out of band. To fetch, install,
+and adopt in one step, use 'marvel upgrade --daemon'.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := send(daemon.Request{Method: "reexec"})
+			if err != nil {
+				return err
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+			fmt.Println("marvel daemon re-executing in place; agents keep running")
+			return nil
+		},
+	}
 }
 
 // daemonLogsCmd — fetch the daemon's recent log lines over mrvl://.
@@ -799,18 +834,40 @@ func versionCmd() *cobra.Command {
 
 func upgradeCmd() *cobra.Command {
 	var targetVersion string
+	var reexecDaemon bool
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade marvel to the latest version",
 		Long: `Upgrade marvel to the latest version.
 
 If installed via Homebrew, delegates to brew upgrade.
-Otherwise downloads the latest release from GitHub.`,
+Otherwise downloads the latest release from GitHub.
+
+This replaces the binary on disk. A running daemon keeps executing the
+old image until it restarts. Pass --daemon to tell the running daemon to
+re-exec in place after the install, adopting its live panes so agents
+keep running (see 'marvel daemon reexec').`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return upgrade.Run(channel, targetVersion)
+			if err := upgrade.Run(channel, targetVersion); err != nil {
+				return err
+			}
+			if !reexecDaemon {
+				return nil
+			}
+			resp, err := send(daemon.Request{Method: "reexec"})
+			if err != nil {
+				return fmt.Errorf("binary upgraded, but sending daemon re-exec failed: %w", err)
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("binary upgraded, but daemon re-exec failed: %s", resp.Error)
+			}
+			fmt.Println("running daemon re-executing in place; agents keep running")
+			return nil
 		},
 	}
 	cmd.Flags().StringVar(&targetVersion, "version", "", "target version (default: latest)")
+	cmd.Flags().BoolVar(&reexecDaemon, "daemon", false,
+		"after installing, tell the running daemon to re-exec in place so it adopts the new binary without stopping agents")
 	return cmd
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -108,6 +108,11 @@ type Daemon struct {
 	// from writing the same line every interval for the life of the
 	// daemon.
 	metricsWarn sync.Once
+
+	// reexec replaces the process image. Defaults to syscall.Exec; tests
+	// override it to assert the pre-exec contract without actually
+	// handing the process over.
+	reexec func(argv0 string, argv []string, envv []string) error
 }
 
 // Options configures optional daemon behavior. Zero value disables
@@ -184,6 +189,7 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 		pidFile:  opts.PidFile,
 		logs:     buf,
 		events:   evRing,
+		reexec:   syscall.Exec,
 	}, nil
 }
 
@@ -326,6 +332,56 @@ func (d *Daemon) Stop() { d.shutdown(true) }
 // (aae-orc-zk5r). No-op when persistence is disabled.
 func (d *Daemon) Checkpoint() error { return d.store.Checkpoint() }
 
+// Reexec replaces the running daemon's process image with a fresh exec
+// of the marvel binary at its current path, argv and environment
+// preserved, without stopping any managed agent. It detaches first
+// (the reconciler and listeners stop, durable state is checkpointed,
+// the bolt file is released, every pane is left running), then execs.
+// The successor process re-opens the same bolt, re-binds the same
+// socket, and adopts the live panes via AdoptOrKill.
+//
+// This is the in-place self-update path (aae-orc-zk5r). It composes with
+// `marvel upgrade`, which fetches and installs the new binary on disk:
+// upgrade replaces the bytes, Reexec adopts them. The two stay distinct
+// verbs so "install a new binary" and "adopt it without dropping agents"
+// never fight over one name.
+//
+// The binary path resolves before the detach, so a resolution failure
+// leaves the daemon serving. On success syscall.Exec does not return.
+// Reexec returns an error only if the exec syscall itself fails, which
+// happens after the detach: the daemon has stopped serving but its
+// agents survive, and a fresh daemon start adopts them.
+func (d *Daemon) Reexec() error {
+	exe, err := selfExecPath()
+	if err != nil {
+		return err
+	}
+	// Detach checkpoints durable state, releases the bolt file, and stops
+	// serving without touching a pane. Its own doc names this as the first
+	// half of self-update.
+	d.Detach()
+	return d.reexec(exe, os.Args, os.Environ())
+}
+
+// selfExecPath resolves the path to the running marvel binary for
+// re-exec. Linux reports /proc/self/exe; after `marvel upgrade` replaces
+// the binary in place the kernel appends " (deleted)" to the old inode's
+// symlink target, so trim it; the replacement lives at the cleaned path.
+func selfExecPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve marvel binary path: %w", err)
+	}
+	return cleanExecPath(exe), nil
+}
+
+// cleanExecPath strips the " (deleted)" suffix the Linux kernel appends
+// to /proc/self/exe once the running binary's inode is replaced. The
+// replacement binary lives at the cleaned path.
+func cleanExecPath(p string) string {
+	return strings.TrimSuffix(p, " (deleted)")
+}
+
 func (d *Daemon) shutdown(teardown bool) {
 	if d.cancel != nil {
 		d.cancel()
@@ -457,6 +513,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleCapture(req.Params)
 	case "stop":
 		return d.handleStop(req.Params)
+	case "reexec":
+		return d.handleReexec()
 	case "logs":
 		return d.handleLogs(req.Params)
 	case "events":
@@ -983,6 +1041,33 @@ func (d *Daemon) handleStop(params json.RawMessage) Response {
 		os.Exit(0)
 	}()
 	result, _ := json.Marshal(map[string]string{"status": "stopping", "mode": mode})
+	return Response{Result: result}
+}
+
+// handleReexec tells the running daemon to replace its own process image
+// with a fresh exec of the marvel binary, adopting the live panes rather
+// than stopping the agents. The CLI (`marvel daemon reexec`, or
+// `marvel upgrade --daemon` after the binary is installed) calls this;
+// the daemon must exec itself because the CLI cannot exec the daemon's
+// process.
+func (d *Daemon) handleReexec() Response {
+	// Resolve the binary here so an unresolvable path is reported to the
+	// client without detaching; better to keep serving than to stop and
+	// then find nothing to exec.
+	exe, err := selfExecPath()
+	if err != nil {
+		return Response{Error: err.Error()}
+	}
+	// Re-exec off the request goroutine so this response reaches the
+	// client before the process image is replaced, mirroring handleStop.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		if rerr := d.Reexec(); rerr != nil {
+			log.Printf("reexec failed after detach: %v; start a fresh daemon to adopt the running panes", rerr)
+			os.Exit(1)
+		}
+	}()
+	result, _ := json.Marshal(map[string]string{"status": "reexec", "binary": exe})
 	return Response{Result: result}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
 )
 
 func skipIfNoTmux(t *testing.T) {
@@ -840,5 +842,282 @@ func TestStopModeDefaultsToDetach(t *testing.T) {
 	}
 	if _, _, err := stopMode(json.RawMessage(`{`)); err == nil {
 		t.Error("expected an error on malformed params")
+	}
+}
+
+// reexecManifest is the one-worker fixture the self-update tests apply,
+// matching the shape startTestDaemon and the detach test use.
+func reexecManifest(ws string) string {
+	return `
+[workspace]
+name = "` + ws + `"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+
+    [team.role.runtime]
+    command = "sleep"
+    args = ["300"]
+`
+}
+
+// TestReexecCheckpointsStateBeforeExec is contract (a): the durable
+// record is flushed and the bolt file released before the exec syscall
+// is attempted, and the agent's pane is left running for the successor.
+// A fake exec stands in for syscall.Exec and inspects the on-disk state
+// at the instant the real exec would fire.
+func TestReexecCheckpointsStateBeforeExec(t *testing.T) {
+	skipIfNoTmux(t)
+
+	boltPath := filepath.Join(t.TempDir(), "marvel.bolt")
+	ws := "test-reexec-checkpoint"
+
+	d, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	sock := filepath.Join(os.TempDir(), "marvel-test-reexec-cp.sock")
+	if err := d.Start(sock); err != nil {
+		t.Fatalf("start daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = d.driver.KillSession("marvel-" + ws)
+		_ = os.Remove(sock)
+	})
+
+	resp, err := SendRequest(sock, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(reexecManifest(ws))}),
+	})
+	if err != nil || resp.Error != "" {
+		t.Fatalf("apply: err=%v resp.Error=%q", err, resp.Error)
+	}
+	time.Sleep(600 * time.Millisecond)
+
+	before := d.store.ListSessionsByTeam(ws, "squad")
+	if len(before) != 1 {
+		t.Fatalf("expected 1 session before reexec, got %d", len(before))
+	}
+	sessKey := before[0].Key()
+	paneID := before[0].PaneID
+	if paneID == "" {
+		t.Fatal("expected the session to have a pane before reexec")
+	}
+
+	var (
+		execCalled bool
+		gotArgv0   string
+		gotArgv    []string
+	)
+	d.reexec = func(argv0 string, argv []string, _ []string) error {
+		execCalled = true
+		gotArgv0 = argv0
+		gotArgv = argv
+
+		// The bolt file must be released before exec, or the successor's
+		// OpenBolt would block on bbolt's exclusive lock.
+		if bp := d.store.BoltPath(); bp != "" {
+			t.Errorf("bolt still open at exec time: %q", bp)
+		}
+		// The record must be durable before exec: a fresh Store opening
+		// the same file rehydrates the applied session.
+		verify := api.NewStore()
+		if oerr := verify.OpenBolt(boltPath); oerr != nil {
+			t.Errorf("reopen bolt at exec time: %v", oerr)
+			return nil
+		}
+		defer func() { _ = verify.CloseBolt() }()
+		if _, gerr := verify.GetSession(sessKey); gerr != nil {
+			t.Errorf("session %s not durable before exec: %v", sessKey, gerr)
+		}
+		return nil
+	}
+
+	if err := d.Reexec(); err != nil {
+		t.Fatalf("Reexec: %v", err)
+	}
+	if !execCalled {
+		t.Fatal("exec was never attempted")
+	}
+	want, err := selfExecPath()
+	if err != nil {
+		t.Fatalf("selfExecPath: %v", err)
+	}
+	if gotArgv0 != want {
+		t.Errorf("exec argv0: want %q, got %q", want, gotArgv0)
+	}
+	if len(gotArgv) == 0 || gotArgv[0] != os.Args[0] {
+		t.Errorf("exec argv should preserve os.Args, got %v", gotArgv)
+	}
+	// The pane the agent runs in must survive, exactly as it does on Detach.
+	if !d.driver.HasPane(paneID) {
+		t.Fatalf("pane %s was killed by Reexec", paneID)
+	}
+}
+
+// TestReexecLeavesPanesForSuccessorToAdopt is contract (b): after a
+// re-exec, a fresh daemon over the same state file adopts the still-
+// running pane instead of spawning a replacement. This is the #73
+// detach/adopt recovery contract driven by Reexec rather than Detach.
+func TestReexecLeavesPanesForSuccessorToAdopt(t *testing.T) {
+	skipIfNoTmux(t)
+
+	boltPath := filepath.Join(t.TempDir(), "marvel.bolt")
+	ws := "test-reexec-adopt"
+
+	d1, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon #1: %v", err)
+	}
+	sock1 := filepath.Join(os.TempDir(), "marvel-test-reexec-1.sock")
+	if err := d1.Start(sock1); err != nil {
+		t.Fatalf("start daemon #1: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = d1.driver.KillSession("marvel-" + ws)
+		_ = os.Remove(sock1)
+	})
+
+	resp, err := SendRequest(sock1, Request{
+		Method: "apply",
+		Params: mustMarshal(t, map[string]any{"manifest_data": []byte(reexecManifest(ws))}),
+	})
+	if err != nil || resp.Error != "" {
+		t.Fatalf("apply: err=%v resp.Error=%q", err, resp.Error)
+	}
+	time.Sleep(600 * time.Millisecond)
+
+	before := d1.store.ListSessionsByTeam(ws, "squad")
+	if len(before) != 1 {
+		t.Fatalf("expected 1 session before reexec, got %d", len(before))
+	}
+	sessKey := before[0].Key()
+	paneID := before[0].PaneID
+	if paneID == "" {
+		t.Fatal("expected the session to have a pane before reexec")
+	}
+
+	// Stand in for syscall.Exec: the real call never returns, so a nil
+	// return models a successful hand-off. The detach inside Reexec has
+	// already run by the time this fires.
+	d1.reexec = func(_ string, _ []string, _ []string) error { return nil }
+	if err := d1.Reexec(); err != nil {
+		t.Fatalf("Reexec: %v", err)
+	}
+	if !d1.driver.HasPane(paneID) {
+		t.Fatalf("pane %s was killed by Reexec", paneID)
+	}
+
+	d2, err := NewWithOptions(Options{StateBolt: boltPath})
+	if err != nil {
+		t.Fatalf("new daemon #2: %v", err)
+	}
+	sock2 := filepath.Join(os.TempDir(), "marvel-test-reexec-2.sock")
+	t.Cleanup(func() {
+		d2.Stop()
+		_ = os.Remove(sock2)
+	})
+
+	rehydrated, err := d2.store.GetSession(sessKey)
+	if err != nil {
+		t.Fatalf("session %s did not survive reexec: %v", sessKey, err)
+	}
+	if rehydrated.PaneID != paneID {
+		t.Fatalf("rehydrated PaneID: want %s, got %s", paneID, rehydrated.PaneID)
+	}
+
+	if err := d2.Start(sock2); err != nil {
+		t.Fatalf("start daemon #2: %v", err)
+	}
+	if !d2.driver.HasPane(paneID) {
+		t.Fatalf("pane %s was killed on restart instead of adopted", paneID)
+	}
+
+	time.Sleep(3 * ReconcileInterval)
+	after := d2.store.ListSessionsByTeam(ws, "squad")
+	if len(after) != 1 {
+		t.Fatalf("expected 1 session after reexec, got %d: %+v", len(after), after)
+	}
+	if after[0].PaneID != paneID {
+		t.Fatalf("session was replaced rather than adopted: pane %s -> %s", paneID, after[0].PaneID)
+	}
+}
+
+// TestDispatchReexecPlumbing is contract (c): the reexec RPC routes to
+// handleReexec, returns the reexec status without erroring, and its
+// background goroutine invokes the exec primitive with the resolved
+// binary path and preserved argv. A fake exec keeps the process alive.
+func TestDispatchReexecPlumbing(t *testing.T) {
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	// In-memory only, never Started: Reexec's Detach is a no-op and the
+	// fake exec returns without replacing the process.
+	type execCall struct {
+		argv0 string
+		argv  []string
+	}
+	calls := make(chan execCall, 1)
+	d.reexec = func(argv0 string, argv []string, _ []string) error {
+		calls <- execCall{argv0: argv0, argv: argv}
+		return nil
+	}
+
+	resp := d.dispatch(Request{Method: "reexec"})
+	if resp.Error != "" {
+		t.Fatalf("reexec dispatch error: %s", resp.Error)
+	}
+	var result map[string]string
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal reexec result: %v", err)
+	}
+	if result["status"] != "reexec" {
+		t.Errorf("status: want %q, got %q", "reexec", result["status"])
+	}
+	if result["binary"] == "" {
+		t.Error("expected a resolved binary path in the response")
+	}
+
+	want, err := selfExecPath()
+	if err != nil {
+		t.Fatalf("selfExecPath: %v", err)
+	}
+	select {
+	case got := <-calls:
+		if got.argv0 != want {
+			t.Errorf("exec argv0: want %q, got %q", want, got.argv0)
+		}
+		if len(got.argv) == 0 || got.argv[0] != os.Args[0] {
+			t.Errorf("exec argv should preserve os.Args, got %v", got.argv)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("exec primitive was not invoked by the reexec goroutine")
+	}
+}
+
+func TestCleanExecPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "/usr/local/bin/marvel", "/usr/local/bin/marvel"},
+		{"deleted suffix", "/usr/local/bin/marvel (deleted)", "/usr/local/bin/marvel"},
+		{"space in path but not deleted", "/opt/my apps/marvel", "/opt/my apps/marvel"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanExecPath(tc.in); got != tc.want {
+				t.Errorf("cleanExecPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Marvel can now pick up a new daemon binary without dropping any agent. Today an upgrade replaces the binary on disk but the running daemon keeps executing the old image until someone restarts it, and a restart is only agent-preserving if the operator remembers to detach first. This wires the in-place path end to end so `marvel upgrade --daemon` installs and adopts in one step, agents never leaving their panes.

## What it does

The running daemon detaches (checkpoint durable state, release the bolt file, stop serving, leave every tmux pane running), then execs the marvel binary at its current path with argv and environment preserved. The successor process re-opens the same bolt, re-binds the same socket, and adopts the live panes via the existing `AdoptOrKill` path from #73. Same PID, zero agent context lost.

## Trigger surface

A new daemon RPC method, `reexec`, because only the daemon can exec its own process (the CLI cannot exec the daemon). Two CLI entry points call it:

- `marvel daemon reexec` adopts a binary that is already installed out of band.
- `marvel upgrade --daemon` runs the existing fetch+install and then the re-exec.

This keeps install and adopt as distinct, composable verbs rather than one name doing both, which resolves the collision the ticket flagged: `internal/upgrade` still owns fetch+install untouched, and the re-exec lives in `internal/daemon`. `marvel upgrade` with no flag behaves exactly as before.

## Tests

`syscall.Exec` cannot run in-process, so the exec primitive is a swappable field defaulting to `syscall.Exec`. The three verifiable contracts are covered separately, which together cover the path:

- checkpoint-and-close happens before exec is attempted (a fake exec re-opens the same bolt at exec time and finds the applied session durable, with the file already released),
- a fresh daemon over the same bolt adopts the still-running pane instead of respawning (the #73 detach/adopt contract driven by `reexec`),
- the RPC routes and the background goroutine invokes the exec primitive with the resolved binary path and preserved argv.

Additive only: no existing behavior changes. `go build`, `go vet`, `go test ./...`, and `golangci-lint run` are clean; pre-push `test-race` passed.

## Honest scope

The exec syscall itself is not exercised in CI (it would replace the test process). The tests assert the pre-exec contract and the adopt-after contract on either side of a stubbed exec. On Linux, `/proc/self/exe` gains a `" (deleted)"` suffix once the binary inode is replaced; `cleanExecPath` trims it and is unit-tested, but the full replace-then-exec-picks-up-new-bytes sequence is verified by construction rather than in CI.

Refs: aae-orc-zk5r