### PR TITLE
fix(team): honest recovery under role removal, stuck shifts, terminal failure

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -30,7 +30,9 @@ const (
 	KindCrashLoopBackoff  Kind = "health.crashloop-backoff"
 	KindShiftStarted      Kind = "team.shift-started"
 	KindShiftCompleted    Kind = "team.shift-completed"
+	KindShiftTimedOut     Kind = "team.shift-timed-out"
 	KindRoleSaturated     Kind = "role.saturated"
+	KindRoleRemoved       Kind = "role.removed"
 )
 
 // Agent-stream kinds. These are the runtime adapter vocabulary

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -38,6 +38,11 @@ type Controller struct {
 	// RehydrateRoleHealth at daemon start. See aae-orc-qdew.
 	roleHealth map[string]*RoleHealth
 
+	// ShiftTimeout bounds how long a single shift may run before the
+	// reconciler declares it stuck and aborts it. Zero uses
+	// defaultShiftTimeout. See aae-orc-qkfl.
+	ShiftTimeout time.Duration
+
 	// now is an injection point for tests; nil means time.Now().UTC().
 	now func() time.Time
 }
@@ -58,6 +63,14 @@ type RoleHealth struct {
 const (
 	restartBackoffInitial = 30 * time.Second
 	restartBackoffMax     = 5 * time.Minute
+	// defaultShiftTimeout bounds how long a shift may run before the
+	// reconciler treats it as stuck. A launch whose new generation never
+	// reaches readiness (e.g. a heartbeat-checked role that never beats)
+	// would otherwise hold the team in phase=launching forever, both
+	// generations running and scale refused. Ten minutes is generous for
+	// agent warm-up while still bounded. Override per Controller via
+	// ShiftTimeout. See aae-orc-qkfl.
+	defaultShiftTimeout = 10 * time.Minute
 )
 
 // NewController creates a team controller.
@@ -87,6 +100,13 @@ func (c *Controller) nowUTC() time.Time {
 		return c.now()
 	}
 	return time.Now().UTC()
+}
+
+func (c *Controller) shiftTimeout() time.Duration {
+	if c.ShiftTimeout > 0 {
+		return c.ShiftTimeout
+	}
+	return defaultShiftTimeout
 }
 
 func (c *Controller) getRoleHealth(key string) *RoleHealth {
@@ -287,12 +307,59 @@ func (c *Controller) noteCrashAndBackoff(workspace, team, role string, maxRestar
 }
 
 func (c *Controller) reconcileTeam(t *api.Team) {
+	// Drain sessions whose role no longer exists in the manifest before
+	// anything else. Manifest.Apply replaces live.Roles wholesale, so a
+	// role removed from a re-applied manifest leaves its sessions running:
+	// the loops below iterate only current roles, so orphans are never
+	// counted, scaled down, or deleted and survive restarts via bolt.
+	// See aae-orc-69i2.
+	c.reconcileOrphanedSessions(t)
+
 	if t.Shift.Phase != api.ShiftNone {
 		c.reconcileShift(t)
 		return
 	}
 	for i := range t.Roles {
 		c.reconcileRole(t, &t.Roles[i])
+	}
+}
+
+// reconcileOrphanedSessions deletes every session whose role is absent
+// from the team's current role set, drained one per orphaned role with an
+// operator-visible role.removed event (the per-session deletes also emit
+// the manager's own session.deleted events). Crash-loop health state for a
+// removed role is forgotten so a later re-add starts clean, mirroring the
+// cascade-clear rationale in ClearRoleHealthForTeam. Caller holds c.mu.
+// See aae-orc-69i2.
+func (c *Controller) reconcileOrphanedSessions(t *api.Team) {
+	known := make(map[string]struct{}, len(t.Roles))
+	for i := range t.Roles {
+		known[t.Roles[i].Name] = struct{}{}
+	}
+	drained := make(map[string]int)
+	for _, sess := range c.store.ListSessionsByTeam(t.Workspace, t.Name) {
+		if _, ok := known[sess.Role]; ok {
+			continue
+		}
+		if err := c.sessMgr.Delete(sess.Key()); err != nil {
+			log.Printf("reconcile: delete orphaned session %s (role %s removed): %v", sess.Key(), sess.Role, err)
+			continue
+		}
+		drained[sess.Role]++
+	}
+	for role, n := range drained {
+		roleKey := t.Workspace + "/" + t.Name + "/" + role
+		delete(c.roleHealth, roleKey)
+		c.forgetRoleHealth(roleKey)
+		log.Printf("reconcile: role %s removed from team %s, drained %d session(s)", role, t.Key(), n)
+		events.Emit(c.Events, events.Event{
+			Kind:      events.KindRoleRemoved,
+			Severity:  events.SeverityWarning,
+			Workspace: t.Workspace,
+			Team:      t.Name,
+			Role:      role,
+			Message:   fmt.Sprintf("role removed from manifest, drained %d session(s)", n),
+		})
 	}
 }
 
@@ -476,6 +543,15 @@ func (c *Controller) applyRestartPolicy(sess *api.Session, t *api.Team, role *ap
 		sess.State = api.SessionFailed
 		log.Printf("health: session %s failed (restart_policy=never, failures=%d)",
 			sess.Key(), sess.FailureCount)
+		events.Emit(c.Events, events.Event{
+			Kind:      events.KindSessionFailed,
+			Severity:  events.SeverityWarning,
+			Workspace: t.Workspace,
+			Team:      t.Name,
+			Role:      role.Name,
+			Session:   sess.Key(),
+			Message:   fmt.Sprintf("restart_policy=never, failures=%d", sess.FailureCount),
+		})
 	case api.RestartOnFailure:
 		if sess.State == api.SessionFailed {
 			c.restartSession(sess, t, role)
@@ -550,6 +626,15 @@ func (c *Controller) restartSession(sess *api.Session, t *api.Team, role *api.Ro
 				Role:      role.Name,
 				Session:   sess.Key(),
 				Message:   fmt.Sprintf("max_restarts=%d reached", role.MaxRestarts),
+			})
+			events.Emit(c.Events, events.Event{
+				Kind:      events.KindSessionFailed,
+				Severity:  events.SeverityWarning,
+				Workspace: t.Workspace,
+				Team:      t.Name,
+				Role:      role.Name,
+				Session:   sess.Key(),
+				Message:   fmt.Sprintf("max_restarts=%d reached, not restarting", role.MaxRestarts),
 			})
 		}
 		_ = c.store.UpdateSession(sess.Key(), func(live *api.Session) error {
@@ -633,7 +718,7 @@ func (c *Controller) InitiateShift(teamKey, role string) error {
 			OldGeneration: oldGen,
 			RoleIndex:     0,
 			Roles:         roles,
-			StartedAt:     time.Now().UTC(),
+			StartedAt:     c.nowUTC(),
 		}
 		return nil
 	}); err != nil {
@@ -669,6 +754,17 @@ func shiftOrder(roles []api.Role) []string {
 }
 
 func (c *Controller) reconcileShift(t *api.Team) {
+	// Shift timeout: bound how long a shift may run. A launch whose new
+	// generation never reaches readiness would otherwise keep the team in
+	// phase=launching forever, both generations running and scale refused
+	// (ShiftState.StartedAt was written and read by nothing). On expiry we
+	// abort the shift; see abortStuckShift for the rollback rationale.
+	// See aae-orc-qkfl.
+	if !t.Shift.StartedAt.IsZero() && c.nowUTC().Sub(t.Shift.StartedAt) > c.shiftTimeout() {
+		c.abortStuckShift(t)
+		return
+	}
+
 	if t.Shift.RoleIndex >= len(t.Shift.Roles) {
 		// All roles shifted — complete.
 		log.Printf("shift: complete for %s/%s", t.Workspace, t.Name)
@@ -719,6 +815,46 @@ func (c *Controller) reconcileShift(t *api.Team) {
 	case api.ShiftDraining:
 		c.shiftDrain(t, role)
 	}
+}
+
+// abortStuckShift ends a shift that exceeded the timeout. Rolling the
+// stuck generation back is the safer default than tearing down the
+// working sessions: in the launching phase the new generation is the one
+// that never came ready, so it is deleted and the known-good old
+// generation is kept; in draining the sessions are left in place and
+// normal reconciliation converges the replica counts. Either way the
+// shift state is cleared, which resumes normal reconciliation and
+// unblocks scale (the daemon refuses scale while a shift is in progress).
+// An operator-visible warning names the phase and the generation rolled
+// back to. Caller holds c.mu. See aae-orc-qkfl.
+func (c *Controller) abortStuckShift(t *api.Team) {
+	var role string
+	if t.Shift.RoleIndex < len(t.Shift.Roles) {
+		role = t.Shift.Roles[t.Shift.RoleIndex]
+	}
+	elapsed := c.nowUTC().Sub(t.Shift.StartedAt)
+	log.Printf("shift: %s stuck in %s for %s (role %s), aborting and rolling back to gen %d",
+		t.Key(), t.Shift.Phase, elapsed, role, t.Shift.OldGeneration)
+	events.Emit(c.Events, events.Event{
+		Kind:      events.KindShiftTimedOut,
+		Severity:  events.SeverityWarning,
+		Workspace: t.Workspace,
+		Team:      t.Name,
+		Role:      role,
+		Message:   fmt.Sprintf("shift stuck in %s past %s, rolled back to gen %d", t.Shift.Phase, c.shiftTimeout(), t.Shift.OldGeneration),
+	})
+	if t.Shift.Phase == api.ShiftLaunching && role != "" {
+		for _, sess := range c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role, t.Generation) {
+			if err := c.sessMgr.Delete(sess.Key()); err != nil {
+				log.Printf("shift: abort delete new-gen session %s: %v", sess.Key(), err)
+			}
+		}
+	}
+	_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
+		live.Shift = api.ShiftState{}
+		return nil
+	})
+	t.Shift = api.ShiftState{}
 }
 
 func (c *Controller) shiftLaunch(t *api.Team, role *api.Role) {

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
 	"github.com/arcavenae/marvel/internal/session"
 	"github.com/arcavenae/marvel/internal/tmux"
 )
@@ -1108,6 +1109,226 @@ func TestShiftSessionNaming(t *testing.T) {
 	}
 	if !strings.Contains(gen2[0].Name, "-g2-") {
 		t.Fatalf("expected g2 in name, got %s", gen2[0].Name)
+	}
+}
+
+// --- Recovery-correctness trio (aae-orc-69i2 / qkfl / 96st) ---
+
+// TestOrphanedSessionsDrainedOnRoleRemoval covers aae-orc-69i2: removing
+// a role from a re-applied manifest (which replaces the role set
+// wholesale) must tear down that role's sessions, not leave them running
+// and uncounted forever. Falsification: without reconcileOrphanedSessions,
+// role b's session survives the re-apply and this fails on the drained
+// count.
+func TestOrphanedSessionsDrainedOnRoleRemoval(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+
+	createTeamFixture(t, store, "test-orphan", "squad", []api.Role{
+		{Name: "a", Replicas: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+		{Name: "b", Replicas: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRole("test-orphan", "squad", "a")); got != 1 {
+		t.Fatalf("expected 1 session for role a, got %d", got)
+	}
+	if got := len(store.ListSessionsByTeamRole("test-orphan", "squad", "b")); got != 1 {
+		t.Fatalf("expected 1 session for role b, got %d", got)
+	}
+	// Give role b some crash-loop state so we can assert it is forgotten
+	// when the role is removed.
+	ctrl.roleHealth["test-orphan/squad/b"] = &RoleHealth{RestartCount: 2}
+
+	// Re-apply with only role a — this is exactly what Manifest.Apply does
+	// (live.Roles = roles).
+	if err := store.UpdateTeam("test-orphan/squad", func(live *api.Team) error {
+		live.Roles = []api.Role{live.Roles[0]}
+		return nil
+	}); err != nil {
+		t.Fatalf("re-apply team: %v", err)
+	}
+
+	ctrl.ReconcileOnce()
+
+	if got := len(store.ListSessionsByTeam("test-orphan", "squad")); got != 1 {
+		t.Fatalf("expected 1 total session after role b removed, got %d", got)
+	}
+	if got := len(store.ListSessionsByTeamRole("test-orphan", "squad", "a")); got != 1 {
+		t.Fatalf("expected role a still running, got %d", got)
+	}
+	if got := len(store.ListSessionsByTeamRole("test-orphan", "squad", "b")); got != 0 {
+		t.Fatalf("expected role b drained, got %d sessions", got)
+	}
+	if _, ok := ctrl.roleHealth["test-orphan/squad/b"]; ok {
+		t.Fatal("expected role b crash-loop state forgotten after removal")
+	}
+	removed := ring.Snapshot(events.Filter{Kind: events.KindRoleRemoved, Role: "b"}, 0)
+	if len(removed) == 0 {
+		t.Fatal("expected a role.removed event for role b")
+	}
+}
+
+// TestShiftTimeoutAbortsStuckLaunch covers aae-orc-qkfl: a shift whose new
+// generation never becomes ready (a heartbeat-checked role that never
+// beats) must hit the timeout and abort, rolling back to the old
+// generation, rather than hang in phase=launching forever. Falsification:
+// without the timeout check in reconcileShift, the shift stays launching
+// after the clock advances and this fails on the phase assertion.
+func TestShiftTimeoutAbortsStuckLaunch(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+	ctrl.ShiftTimeout = 2 * time.Minute
+
+	// A generous heartbeat timeout keeps the sessions in HealthUnknown
+	// (never marked unhealthy) so the ONLY thing blocking shift completion
+	// is allReady's requirement of a first heartbeat — which never arrives.
+	createTeamFixture(t, store, "test-shift-stuck", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 2,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Hour, FailureThreshold: 3},
+		},
+	})
+	teamKey := "test-shift-stuck/squad"
+
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRoleGeneration("test-shift-stuck", "squad", "worker", 1)); got != 2 {
+		t.Fatalf("expected 2 gen-1 sessions, got %d", got)
+	}
+
+	if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+		t.Fatalf("initiate shift: %v", err)
+	}
+
+	// One tick launches gen-2 but cannot complete (no heartbeat).
+	ctrl.ReconcileOnce()
+	team, _ := store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftLaunching {
+		t.Fatalf("expected launching before timeout, got %s", team.Shift.Phase)
+	}
+	if got := len(store.ListSessionsByTeamRoleGeneration("test-shift-stuck", "squad", "worker", 2)); got != 2 {
+		t.Fatalf("expected 2 gen-2 sessions launched, got %d", got)
+	}
+
+	// Move past the timeout and reconcile: the shift must abort.
+	clock.Advance(3 * time.Minute)
+	ctrl.ReconcileOnce()
+
+	team, _ = store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftNone {
+		t.Fatalf("expected shift aborted (phase none) after timeout, got %s", team.Shift.Phase)
+	}
+	if got := len(store.ListSessionsByTeamRoleGeneration("test-shift-stuck", "squad", "worker", 2)); got != 0 {
+		t.Fatalf("expected stuck gen-2 torn down on abort, got %d", got)
+	}
+	if got := len(store.ListSessionsByTeamRoleGeneration("test-shift-stuck", "squad", "worker", 1)); got != 2 {
+		t.Fatalf("expected old gen-1 kept on rollback, got %d", got)
+	}
+	if len(ring.Snapshot(events.Filter{Kind: events.KindShiftTimedOut}, 0)) == 0 {
+		t.Fatal("expected a team.shift-timed-out event")
+	}
+}
+
+// TestSessionFailedEventOnRestartNever covers aae-orc-96st: a role with
+// restart_policy=never whose session fails health must emit
+// events.KindSessionFailed. Falsification: without the emit in
+// applyRestartPolicy's RestartNever case, no session.failed event is
+// recorded and this fails.
+func TestSessionFailedEventOnRestartNever(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+
+	createTeamFixture(t, store, "test-failed-never", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartNever,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	sess := store.ListSessionsByTeamRole("test-failed-never", "squad", "worker")[0]
+	if err := store.UpdateSession(sess.Key(), func(live *api.Session) error {
+		live.LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+		return nil
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	ctrl.ReconcileOnce()
+
+	got, err := store.GetSession(sess.Key())
+	if err != nil {
+		t.Fatalf("session should still exist (restart_policy=never): %v", err)
+	}
+	if got.State != api.SessionFailed {
+		t.Fatalf("expected failed state, got %s", got.State)
+	}
+	failed := ring.Snapshot(events.Filter{Kind: events.KindSessionFailed, Session: sess.Key()}, 0)
+	if len(failed) == 0 {
+		t.Fatal("expected a session.failed event on restart_policy=never failure")
+	}
+}
+
+// TestSessionFailedEventOnSaturation covers aae-orc-96st: a role that
+// saturates MaxRestarts must emit events.KindSessionFailed in addition to
+// events.KindRoleSaturated. Falsification: without the emit in
+// restartSession's saturation branch, only role.saturated is recorded and
+// the session.failed assertion fails.
+func TestSessionFailedEventOnSaturation(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	clock := newTestClock(time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-failed-sat", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartAlways,
+			MaxRestarts:   1,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	// Burn the single restart, then saturate on the next crash.
+	for i := 0; i < 2; i++ {
+		ctrl.ReconcileOnce()
+		got := store.ListSessionsByTeamRole("test-failed-sat", "squad", "worker")
+		if len(got) == 0 {
+			continue
+		}
+		if err := store.UpdateSession(got[0].Key(), func(live *api.Session) error {
+			live.LastHeartbeat = time.Now().UTC().Add(-1 * time.Hour)
+			return nil
+		}); err != nil {
+			t.Fatalf("iter %d update heartbeat: %v", i, err)
+		}
+		ctrl.ReconcileOnce()
+		clock.Advance(10 * time.Minute)
+	}
+
+	if len(ring.Snapshot(events.Filter{Kind: events.KindRoleSaturated}, 0)) == 0 {
+		t.Fatal("expected a role.saturated event on saturation")
+	}
+	if len(ring.Snapshot(events.Filter{Kind: events.KindSessionFailed}, 0)) == 0 {
+		t.Fatal("expected a session.failed event on saturation")
 	}
 }
 


### PR DESCRIPTION
Three recovery paths in the team reconcile loop either stranded state or went silent, so an operator watching `marvel events` or `marvel get sessions` got a picture that did not match reality. Each fix ships with a test that fails before the change (falsified), so the regression is pinned.

## Role removal orphans sessions forever (aae-orc-69i2)
`Manifest.Apply` replaces a team's role set wholesale, and `reconcileTeam` iterated only the current roles. A role dropped from a re-applied manifest left its sessions running: never counted toward a replica total, never scaled down, never deleted, and re-hydrated across daemon restarts through bolt. `reconcileOrphanedSessions` now drains any session whose role is absent from the manifest, forgets that role's crash-loop health so a later re-add starts clean, and emits a `role.removed` event.

## Shifts have no timeout (aae-orc-qkfl)
If the new generation never reached readiness (a heartbeat-checked role that never beats), the team sat in `phase=launching` forever with both generations running and scale refused. `ShiftState.StartedAt` was written and read by nothing. `reconcileShift` now compares `StartedAt` against a configurable `Controller.ShiftTimeout` (default 10m). On expiry it aborts: the not-ready new generation is torn down, the known-good old generation is kept, the shift state clears so scale unblocks, and a `team.shift-timed-out` warning is emitted. Rolling the stuck generation back is the safer default than tearing down the working sessions; draining-phase timeouts just clear the shift and let normal reconciliation converge.

## session.failed declared but never emitted (aae-orc-96st)
`events.KindSessionFailed` existed but no path emitted it, so `marvel events --kind session.failed` was always empty. Both terminal paths now emit it: `restart_policy=never` on a health failure, and `MaxRestarts` saturation (in addition to `role.saturated`, not instead of it).

## Cost of merge
Additive. New behavior triggers only on role removal, shift-timeout expiry, and terminal session failure; existing shift/scale/health flows are unchanged. Two new event kinds (`team.shift-timed-out`, `role.removed`) and one new configurable field (`Controller.ShiftTimeout`, defaulted). No `api/types.go` changes.

## Tests
Four new tests in `internal/team`, each falsified against the pre-fix code:
- `TestOrphanedSessionsDrainedOnRoleRemoval`
- `TestShiftTimeoutAbortsStuckLaunch`
- `TestSessionFailedEventOnRestartNever`
- `TestSessionFailedEventOnSaturation`

These use the tmux harness; run the package with `-p 1`. `go build/vet/test ./...`, `golangci-lint`, gofumpt, and the race suite all pass.