### PR TITLE
fix: make observe and inject trustworthy (inject race, log dedup, generic scrape)

### DIFF
--- a/internal/logbuf/logbuf.go
+++ b/internal/logbuf/logbuf.go
@@ -36,12 +36,15 @@ type Buffer struct {
 	lines []string
 	max   int
 
-	// Dedup state. When a write records a line identical to lastLine,
-	// the buffer bumps runCount instead of appending. When a different
-	// line arrives (or Flush is called), a summary line is appended
-	// before the new content. lastLine == "" means no run is active.
-	lastLine string
-	runCount int // 1 after initial write, 2+ when active run is accumulating
+	// Dedup state. When a write records a line whose fingerprint matches
+	// lastFingerprint, the buffer bumps runCount instead of appending.
+	// When a different line arrives (or Flush is called), a summary line
+	// is appended before the new content. runCount == 0 means no run is
+	// active. The fingerprint, not the raw line, is compared so a Go log
+	// timestamp prefix (which differs every line) does not defeat dedup —
+	// see fingerprint.
+	lastFingerprint string
+	runCount        int // 1 after initial write, 2+ when active run is accumulating
 }
 
 // New returns a Buffer that retains the most recent max lines.
@@ -84,8 +87,13 @@ func (b *Buffer) Write(p []byte) (int, error) {
 }
 
 // appendLocked records one line, applying dedup. Caller holds b.mu.
+// Dedup compares fingerprints (message body without the Go log timestamp
+// prefix) so a repeated message still collapses even though its prefix
+// changes every line. The full line, prefix included, is what lands in
+// the ring — the operator keeps the timestamp of the first occurrence.
 func (b *Buffer) appendLocked(line string) {
-	if b.runCount > 0 && line == b.lastLine {
+	fp := fingerprint(line)
+	if b.runCount > 0 && fp == b.lastFingerprint {
 		b.runCount++
 		return
 	}
@@ -96,8 +104,68 @@ func (b *Buffer) appendLocked(line string) {
 		b.lines = append(b.lines, summarize(b.runCount))
 	}
 	b.lines = append(b.lines, line)
-	b.lastLine = line
+	b.lastFingerprint = fp
 	b.runCount = 1
+}
+
+// fingerprint returns the comparable body of a log line: the line with a
+// leading Go standard-library log timestamp prefix stripped. The daemon
+// logs with the default flags (log.LstdFlags == Ldate|Ltime), so every
+// line carries a unique "2006/01/02 15:04:05 " prefix; comparing whole
+// lines never collapses a repeat. Fingerprinting the body makes dedup
+// correct regardless of the producer's flags: a line with no recognized
+// prefix fingerprints to itself.
+func fingerprint(line string) string {
+	// Ldate|Ltime renders as "2006/01/02 15:04:05", optionally with a
+	// ".000000" microsecond field (Lmicroseconds), then a single space
+	// before the message.
+	const dateTimeLen = len("2006/01/02 15:04:05")
+	if len(line) < dateTimeLen+1 || !isLogDateTime(line[:dateTimeLen]) {
+		return line
+	}
+	rest := line[dateTimeLen:]
+	if len(rest) > 1 && rest[0] == '.' {
+		i := 1
+		for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+			i++
+		}
+		rest = rest[i:]
+	}
+	if len(rest) > 0 && rest[0] == ' ' {
+		return rest[1:]
+	}
+	// Matched the date/time shape but not the trailing separator; the
+	// prefix was not a log timestamp after all.
+	return line
+}
+
+// isLogDateTime reports whether s has the exact shape "2006/01/02 15:04:05".
+func isLogDateTime(s string) bool {
+	if len(s) != len("2006/01/02 15:04:05") {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch i {
+		case 4, 7:
+			if c != '/' {
+				return false
+			}
+		case 10:
+			if c != ' ' {
+				return false
+			}
+		case 13, 16:
+			if c != ':' {
+				return false
+			}
+		default:
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // trimLocked enforces the capacity bound. Caller holds b.mu.
@@ -130,7 +198,7 @@ func (b *Buffer) Flush() {
 		// the next occurrence re-records the line as a new run of 1,
 		// which is the right answer: the summary's "N times" covered
 		// the history up to now, and the clock starts over.
-		b.lastLine = ""
+		b.lastFingerprint = ""
 		b.runCount = 0
 	}
 }

--- a/internal/logbuf/logbuf_test.go
+++ b/internal/logbuf/logbuf_test.go
@@ -195,3 +195,83 @@ func TestDedup_SingleOccurrenceNoSummary(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+
+// TestDedup_IgnoresLogTimestampPrefix: the daemon logs with the default
+// Go log flags (Ldate|Ltime), so every line carries a unique timestamp.
+// Before the fingerprint fix, whole-line comparison never matched and the
+// dedup never fired. The same message on consecutive lines must collapse
+// even though its prefix differs, and the first line's timestamp is kept.
+func TestDedup_IgnoresLogTimestampPrefix(t *testing.T) {
+	b := New(100)
+	_, _ = b.Write([]byte(
+		"2026/07/31 10:00:00 ssh: client connected\n" +
+			"2026/07/31 10:00:02 ssh: client connected\n" +
+			"2026/07/31 10:00:04 ssh: client connected\n",
+	))
+	got := b.Tail(10)
+	want := []string{
+		"2026/07/31 10:00:00 ssh: client connected",
+		"last message repeated 2 times so far",
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if b.Len() != 1 {
+		t.Errorf("expected 3 timestamped repeats to collapse to 1 stored line, got %d", b.Len())
+	}
+}
+
+// TestDedup_MicrosecondPrefix: Lmicroseconds adds a ".000000" field. The
+// message body must still fingerprint identically across lines.
+func TestDedup_MicrosecondPrefix(t *testing.T) {
+	b := New(100)
+	_, _ = b.Write([]byte(
+		"2026/07/31 10:00:00.123456 tick\n" +
+			"2026/07/31 10:00:00.789012 tick\n",
+	))
+	got := b.Tail(10)
+	want := []string{"2026/07/31 10:00:00.123456 tick", "last message repeated 1 times so far"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestDedup_DistinctMessagesWithPrefixNotCollapsed: two different bodies
+// under timestamp prefixes must NOT collapse — fingerprint compares the
+// body, and the bodies differ.
+func TestDedup_DistinctMessagesWithPrefixNotCollapsed(t *testing.T) {
+	b := New(100)
+	_, _ = b.Write([]byte(
+		"2026/07/31 10:00:00 alpha\n" +
+			"2026/07/31 10:00:01 beta\n",
+	))
+	got := b.Tail(10)
+	want := []string{"2026/07/31 10:00:00 alpha", "2026/07/31 10:00:01 beta"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFingerprint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ldate_ltime", "2026/07/31 10:00:00 hello world", "hello world"},
+		{"microseconds", "2026/07/31 10:00:00.123456 hello", "hello"},
+		{"no_prefix", "plain message", "plain message"},
+		{"empty_body", "2026/07/31 10:00:00 ", ""},
+		{"date_shape_no_space_sep", "2026/07/31 10:00:00x", "2026/07/31 10:00:00x"},
+		{"too_short", "2026/07/31", "2026/07/31"},
+		{"wrong_separators", "2026-07-31 10:00:00 hello", "2026-07-31 10:00:00 hello"},
+		{"letters_in_date", "20AB/07/31 10:00:00 hello", "20AB/07/31 10:00:00 hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fingerprint(tt.in); got != tt.want {
+				t.Errorf("fingerprint(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/generic.go
+++ b/internal/runtime/generic.go
@@ -1,9 +1,96 @@
 package runtime
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Generic is the fallback adapter for any CLI that accepts a prompt on
 // stdin. Minimal integration: environment-based identity only. Marvel
-// observes the session via capture-pane scraping.
+// observes the session with a capture-pane history scrape — see
+// GenericScraper.
 type Generic struct{}
+
+// PaneRangeCapturer is the slice of the tmux driver GenericScraper needs.
+// Declaring it here keeps package runtime free of a hard tmux dependency
+// and lets tests drive the scraper without a tmux server.
+type PaneRangeCapturer interface {
+	CapturePaneRange(paneID string, start, end int) (string, error)
+}
+
+const (
+	// scrapeHistoryStart reaches as far into scrollback as the pane
+	// retains. tmux clamps an over-large negative -S to the oldest
+	// retained line, so the effective reach is min(this, history-limit).
+	scrapeHistoryStart = -100000
+	// scrapeVisibleEnd reaches the bottom of the visible region. tmux
+	// clamps an over-large -E to the last row of the pane.
+	scrapeVisibleEnd = 100000
+)
+
+// GenericScraper is the observation path for a generic session's pane: a
+// capture-pane history scrape with a per-session high-water mark. It reads
+// scrollback with CapturePaneRange (the "capture-pane -S <start> -E <end>"
+// history form), not Driver.CapturePane (the "capture-pane -p" visible
+// region that finding-005 measured at 0.48% coverage on a burst). The
+// visible form caps at rows*poll_hz lines and drops everything that
+// scrolls off between polls; the history form retains it.
+//
+// Each Scrape returns only lines past the high-water mark and advances the
+// mark, so the consumer never sees a line twice. One GenericScraper drives
+// one pane and is not safe for concurrent use; the observation loop that
+// owns a session steps it from a single goroutine.
+//
+// Coverage still depends on the session's tmux history-limit. At the 2000
+// line default a burst larger than the scrollback is lost before a poll
+// can read it (finding-005 case (f): 20% of a 20000-line burst). Raising
+// the limit at session creation is tracked separately as aae-orc-22sz; this
+// scraper is correct within whatever limit is in force.
+type GenericScraper struct {
+	cap    PaneRangeCapturer
+	paneID string
+	// delivered is the high-water mark: the count of pane lines already
+	// returned to the consumer. It advances each poll and never re-emits.
+	delivered int
+}
+
+// NewGenericScraper builds a scraper for one pane.
+func NewGenericScraper(capturer PaneRangeCapturer, paneID string) *GenericScraper {
+	return &GenericScraper{cap: capturer, paneID: paneID}
+}
+
+// Scrape captures the pane's retained scrollback and returns the lines
+// produced since the previous call, advancing the high-water mark. A poll
+// that finds no new content returns an empty slice and no error.
+func (s *GenericScraper) Scrape() ([]string, error) {
+	content, err := s.cap.CapturePaneRange(s.paneID, scrapeHistoryStart, scrapeVisibleEnd)
+	if err != nil {
+		return nil, fmt.Errorf("scrape pane %s: %w", s.paneID, err)
+	}
+
+	lines := strings.Split(content, "\n")
+	// Drop trailing blank lines: the final-newline empty element plus any
+	// empty visible rows tmux padded the capture with. Counting them would
+	// desync the mark once real output fills those rows.
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if len(lines) < s.delivered {
+		// The buffer shrank (screen clear, alternate-screen switch).
+		// Rebaseline to the current extent rather than re-emit history;
+		// the scrape is best-effort for harnesses that repaint.
+		s.delivered = len(lines)
+		return nil, nil
+	}
+	if len(lines) == s.delivered {
+		return nil, nil
+	}
+
+	fresh := append([]string(nil), lines[s.delivered:]...)
+	s.delivered = len(lines)
+	return fresh, nil
+}
 
 func (g *Generic) Name() string { return "generic" }
 

--- a/internal/runtime/generic_scraper_test.go
+++ b/internal/runtime/generic_scraper_test.go
@@ -1,0 +1,157 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeRangeCapturer replays a scripted sequence of capture-pane outputs
+// and records the (start, end) arguments each Scrape passed, so a test
+// can assert the history form is used and the mark advances.
+type fakeRangeCapturer struct {
+	outputs []string
+	err     error
+	calls   [][2]int
+	idx     int
+}
+
+func (f *fakeRangeCapturer) CapturePaneRange(_ string, start, end int) (string, error) {
+	f.calls = append(f.calls, [2]int{start, end})
+	if f.err != nil {
+		return "", f.err
+	}
+	out := f.outputs[len(f.outputs)-1]
+	if f.idx < len(f.outputs) {
+		out = f.outputs[f.idx]
+	}
+	f.idx++
+	return out, nil
+}
+
+func TestGenericScraper_UsesHistoryRangeForm(t *testing.T) {
+	t.Parallel()
+	cap := &fakeRangeCapturer{outputs: []string{"a\nb\n"}}
+	s := NewGenericScraper(cap, "%1")
+
+	if _, err := s.Scrape(); err != nil {
+		t.Fatalf("scrape: %v", err)
+	}
+	if len(cap.calls) != 1 {
+		t.Fatalf("expected 1 CapturePaneRange call, got %d", len(cap.calls))
+	}
+	// A history scrape reaches into scrollback (negative start) rather than
+	// the visible region — the whole point of the range form.
+	if start := cap.calls[0][0]; start >= 0 {
+		t.Errorf("start = %d, want a negative scrollback offset", start)
+	}
+}
+
+func TestGenericScraper_AdvancesHighWaterMark(t *testing.T) {
+	t.Parallel()
+	// Each poll sees the pane's scrollback grow. Scrape must return only
+	// the lines added since the previous poll, never re-emit.
+	cap := &fakeRangeCapturer{outputs: []string{
+		"line1\nline2\n",
+		"line1\nline2\nline3\n",
+		"line1\nline2\nline3\nline4\nline5\n",
+		"line1\nline2\nline3\nline4\nline5\n", // idle poll, nothing new
+	}}
+	s := NewGenericScraper(cap, "%1")
+
+	steps := []struct {
+		want []string
+	}{
+		{[]string{"line1", "line2"}},
+		{[]string{"line3"}},
+		{[]string{"line4", "line5"}},
+		{nil},
+	}
+	for i, step := range steps {
+		got, err := s.Scrape()
+		if err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+		if fmt.Sprint(got) != fmt.Sprint(step.want) {
+			t.Errorf("poll %d: got %v, want %v", i, got, step.want)
+		}
+	}
+	if s.delivered != 5 {
+		t.Errorf("high-water mark = %d, want 5", s.delivered)
+	}
+}
+
+func TestGenericScraper_TrimsTrailingBlankRows(t *testing.T) {
+	t.Parallel()
+	// tmux pads a short pane with empty visible rows. Those must not count
+	// toward the mark, or real output filling them later is misreported.
+	cap := &fakeRangeCapturer{outputs: []string{
+		"only line\n\n\n\n",
+		"only line\nnext line\n\n\n",
+	}}
+	s := NewGenericScraper(cap, "%1")
+
+	first, err := s.Scrape()
+	if err != nil {
+		t.Fatalf("first scrape: %v", err)
+	}
+	if fmt.Sprint(first) != fmt.Sprint([]string{"only line"}) {
+		t.Errorf("first = %v, want [only line]", first)
+	}
+	second, err := s.Scrape()
+	if err != nil {
+		t.Fatalf("second scrape: %v", err)
+	}
+	if fmt.Sprint(second) != fmt.Sprint([]string{"next line"}) {
+		t.Errorf("second = %v, want [next line]", second)
+	}
+}
+
+func TestGenericScraper_RebaselinesOnShrink(t *testing.T) {
+	t.Parallel()
+	// A screen clear shrinks the buffer. The scraper must rebaseline to the
+	// new extent instead of re-emitting or panicking on a slice bound.
+	cap := &fakeRangeCapturer{outputs: []string{
+		"a\nb\nc\n",
+		"x\n", // cleared, fewer lines than delivered
+		"x\ny\n",
+	}}
+	s := NewGenericScraper(cap, "%1")
+
+	if _, err := s.Scrape(); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	shrunk, err := s.Scrape()
+	if err != nil {
+		t.Fatalf("shrink poll: %v", err)
+	}
+	if len(shrunk) != 0 {
+		t.Errorf("shrink poll emitted %v, want nothing (rebaseline)", shrunk)
+	}
+	if s.delivered != 1 {
+		t.Errorf("mark after shrink = %d, want 1", s.delivered)
+	}
+	grown, err := s.Scrape()
+	if err != nil {
+		t.Fatalf("grow poll: %v", err)
+	}
+	if fmt.Sprint(grown) != fmt.Sprint([]string{"y"}) {
+		t.Errorf("grow poll = %v, want [y]", grown)
+	}
+}
+
+func TestGenericScraper_PropagatesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("no pane")
+	cap := &fakeRangeCapturer{outputs: []string{""}, err: sentinel}
+	s := NewGenericScraper(cap, "%1")
+
+	_, err := s.Scrape()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want it to wrap %v", err, sentinel)
+	}
+	if !strings.Contains(err.Error(), "%1") {
+		t.Errorf("error %q should name the pane", err)
+	}
+}

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // Driver manages tmux sessions and panes by shelling out to the tmux binary.
@@ -21,6 +22,16 @@ type Driver struct {
 	// Set via the MARVEL_TMUX_SOCKET env var at NewDriver time. Tests
 	// use this to get per-package isolation from the system-wide tmux.
 	socket string
+
+	// paneMu serializes SendKeys per pane. The daemon runs each inject
+	// RPC in its own goroutine, so two concurrent injects to one pane
+	// could otherwise interleave their tmux invocations (one call's text
+	// landing between another call's text and Enter). Keyed by pane id;
+	// paneMuGuard protects the map. The map grows with pane churn and is
+	// not reaped: pane ids are cheap and the shim-in-pane path (kxce)
+	// retires this whole class, so a reaper would be discarded work.
+	paneMuGuard sync.Mutex
+	paneMu      map[string]*sync.Mutex
 }
 
 // NewDriver creates a tmux driver, verifying tmux is available.
@@ -34,7 +45,29 @@ func NewDriver() (*Driver, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tmux not found: %w", err)
 	}
-	return &Driver{binary: path, socket: os.Getenv("MARVEL_TMUX_SOCKET")}, nil
+	return &Driver{
+		binary: path,
+		socket: os.Getenv("MARVEL_TMUX_SOCKET"),
+		paneMu: make(map[string]*sync.Mutex),
+	}, nil
+}
+
+// lockPane acquires the per-pane inject lock and returns its unlock
+// func. Lazily allocates both the map and a pane's mutex so a Driver
+// built without NewDriver (e.g. a test literal) still serializes.
+func (d *Driver) lockPane(paneID string) func() {
+	d.paneMuGuard.Lock()
+	if d.paneMu == nil {
+		d.paneMu = make(map[string]*sync.Mutex)
+	}
+	mu := d.paneMu[paneID]
+	if mu == nil {
+		mu = &sync.Mutex{}
+		d.paneMu[paneID] = mu
+	}
+	d.paneMuGuard.Unlock()
+	mu.Lock()
+	return mu.Unlock
 }
 
 // cmd builds an exec.Cmd for tmux with the driver's socket prefix
@@ -218,21 +251,35 @@ func (d *Driver) KillServer() error {
 // SendKeys sends keystrokes to a tmux pane. If literal is true, each key is
 // sent literally (tmux send-keys -l) — no interpretation of special key names.
 // If enter is true, an Enter keystroke is appended after the text.
+//
+// Text and Enter go in a single tmux invocation so a concurrent inject to
+// the same pane cannot land its text between this call's text and Enter:
+// a non-literal Enter rides as a trailing key argument, and a literal
+// Enter as a trailing carriage return (what the Enter key sends). The
+// per-pane lock is the backstop for any caller that still issues separate
+// SendKeys calls to one pane.
 func (d *Driver) SendKeys(paneID, text string, literal, enter bool) error {
+	unlock := d.lockPane(paneID)
+	defer unlock()
+
 	args := []string{"send-keys", "-t", paneID}
 	if literal {
-		args = append(args, "-l")
+		// -l makes tmux send every argument literally, so a "Enter" key
+		// name cannot ride along. A trailing carriage return is what the
+		// Enter key itself sends, and it submits from the same invocation.
+		if enter {
+			text += "\r"
+		}
+		args = append(args, "-l", text)
+	} else {
+		args = append(args, text)
+		if enter {
+			args = append(args, "Enter")
+		}
 	}
-	args = append(args, text)
 
 	if out, err := d.cmd(args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("send-keys %s: %s: %w", paneID, string(out), err)
-	}
-
-	if enter {
-		if out, err := d.cmd("send-keys", "-t", paneID, "Enter").CombinedOutput(); err != nil {
-			return fmt.Errorf("send-keys Enter %s: %s: %w", paneID, string(out), err)
-		}
 	}
 	return nil
 }

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -209,6 +209,103 @@ func TestSendKeys(t *testing.T) {
 	}
 }
 
+// TestSendKeysConcurrentInjectNoInterleave drives many goroutines
+// injecting distinct markers into ONE pane at once, each as a literal
+// text + Enter. Before the fix, SendKeys issued text and Enter as two
+// separate tmux processes with no per-pane serialization, so a concurrent
+// inject could land its text between another call's text and Enter,
+// merging two markers onto one line. With text+Enter in a single
+// invocation and a per-pane lock, every marker must land on its own line.
+//
+// The pane runs cat, which echoes each completed line, so a marker shows
+// up on its echoed input line and on cat's output line; both must carry
+// exactly one marker.
+func TestSendKeysConcurrentInjectNoInterleave(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	sessionName := "marvel-test-inject-race"
+	t.Cleanup(func() { _ = d.KillSession(sessionName) })
+	if err := d.NewSession(sessionName); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	paneID, err := d.NewPane(sessionName, "cat", "inject-race", nil)
+	if err != nil {
+		t.Fatalf("new pane: %v", err)
+	}
+
+	const workers = 16
+	markers := make([]string, workers)
+	for i := range markers {
+		markers[i] = fmt.Sprintf("MK%03d", i)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := d.SendKeys(paneID, markers[i], true, true); err != nil {
+				errCh <- fmt.Errorf("inject %s: %w", markers[i], err)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent inject failed: %v", err)
+	}
+
+	// Wait until every marker has been echoed back at least once.
+	var content string
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		if !d.HasPane(paneID) {
+			t.Fatalf("pane %s vanished before capture", paneID)
+		}
+		c, cerr := d.CapturePaneRange(paneID, -1000, 1000)
+		if cerr == nil && allPresent(c, markers) {
+			content = c
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if content == "" {
+		last, _ := d.CapturePaneRange(paneID, -1000, 1000)
+		t.Fatalf("not all markers appeared within deadline; last capture:\n%s", last)
+	}
+
+	// No captured line may carry more than one marker — that is the
+	// interleave the fix prevents.
+	for _, line := range strings.Split(content, "\n") {
+		if n := countMarkers(line, markers); n > 1 {
+			t.Errorf("line %q carries %d markers, want at most 1 (text/Enter interleaved)", line, n)
+		}
+	}
+}
+
+func allPresent(content string, markers []string) bool {
+	for _, m := range markers {
+		if !strings.Contains(content, m) {
+			return false
+		}
+	}
+	return true
+}
+
+func countMarkers(line string, markers []string) int {
+	n := 0
+	for _, m := range markers {
+		n += strings.Count(line, m)
+	}
+	return n
+}
+
 func TestCapturePane(t *testing.T) {
 	skipIfNoTmux(t)
 	d, err := NewDriver()


### PR DESCRIPTION
Three small, independent fixes so marvel's observe and inject surfaces report the truth. Today an operator injecting to a busy pane can get two commands merged into one, a busy log poll can bury every interesting line without the dedup ever firing, and the generic adapter's scrape drops almost everything under load. Each fix is isolated to one file plus tests; no shared behavior changes.

## fix(tmux): per-pane inject serialization + single-invocation text/Enter (aae-orc-qtkj)
`SendKeys` sent the text and the Enter keystroke as two separate tmux processes, and the daemon runs each inject RPC in its own goroutine with no per-pane lock. Two concurrent injects to one pane could interleave: one call's text landing between another's text and Enter. Text and Enter now ride in a single `send-keys` invocation (a trailing key argument when interpreted, a trailing carriage return when literal), and a per-pane mutex serializes injects to the same pane. Different panes still inject concurrently. Minimal by intent per the kxce substrate decision (2026-07-31): the shim-in-pane path retires this class, so no reaper or elaborate machinery was added.

## fix(logbuf): dedup on the message body, not the timestamp prefix (aae-orc-407l)
The daemon logs with the default Go log flags (`Ldate|Ltime`), so every line carries a unique timestamp. The Cisco-style dedup compared whole lines, so identical messages never matched and the "last message repeated N times" collapse never fired. Dedup now compares a fingerprint (the body with a recognized Go log timestamp prefix stripped), so a run collapses regardless of the producer's flags. The full line, prefix included, still lands in the ring, so the first occurrence keeps its timestamp.

## feat(runtime): history-form scrape with a high-water mark for the generic adapter (aae-orc-xnkh)
finding-005 measured the visible-region capture (`capture-pane -p`, what `Driver.CapturePane` uses) at 0.48% coverage on a burst. The generic adapter called itself the capture-pane scrape fallback but had no observation path of its own. `GenericScraper` reads scrollback with `CapturePaneRange` (the history form) and tracks a per-session high-water mark, returning only lines produced since the last poll and never re-emitting. Coverage still depends on raising the session's tmux `history-limit` above the 2000-line default, tracked separately as aae-orc-22sz; this scraper is correct within whatever limit is in force.

## Testing
- `go test -p 1 ./...` passes (tmux tests need `-p 1`).
- `go test -race ./internal/logbuf/ ./internal/runtime/` and `-race` on the tmux package pass.
- `golangci-lint run ./...`: 0 issues; gofumpt clean.
- New: a tmux-gated concurrent-inject test (16 goroutines to one pane, no line carries two markers), logbuf timestamp-prefix dedup + fingerprint table tests, and fake-capturer scraper tests (history form used, mark advances, trailing-blank trim, shrink rebaseline, error propagation).

Scoped to driver.go, logbuf.go, generic.go plus tests. daemon.go and main.go are untouched.