### PR TITLE
feat(marvel): Policy resource + live per-session settings projection

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -505,7 +505,7 @@ func getCmd() *cobra.Command {
 	var watchSec string
 	cmd := &cobra.Command{
 		Use:   "get <resource-type>",
-		Short: "List resources (sessions, teams, workspaces, endpoints)",
+		Short: "List resources (sessions, teams, workspaces, endpoints, policies)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().Changed("watch") {
@@ -557,6 +557,8 @@ func getResources(resourceType string) error {
 		return printWorkspaces(resp.Result)
 	case "endpoints", "endpoint":
 		return printEndpoints(resp.Result)
+	case "policies", "policy":
+		return printPolicies(resp.Result)
 	default:
 		fmt.Println(string(resp.Result))
 	}
@@ -1661,6 +1663,23 @@ func printEndpoints(data json.RawMessage) error {
 	_, _ = fmt.Fprintf(w, "WORKSPACE\tNAME\tTEAM\n")
 	for _, e := range endpoints {
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", e.Workspace, e.Name, e.Team)
+	}
+	return w.Flush()
+}
+
+func printPolicies(data json.RawMessage) error {
+	var policies []api.Policy
+	if err := json.Unmarshal(data, &policies); err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "WORKSPACE\tNAME\tVERSION\tKEYS\n")
+	for _, p := range policies {
+		version := p.Version
+		if version == "" {
+			version = "-"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", p.Workspace, p.Name, version, len(p.Settings))
 	}
 	return w.Flush()
 }

--- a/examples/policy-projection-v2.toml
+++ b/examples/policy-projection-v2.toml
@@ -1,0 +1,47 @@
+# Marvel example — policy projection, version 2 (the live swap).
+#
+# Same workspace, team, and role as examples/policy-projection.toml, with
+# the reviewer-contract policy edited: Edit is now allowed and a hook is
+# added. Applying this over the v1 manifest re-projects the settings file
+# for the already-running reviewer session and emits a policy.projected
+# event — the running agent's contract changes with no restart.
+#
+#   ./marvel work examples/policy-projection-v2.toml
+#   ./marvel events --kind policy.projected
+#   ./marvel get policies                     # version now "2"
+
+[workspace]
+name = "policy-demo"
+
+# Version 2: the reviewer may now Edit, and a session-start hook fires.
+[[policy]]
+name = "reviewer-contract"
+version = "2"
+
+  [policy.settings.permissions]
+  allow = ["Read", "Grep", "Glob", "Edit"]
+  deny = ["Bash", "Write"]
+
+  [[policy.settings.hooks.SessionStart]]
+  matcher = ""
+
+    [[policy.settings.hooks.SessionStart.hooks]]
+    type = "command"
+    command = "echo 'reviewer-contract v2 active'"
+
+[[team]]
+name = "review-squad"
+
+  [[team.role]]
+  name = "reviewer"
+  replicas = 1
+  permissions = "plan"
+  policy = "reviewer-contract"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"
+
+[[endpoint]]
+name = "review-svc"
+team = "review-squad"

--- a/examples/policy-projection-v2.yaml
+++ b/examples/policy-projection-v2.yaml
@@ -1,0 +1,43 @@
+# Marvel example — policy projection, version 2 (the live swap).
+#
+# Same workspace, team, and role as examples/policy-projection.yaml, with
+# the reviewer-contract policy edited: Edit is now allowed and a
+# SessionStart hook is added. Applying this over v1 re-projects the running
+# reviewer session's settings file and emits a policy.projected event — the
+# contract changes with no restart.
+#
+#   ./marvel work examples/policy-projection-v2.yaml
+#   ./marvel events --kind policy.projected
+#   ./marvel get policies            # version now "2"
+
+workspace:
+  name: policy-demo
+
+policies:
+  - name: reviewer-contract
+    version: "2"
+    settings:
+      permissions:
+        allow: ["Read", "Grep", "Glob", "Edit"]
+        deny: ["Bash", "Write"]
+      hooks:
+        SessionStart:
+          - matcher: ""
+            hooks:
+              - type: command
+                command: "echo 'reviewer-contract v2 active'"
+
+teams:
+  - name: review-squad
+    roles:
+      - name: reviewer
+        replicas: 1
+        permissions: plan
+        policy: reviewer-contract
+        runtime:
+          image: claude
+          command: claude
+
+endpoints:
+  - name: review-svc
+    team: review-squad

--- a/examples/policy-projection.toml
+++ b/examples/policy-projection.toml
@@ -1,0 +1,55 @@
+# Marvel example — policy projection (finding-024 contract half).
+#
+# A Policy is a named Claude Code settings fragment marvel writes to a
+# per-session file the harness reads. A Role references it by name; at
+# spawn marvel writes the file and points the harness at it (claude via
+# --settings, forestage via the same flag in its claude passthrough).
+#
+# The demo beat is LIVE re-projection: edit a policy and re-apply, and the
+# running agent's contract changes with no restart, because Claude Code's
+# file watcher re-reads the settings file. examples/policy-projection-v2.toml
+# is the tightened version to swap to.
+#
+# Setup:
+#   just build
+#   ./marvel daemon &
+#   ./marvel work examples/policy-projection.toml
+#   ./marvel get policies
+#   ./marvel events --kind policy.projected      # projection at spawn
+#
+# Now swap the policy live and watch the re-projection event:
+#   ./marvel work examples/policy-projection-v2.toml
+#   ./marvel events --kind policy.projected      # re-projected, no restart
+#
+# Runtimes with no Claude Code settings surface (codex, opencode, generic)
+# log the policy as advisory and are not projected — nothing is dropped
+# silently.
+
+[workspace]
+name = "policy-demo"
+
+# The reviewer's contract: read-only, no shell. Version 1.
+[[policy]]
+name = "reviewer-contract"
+version = "1"
+
+  [policy.settings.permissions]
+  allow = ["Read", "Grep", "Glob"]
+  deny = ["Bash", "Write", "Edit"]
+
+[[team]]
+name = "review-squad"
+
+  [[team.role]]
+  name = "reviewer"
+  replicas = 1
+  permissions = "plan"
+  policy = "reviewer-contract"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"
+
+[[endpoint]]
+name = "review-svc"
+team = "review-squad"

--- a/examples/policy-projection.yaml
+++ b/examples/policy-projection.yaml
@@ -1,0 +1,44 @@
+# Marvel example — policy projection (finding-024 contract half).
+#
+# A Policy is a named Claude Code settings fragment marvel writes to a
+# per-session file the harness reads. A Role references it by name; at
+# spawn marvel writes the file and points the harness at it (claude via
+# --settings, forestage via the same flag in its claude passthrough).
+#
+# The demo beat is LIVE re-projection: edit a policy and re-apply, and the
+# running agent's contract changes with no restart. See
+# examples/policy-projection-v2.yaml for the tightened version to swap to.
+#
+#   just build
+#   ./marvel daemon &
+#   ./marvel work examples/policy-projection.yaml
+#   ./marvel get policies
+#   ./marvel events --kind policy.projected
+#   ./marvel work examples/policy-projection-v2.yaml   # live swap
+#   ./marvel events --kind policy.projected            # re-projected, no restart
+
+workspace:
+  name: policy-demo
+
+policies:
+  - name: reviewer-contract
+    version: "1"
+    settings:
+      permissions:
+        allow: ["Read", "Grep", "Glob"]
+        deny: ["Bash", "Write", "Edit"]
+
+teams:
+  - name: review-squad
+    roles:
+      - name: reviewer
+        replicas: 1
+        permissions: plan
+        policy: reviewer-contract
+        runtime:
+          image: claude
+          command: claude
+
+endpoints:
+  - name: review-svc
+    team: review-squad

--- a/internal/api/bolt.go
+++ b/internal/api/bolt.go
@@ -35,6 +35,7 @@ var (
 	bucketTeams      = []byte("teams")
 	bucketSessions   = []byte("sessions")
 	bucketEndpoints  = []byte("endpoints")
+	bucketPolicies   = []byte("policies")
 	bucketRoleHealth = []byte("role_health")
 	bucketMeta       = []byte("meta")
 )
@@ -58,6 +59,7 @@ var allBuckets = [][]byte{
 	bucketTeams,
 	bucketSessions,
 	bucketEndpoints,
+	bucketPolicies,
 	bucketRoleHealth,
 	bucketMeta,
 }
@@ -215,6 +217,17 @@ func (s *Store) rehydrate() error {
 				return fmt.Errorf("unmarshal endpoint: %w", err)
 			}
 			s.endpoints[e.Key()] = &e
+			return nil
+		}); err != nil {
+			return err
+		}
+		// Policies
+		if err := tx.Bucket(bucketPolicies).ForEach(func(_, v []byte) error {
+			var p Policy
+			if err := json.Unmarshal(v, &p); err != nil {
+				return fmt.Errorf("unmarshal policy: %w", err)
+			}
+			s.policies[p.Key()] = &p
 			return nil
 		}); err != nil {
 			return err

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -19,6 +19,16 @@ type Manifest struct {
 	Workspace ManifestWorkspace  `toml:"workspace" yaml:"workspace"`
 	Teams     []ManifestTeam     `toml:"team"      yaml:"teams"`
 	Endpoints []ManifestEndpoint `toml:"endpoint"   yaml:"endpoints"`
+	Policies  []ManifestPolicy   `toml:"policy"     yaml:"policies"`
+}
+
+// ManifestPolicy is a policy section of a manifest — a named Claude Code
+// settings fragment marvel projects into a per-session file. Settings is
+// carried verbatim; marvel does not interpret it.
+type ManifestPolicy struct {
+	Name     string         `toml:"name"              yaml:"name"`
+	Version  string         `toml:"version,omitempty" yaml:"version,omitempty"`
+	Settings map[string]any `toml:"settings,omitempty" yaml:"settings,omitempty"`
 }
 
 // ManifestWorkspace is the workspace section of a manifest.
@@ -44,6 +54,7 @@ type ManifestRole struct {
 	DangerousPermissions bool                 `toml:"dangerous_permissions,omitempty" yaml:"dangerous_permissions,omitempty"`
 	Persona              string               `toml:"persona,omitempty"             yaml:"persona,omitempty"`
 	Identity             string               `toml:"identity,omitempty"            yaml:"identity,omitempty"`
+	Policy               string               `toml:"policy,omitempty"              yaml:"policy,omitempty"`
 	HealthCheck          *ManifestHealthCheck `toml:"healthcheck,omitempty"         yaml:"healthcheck,omitempty"`
 }
 
@@ -121,6 +132,16 @@ func validateManifest(m *Manifest) (*Manifest, error) {
 	if m.Workspace.Name == "" {
 		return nil, fmt.Errorf("parse manifest: workspace.name is required")
 	}
+	policyNames := make(map[string]bool, len(m.Policies))
+	for i, p := range m.Policies {
+		if p.Name == "" {
+			return nil, fmt.Errorf("parse manifest: policy[%d].name is required", i)
+		}
+		if policyNames[p.Name] {
+			return nil, fmt.Errorf("parse manifest: policy[%d].name %q is duplicated", i, p.Name)
+		}
+		policyNames[p.Name] = true
+	}
 	for i, t := range m.Teams {
 		if t.Name == "" {
 			return nil, fmt.Errorf("parse manifest: team[%d].name is required", i)
@@ -137,6 +158,9 @@ func validateManifest(m *Manifest) (*Manifest, error) {
 			}
 			if r.Runtime.Image == "" && r.Runtime.Command == "" {
 				return nil, fmt.Errorf("parse manifest: team[%d].role[%d].runtime needs image or command", i, j)
+			}
+			if r.Policy != "" && !policyNames[r.Policy] {
+				return nil, fmt.Errorf("parse manifest: team[%d].role[%d] references undefined policy %q", i, j, r.Policy)
 			}
 		}
 	}
@@ -218,6 +242,30 @@ func (m *Manifest) Apply(store *Store) error {
 		return fmt.Errorf("apply workspace: %w", err)
 	}
 
+	// Policies first, so a role's policy reference resolves against
+	// already-present state and an edited policy is in the store before
+	// the reconciler re-projects.
+	for _, mp := range m.Policies {
+		policy := &Policy{
+			Name:      mp.Name,
+			Workspace: m.Workspace.Name,
+			Version:   mp.Version,
+			Settings:  mp.Settings,
+			CreatedAt: now,
+		}
+		if _, err := store.GetPolicy(policy.Key()); err == nil {
+			if err := store.UpdatePolicy(policy.Key(), func(live *Policy) error {
+				live.Version = mp.Version
+				live.Settings = mp.Settings
+				return nil
+			}); err != nil {
+				return fmt.Errorf("apply policy %s: %w", mp.Name, err)
+			}
+		} else if err := store.CreatePolicy(policy); err != nil {
+			return fmt.Errorf("apply policy %s: %w", mp.Name, err)
+		}
+	}
+
 	for _, mt := range m.Teams {
 		var roles []Role
 		for _, mr := range mt.Roles {
@@ -242,6 +290,7 @@ func (m *Manifest) Apply(store *Store) error {
 				DangerousPermissions: mr.DangerousPermissions,
 				Persona:              mr.Persona,
 				Identity:             mr.Identity,
+				Policy:               mr.Policy,
 			}
 			if mr.RestartPolicy != "" {
 				role.RestartPolicy = RestartPolicy(mr.RestartPolicy)

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const policyManifestTOML = `
+[workspace]
+name = "acme"
+
+[[policy]]
+name = "reviewer-contract"
+version = "1.0"
+
+  [policy.settings.permissions]
+  allow = ["Read", "Grep"]
+  deny = ["Bash"]
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "reviewer"
+  replicas = 1
+  policy = "reviewer-contract"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"
+`
+
+func TestParseManifestPolicy(t *testing.T) {
+	t.Parallel()
+	m, err := ParseManifestBytes([]byte(policyManifestTOML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Policies) != 1 {
+		t.Fatalf("policies = %d, want 1", len(m.Policies))
+	}
+	p := m.Policies[0]
+	if p.Name != "reviewer-contract" {
+		t.Errorf("policy name = %q, want reviewer-contract", p.Name)
+	}
+	if p.Version != "1.0" {
+		t.Errorf("policy version = %q, want 1.0", p.Version)
+	}
+	perms, ok := p.Settings["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("settings.permissions is %T, want map", p.Settings["permissions"])
+	}
+	allow, ok := perms["allow"].([]any)
+	if !ok || len(allow) != 2 {
+		t.Fatalf("permissions.allow = %v, want two entries", perms["allow"])
+	}
+	if m.Teams[0].Roles[0].Policy != "reviewer-contract" {
+		t.Errorf("role policy = %q, want reviewer-contract", m.Teams[0].Roles[0].Policy)
+	}
+}
+
+func TestValidateManifestPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string // substring; empty means expect success
+	}{
+		{
+			name: "valid policy reference",
+			body: policyManifestTOML,
+		},
+		{
+			name: "policy without name",
+			body: `
+[workspace]
+name = "acme"
+[[policy]]
+version = "1.0"
+`,
+			wantErr: "policy[0].name is required",
+		},
+		{
+			name: "duplicate policy names",
+			body: `
+[workspace]
+name = "acme"
+[[policy]]
+name = "dup"
+[[policy]]
+name = "dup"
+`,
+			wantErr: `policy[1].name "dup" is duplicated`,
+		},
+		{
+			name: "role references undefined policy",
+			body: `
+[workspace]
+name = "acme"
+[[team]]
+name = "squad"
+  [[team.role]]
+  name = "reviewer"
+  replicas = 1
+  policy = "ghost"
+    [team.role.runtime]
+    command = "claude"
+`,
+			wantErr: `references undefined policy "ghost"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseManifestBytes([]byte(tt.body))
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplyPolicyCreatesAndUpdates(t *testing.T) {
+	t.Parallel()
+	store := NewStore()
+
+	m, err := ParseManifestBytes([]byte(policyManifestTOML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := m.Apply(store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := store.GetPolicy("acme/reviewer-contract")
+	if err != nil {
+		t.Fatalf("get policy: %v", err)
+	}
+	if got.Version != "1.0" {
+		t.Errorf("version = %q, want 1.0", got.Version)
+	}
+	if got.Workspace != "acme" {
+		t.Errorf("workspace = %q, want acme", got.Workspace)
+	}
+
+	// Re-apply an edited version: same name, new settings. Apply must
+	// update in place rather than fail on already-exists.
+	edited := strings.Replace(policyManifestTOML, `version = "1.0"`, `version = "2.0"`, 1)
+	m2, err := ParseManifestBytes([]byte(edited))
+	if err != nil {
+		t.Fatalf("parse edited: %v", err)
+	}
+	if err := m2.Apply(store); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	got2, err := store.GetPolicy("acme/reviewer-contract")
+	if err != nil {
+		t.Fatalf("get policy after re-apply: %v", err)
+	}
+	if got2.Version != "2.0" {
+		t.Errorf("version after re-apply = %q, want 2.0", got2.Version)
+	}
+	if n := len(store.ListPolicies()); n != 1 {
+		t.Errorf("policy count = %d, want 1 (update in place, not duplicate)", n)
+	}
+}
+
+func TestPolicyProjectionExamplesParse(t *testing.T) {
+	t.Parallel()
+	// Guard the demo manifests so a schema change that breaks them fails
+	// here rather than in a live demo.
+	for _, name := range []string{
+		"policy-projection.toml", "policy-projection-v2.toml",
+		"policy-projection.yaml", "policy-projection-v2.yaml",
+	} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join("..", "..", "examples", name)
+			m, err := ParseManifest(path)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			if len(m.Policies) == 0 {
+				t.Fatalf("%s declares no policies", name)
+			}
+			if m.Teams[0].Roles[0].Policy == "" {
+				t.Fatalf("%s role does not reference a policy", name)
+			}
+			store := NewStore()
+			if err := m.Apply(store); err != nil {
+				t.Fatalf("apply %s: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestStorePolicySnapshotIsolation(t *testing.T) {
+	t.Parallel()
+	store := NewStore()
+	p := &Policy{
+		Name:      "base",
+		Workspace: "acme",
+		Settings:  map[string]any{"permissions": map[string]any{"allow": []any{"Read"}}},
+	}
+	if err := store.CreatePolicy(p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Mutating the caller's map after Create must not affect the store.
+	p.Settings["permissions"] = "clobbered"
+
+	got, err := store.GetPolicy("acme/base")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if _, ok := got.Settings["permissions"].(map[string]any); !ok {
+		t.Fatalf("store snapshot aliased caller state: permissions is %T", got.Settings["permissions"])
+	}
+	// Mutating the returned snapshot must not affect a later read.
+	got.Settings["permissions"] = "clobbered-again"
+	again, err := store.GetPolicy("acme/base")
+	if err != nil {
+		t.Fatalf("get again: %v", err)
+	}
+	if _, ok := again.Settings["permissions"].(map[string]any); !ok {
+		t.Fatalf("returned snapshot aliased store state: permissions is %T", again.Settings["permissions"])
+	}
+}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -26,6 +26,7 @@ type Store struct {
 	sessions   map[string]*Session
 	teams      map[string]*Team
 	endpoints  map[string]*Endpoint
+	policies   map[string]*Policy
 
 	// bolt is the optional L2 persistence backend. Nil means in-memory
 	// only (default for tests + the legacy daemon path). Populated by
@@ -41,6 +42,7 @@ func NewStore() *Store {
 		sessions:   make(map[string]*Session),
 		teams:      make(map[string]*Team),
 		endpoints:  make(map[string]*Endpoint),
+		policies:   make(map[string]*Policy),
 	}
 }
 
@@ -88,6 +90,42 @@ func cloneTeam(t *Team) Team {
 		out.Shift.Roles = slices.Clone(t.Shift.Roles)
 	}
 	return out
+}
+
+func clonePolicy(p *Policy) Policy {
+	out := *p
+	out.Settings = cloneSettings(p.Settings)
+	return out
+}
+
+// cloneSettings deep-copies a JSON-shaped settings tree so a snapshot is
+// safe to mutate or marshal while the store keeps updating the live one.
+// Settings only ever holds JSON-decoded values (map[string]any, []any,
+// and scalars), so a structural walk is enough; scalars copy by value.
+func cloneSettings(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = cloneSettingsValue(v)
+	}
+	return out
+}
+
+func cloneSettingsValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return cloneSettings(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = cloneSettingsValue(e)
+		}
+		return out
+	default:
+		return t
+	}
 }
 
 // Workspace operations
@@ -382,6 +420,74 @@ func (s *Store) DeleteEndpoint(key string) error {
 	}
 	delete(s.endpoints, key)
 	return nil
+}
+
+// Policy operations
+
+// CreatePolicy clones the input into the store. The caller's pointer is
+// not aliased with store state; Settings is deep-copied.
+func (s *Store) CreatePolicy(p *Policy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.policies[p.Key()]; ok {
+		return fmt.Errorf("policy %s: %w", p.Key(), ErrAlreadyExists)
+	}
+	c := clonePolicy(p)
+	if err := s.persistPut(bucketPolicies, c.Key(), c); err != nil {
+		return err
+	}
+	s.policies[p.Key()] = &c
+	return nil
+}
+
+// GetPolicy returns a snapshot of the named policy.
+func (s *Store) GetPolicy(key string) (Policy, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.policies[key]
+	if !ok {
+		return Policy{}, fmt.Errorf("policy %s: %w", key, ErrNotFound)
+	}
+	return clonePolicy(p), nil
+}
+
+// ListPolicies returns snapshots of all policies.
+func (s *Store) ListPolicies() []Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]Policy, 0, len(s.policies))
+	for _, p := range s.policies {
+		result = append(result, clonePolicy(p))
+	}
+	return result
+}
+
+func (s *Store) DeletePolicy(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.policies[key]; !ok {
+		return fmt.Errorf("policy %s: %w", key, ErrNotFound)
+	}
+	if err := s.persistDelete(bucketPolicies, key); err != nil {
+		return err
+	}
+	delete(s.policies, key)
+	return nil
+}
+
+// UpdatePolicy applies fn to the live policy under the write lock. Same
+// pointer-lifetime and persist semantics as UpdateTeam.
+func (s *Store) UpdatePolicy(key string, fn func(*Policy) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.policies[key]
+	if !ok {
+		return fmt.Errorf("policy %s: %w", key, ErrNotFound)
+	}
+	if err := fn(p); err != nil {
+		return err
+	}
+	return s.persistPut(bucketPolicies, p.Key(), p)
 }
 
 // UpdateSessionHeartbeat updates a session's context pressure and

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -175,10 +175,16 @@ type Role struct {
 	// is a cooperative contract; real enforcement belongs to curtain.
 	// Combined with a curtain profile, this is the default sensible shape
 	// for autonomous fleet agents.
-	DangerousPermissions bool         `toml:"dangerous_permissions,omitempty"`
-	Persona              string       `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
-	Identity             string       `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")
-	HealthCheck          *HealthCheck `toml:"-"`
+	DangerousPermissions bool   `toml:"dangerous_permissions,omitempty"`
+	Persona              string `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
+	Identity             string `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")
+	// Policy names the Policy this role's sessions are projected with —
+	// the contract half of finding-024: a Claude Code settings fragment
+	// marvel writes to a per-session file the harness reads. Empty means
+	// no projection. Resolved within the role's workspace. The sandbox
+	// half (a curtain profile) stays parked with aae-orc-10x.
+	Policy      string       `toml:"policy,omitempty"`
+	HealthCheck *HealthCheck `toml:"-"`
 	// MaxRestarts caps the number of restarts for any single replica
 	// slot in this role before the reconciler gives up and leaves the
 	// session in SessionFailed. Zero means unlimited; negative values
@@ -227,8 +233,34 @@ type Host struct {
 	Status string
 }
 
+// Policy is a named Claude Code settings fragment marvel projects into a
+// per-session file (the ConfigMap equivalent in the finding-024 model).
+// It is the contract half only: Settings is written verbatim as JSON to
+// the file the harness reads (permissions.allow/deny, hooks, and the rest
+// of the Claude Code settings surface). Marvel owns the truth and does not
+// interpret the contents. The sandbox half (a curtain profile) is a
+// separate resource parked with aae-orc-10x; tamper-proofing the projected
+// file is aae-orc-wbqi. Scoped to a workspace and referenced by a Role's
+// Policy field.
+type Policy struct {
+	Name      string `toml:"name"`
+	Workspace string `toml:"-"`
+	// Version is an operator-facing label (e.g. "1.2"). Marvel does not
+	// resolve on it today — it rides along for observability and future
+	// pinning.
+	Version string `toml:"version,omitempty"`
+	// Settings is the Claude Code settings fragment, written verbatim as
+	// JSON. It is map[string]any because marvel is a pass-through for a
+	// third party's schema (Claude Code's), not an owner of it — pinning a
+	// Go struct here would couple marvel's releases to Claude Code's
+	// settings schema for no gain.
+	Settings  map[string]any `toml:"-"`
+	CreatedAt time.Time      `toml:"-"`
+}
+
 // Key returns the namespaced key for a resource.
 func (w *Workspace) Key() string { return w.Name }
 func (s *Session) Key() string   { return fmt.Sprintf("%s/%s", s.Workspace, s.Name) }
 func (t *Team) Key() string      { return fmt.Sprintf("%s/%s", t.Workspace, t.Name) }
 func (e *Endpoint) Key() string  { return fmt.Sprintf("%s/%s", e.Workspace, e.Name) }
+func (p *Policy) Key() string    { return fmt.Sprintf("%s/%s", p.Workspace, p.Name) }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -617,6 +617,15 @@ func (d *Daemon) handleApply(params json.RawMessage) Response {
 		return Response{Error: fmt.Sprintf("apply manifest: %v", err)}
 	}
 
+	// Re-project policies for already-running sessions before reconciling.
+	// A policy edited in this manifest reconciles by rewriting the session's
+	// settings file (finding-024 contract half); Claude Code's file watcher
+	// hot-reloads it with no restart. New sessions spawned by the reconcile
+	// below get their projection at spawn time.
+	if n := d.sessMgr.Reproject(); n > 0 {
+		log.Printf("apply: re-projected policy for %d running session(s)", n)
+	}
+
 	// Trigger immediate reconciliation.
 	d.teamCtrl.ReconcileOnce()
 
@@ -648,6 +657,8 @@ func (d *Daemon) handleGet(params json.RawMessage) Response {
 		result = d.store.ListWorkspaces()
 	case "endpoints", "endpoint":
 		result = d.store.ListEndpoints()
+	case "policies", "policy":
+		result = d.store.ListPolicies()
 	default:
 		return Response{Error: fmt.Sprintf("unknown resource type: %s", p.ResourceType)}
 	}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -31,6 +31,11 @@ const (
 	KindShiftStarted      Kind = "team.shift-started"
 	KindShiftCompleted    Kind = "team.shift-completed"
 	KindRoleSaturated     Kind = "role.saturated"
+	// KindPolicyProjected records that marvel wrote (or rewrote) a
+	// session's projected Claude Code settings file — the observable
+	// signal of a policy landing at spawn and of live re-projection after
+	// a manifest change. See finding-024.
+	KindPolicyProjected Kind = "policy.projected"
 )
 
 // Agent-stream kinds. These are the runtime adapter vocabulary

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -6,6 +6,8 @@ package runtime
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/arcavenae/marvel/internal/api"
@@ -26,6 +28,29 @@ type LaunchContext struct {
 	// has no sink directory. An adapter that finds it empty must produce
 	// a working command anyway.
 	StreamPath string
+	// PolicyProjectionPath is the file the session manager wrote this
+	// session's projected Claude Code settings fragment to (see
+	// finding-024). It is non-empty only when the role references a policy
+	// AND the adapter reported ProjectionFor().Supported. Prepare appends
+	// the adapter's own read-flag pointing at it (claude: a top-level
+	// --settings; forestage: --settings in the claude passthrough). Empty
+	// means no projection for this launch and Prepare injects nothing.
+	PolicyProjectionPath string
+}
+
+// ProjectionTarget is an adapter's answer to "where does this session's
+// projected policy settings file go, and can this harness read one?".
+// The session manager calls ProjectionFor at spawn and on every live
+// re-projection; it writes Settings JSON to Path only when Supported.
+type ProjectionTarget struct {
+	// Supported reports whether this harness exposes a Claude Code
+	// settings-fragment surface. False for harnesses that have none
+	// (codex, opencode, generic today); marvel then logs the referenced
+	// policy as advisory for that runtime rather than dropping it silently.
+	Supported bool
+	// Path is the file marvel writes the resolved settings fragment to.
+	// Set only when Supported.
+	Path string
 }
 
 // LaunchResult is what the adapter returns: the fully resolved command,
@@ -50,6 +75,15 @@ type Adapter interface {
 	// Prepare constructs the command, args, and environment for launching
 	// a session. The returned command string is passed to tmux new-window.
 	Prepare(ctx *LaunchContext) (*LaunchResult, error)
+
+	// ProjectionFor reports where marvel writes this session's projected
+	// Claude Code settings fragment and whether the harness can read one.
+	// dir is the manager-owned directory projected files live under. The
+	// session manager calls this at spawn (before Prepare) and on every
+	// live re-projection, so the answer must depend only on the runtime
+	// and the launch identity, never on prior Prepare state. A harness
+	// with no settings surface returns Supported=false.
+	ProjectionFor(ctx *LaunchContext, dir string) ProjectionTarget
 }
 
 // Registry maps runtime names to adapters.
@@ -146,6 +180,16 @@ func shellQuote(s string) string {
 	}
 	result += "'"
 	return result
+}
+
+// settingsProjectionPath is the per-session projected settings file for
+// adapters that read a Claude Code settings fragment (claude, forestage).
+// One shape, shared, so the two supporting adapters agree on where the
+// manager writes and re-writes the file. Session keys contain a slash
+// (workspace/name); it is folded to a dash so the key is one path segment.
+func settingsProjectionPath(dir, sessionKey string) string {
+	name := strings.ReplaceAll(sessionKey, "/", "-") + ".settings.json"
+	return filepath.Join(dir, name)
 }
 
 // resolveCommand returns the command to execute. If Runtime.Command is set,

--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -20,6 +20,16 @@ func (c *Claude) SupportsStream(ctx *LaunchContext) bool {
 	return ctx.Session.Runtime.Mode == api.RuntimeModeHeadless
 }
 
+// ProjectionFor reports where marvel writes claude's projected settings
+// fragment. Claude Code reads it via a top-level --settings flag
+// (injected in Prepare), so this runtime supports projection.
+func (c *Claude) ProjectionFor(ctx *LaunchContext, dir string) ProjectionTarget {
+	return ProjectionTarget{
+		Supported: true,
+		Path:      settingsProjectionPath(dir, ctx.Session.Key()),
+	}
+}
+
 func (c *Claude) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {
@@ -32,6 +42,13 @@ func (c *Claude) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 
 	args := make([]string, len(ctx.Session.Runtime.Args))
 	copy(args, ctx.Session.Runtime.Args)
+
+	// Point claude at the projected policy settings file when marvel wrote
+	// one for this launch. Claude Code re-reads it mid-session, so a later
+	// re-projection changes the running agent's contract without a restart.
+	if ctx.PolicyProjectionPath != "" {
+		args = append(args, "--settings", ctx.PolicyProjectionPath)
+	}
 
 	if headless {
 		// --verbose is not optional here: claude refuses stream-json

--- a/internal/runtime/codex.go
+++ b/internal/runtime/codex.go
@@ -31,6 +31,14 @@ func (c *Codex) SupportsStream(ctx *LaunchContext) bool {
 	return ctx.Session.Runtime.Mode == api.RuntimeModeHeadless
 }
 
+// ProjectionFor reports no projection surface. Codex configures itself
+// through its own config file and -c overrides, not a Claude Code
+// settings fragment, so a policy is advisory for this runtime — marvel
+// logs it rather than writing a file codex would not read.
+func (c *Codex) ProjectionFor(_ *LaunchContext, _ string) ProjectionTarget {
+	return ProjectionTarget{Supported: false}
+}
+
 func (c *Codex) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {

--- a/internal/runtime/forestage.go
+++ b/internal/runtime/forestage.go
@@ -25,6 +25,17 @@ type Forestage struct{}
 
 func (f *Forestage) Name() string { return "forestage" }
 
+// ProjectionFor reports where marvel writes forestage's projected settings
+// fragment. forestage forwards claude flags after the "--" passthrough, so
+// the projected file reaches Claude Code via --settings there (injected in
+// Prepare). This runtime supports projection.
+func (f *Forestage) ProjectionFor(ctx *LaunchContext, dir string) ProjectionTarget {
+	return ProjectionTarget{
+		Supported: true,
+		Path:      settingsProjectionPath(dir, ctx.Session.Key()),
+	}
+}
+
 func (f *Forestage) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {
@@ -48,7 +59,8 @@ func (f *Forestage) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	args = append(args, "--role", ctx.Role.Name)
 
 	// Inject marvel identity flags — forestage accepts these natively.
-	args = append(args,
+	args = append(
+		args,
 		"--name", ctx.Session.Name,
 		"--workspace", ctx.Workspace.Name,
 		"--team", ctx.Team.Name,
@@ -76,12 +88,19 @@ func (f *Forestage) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 		args = append(args, "--script", ctx.Session.Runtime.Script)
 	}
 
-	// Claude passthrough: team context as system prompt.
+	// Claude passthrough: projected settings file (when marvel wrote one)
+	// then team context as system prompt. forestage forwards everything
+	// after "--" to its claude subprocess, so --settings lands where Claude
+	// Code's file watcher hot-reloads it on a later re-projection.
 	teamContext := fmt.Sprintf(
 		"You are %s (role: %s, team: %s, workspace: %s).",
 		ctx.Session.Name, ctx.Role.Name, ctx.Team.Name, ctx.Workspace.Name,
 	)
-	args = append(args, "--", "--append-system-prompt", teamContext)
+	args = append(args, "--")
+	if ctx.PolicyProjectionPath != "" {
+		args = append(args, "--settings", ctx.PolicyProjectionPath)
+	}
+	args = append(args, "--append-system-prompt", teamContext)
 
 	env := baseEnv(ctx)
 

--- a/internal/runtime/generic.go
+++ b/internal/runtime/generic.go
@@ -94,6 +94,13 @@ func (s *GenericScraper) Scrape() ([]string, error) {
 
 func (g *Generic) Name() string { return "generic" }
 
+// ProjectionFor reports no projection surface. A generic command has no
+// known settings-fragment mechanism, so a referenced policy is advisory —
+// marvel logs it rather than writing a file the command would not read.
+func (g *Generic) ProjectionFor(_ *LaunchContext, _ string) ProjectionTarget {
+	return ProjectionTarget{Supported: false}
+}
+
 func (g *Generic) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {

--- a/internal/runtime/opencode.go
+++ b/internal/runtime/opencode.go
@@ -30,6 +30,14 @@ func (o *OpenCode) SupportsStream(ctx *LaunchContext) bool {
 	return ctx.Session.Runtime.Mode == api.RuntimeModeHeadless
 }
 
+// ProjectionFor reports no projection surface. OpenCode reads its own
+// opencode.json config, not a Claude Code settings fragment, so a policy
+// is advisory for this runtime — marvel logs it rather than writing a
+// file opencode would not read.
+func (o *OpenCode) ProjectionFor(_ *LaunchContext, _ string) ProjectionTarget {
+	return ProjectionTarget{Supported: false}
+}
+
 func (o *OpenCode) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
 	binary := resolveCommand(&ctx.Session.Runtime)
 	if binary == "" {

--- a/internal/runtime/projection_test.go
+++ b/internal/runtime/projection_test.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProjectionFor exercises the projection surface each adapter declares.
+// claude and forestage read a Claude Code settings fragment; codex,
+// opencode, and generic have none and must report Supported=false so the
+// manager logs the policy as advisory rather than dropping it.
+func TestProjectionFor(t *testing.T) {
+	t.Parallel()
+	const dir = "/var/run/marvel/policies"
+
+	tests := []struct {
+		name          string
+		adapter       Adapter
+		wantSupported bool
+		wantPath      string
+	}{
+		{"claude", &Claude{}, true, "/var/run/marvel/policies/acme-squad-worker-g1-0.settings.json"},
+		{"forestage", &Forestage{}, true, "/var/run/marvel/policies/acme-squad-worker-g1-0.settings.json"},
+		{"codex", &Codex{}, false, ""},
+		{"opencode", &OpenCode{}, false, ""},
+		{"generic", &Generic{}, false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.adapter.ProjectionFor(testContext(), dir)
+			if got.Supported != tt.wantSupported {
+				t.Fatalf("Supported = %v, want %v", got.Supported, tt.wantSupported)
+			}
+			if got.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestPrepareInjectsProjectionFlag confirms the supporting adapters point
+// their harness at the projected file when the manager set the path, and
+// place the flag correctly (claude top-level; forestage inside the "--"
+// passthrough).
+func TestPrepareInjectsProjectionFlag(t *testing.T) {
+	t.Parallel()
+	const path = "/var/run/marvel/policies/acme-squad-worker-g1-0.settings.json"
+
+	t.Run("claude top-level", func(t *testing.T) {
+		t.Parallel()
+		ctx := testContext()
+		ctx.Session.Runtime.Command = "claude"
+		ctx.PolicyProjectionPath = path
+		res, err := (&Claude{}).Prepare(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		if !strings.Contains(res.Command, "--settings "+path) {
+			t.Errorf("command missing --settings %s:\n%s", path, res.Command)
+		}
+	})
+
+	t.Run("forestage passthrough after --", func(t *testing.T) {
+		t.Parallel()
+		ctx := testContext()
+		ctx.PolicyProjectionPath = path
+		res, err := (&Forestage{}).Prepare(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		sep := strings.Index(res.Command, " -- ")
+		if sep < 0 {
+			t.Fatalf("no -- passthrough separator in:\n%s", res.Command)
+		}
+		flag := strings.Index(res.Command, "--settings "+path)
+		if flag < 0 {
+			t.Fatalf("command missing --settings %s:\n%s", path, res.Command)
+		}
+		if flag < sep {
+			t.Errorf("--settings appears before -- separator (should be passthrough):\n%s", res.Command)
+		}
+	})
+
+	t.Run("no path means no flag", func(t *testing.T) {
+		t.Parallel()
+		ctx := testContext()
+		ctx.Session.Runtime.Command = "claude"
+		res, err := (&Claude{}).Prepare(ctx)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		if strings.Contains(res.Command, "--settings") {
+			t.Errorf("unexpected --settings with no projection path:\n%s", res.Command)
+		}
+	})
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -34,6 +34,12 @@ type Manager struct {
 	// from. Defaults to a per-process temp directory; the pipes carry no
 	// content at rest, so there is nothing to preserve across restarts.
 	StreamDir string
+	// ProjectionDir holds the per-session projected policy settings files
+	// (finding-024's contract half). Defaults to a per-process temp
+	// directory. The files are derived from the store's policies, so they
+	// are rewritten at spawn and on re-projection; nothing is preserved
+	// across restarts.
+	ProjectionDir string
 
 	// instances tracks the live Instance per session key. Sessions
 	// adopted from a previous daemon have no entry: their pane predates
@@ -45,17 +51,24 @@ type Manager struct {
 // NewManager creates a session manager with the default runtime adapter registry.
 func NewManager(store *api.Store, driver *tmux.Driver) *Manager {
 	return &Manager{
-		store:     store,
-		driver:    driver,
-		adapters:  runtime.NewRegistry(),
-		StreamDir: defaultStreamDir(),
-		instances: make(map[string]*runtime.TmuxInstance),
+		store:         store,
+		driver:        driver,
+		adapters:      runtime.NewRegistry(),
+		StreamDir:     defaultStreamDir(),
+		ProjectionDir: defaultProjectionDir(),
+		instances:     make(map[string]*runtime.TmuxInstance),
 	}
 }
 
 // defaultStreamDir keeps one daemon's pipes away from another's.
 func defaultStreamDir() string {
 	return filepath.Join(os.TempDir(), fmt.Sprintf("marvel-streams-%d", os.Getpid()))
+}
+
+// defaultProjectionDir keeps one daemon's projected settings files away
+// from another's.
+func defaultProjectionDir() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("marvel-policies-%d", os.Getpid()))
 }
 
 // marvelSessionPrefix is the tmux session name prefix marvel owns.
@@ -305,6 +318,12 @@ func (m *Manager) planLaunch(sess *api.Session) launchPlan {
 		Workspace:  &ws,
 		SocketPath: m.SocketPath,
 	}
+
+	// Project the role's policy (finding-024 contract half) before Prepare
+	// so the adapter can point the harness at the settings file. Sets
+	// lctx.PolicyProjectionPath when the adapter supports projection and a
+	// policy resolves; a no-op otherwise.
+	m.projectForLaunch(lctx, adapter)
 
 	// Ask before building: an adapter that never streams (or one asked
 	// for an interactive launch) should cost no filesystem work.

--- a/internal/session/projection.go
+++ b/internal/session/projection.go
@@ -1,0 +1,188 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	"github.com/arcavenae/marvel/internal/runtime"
+)
+
+// projectForLaunch resolves the policy a launch's role references and, when
+// the adapter exposes a settings surface, writes the projected file and
+// points the launch at it via lctx.PolicyProjectionPath. Called from
+// planLaunch before Prepare. Projection is best-effort relative to a
+// working session: a write failure is logged and the session launches
+// unprojected rather than being refused.
+func (m *Manager) projectForLaunch(lctx *runtime.LaunchContext, adapter runtime.Adapter) {
+	target, wrote, _, err := m.projectPolicy(lctx, adapter)
+	if err != nil {
+		log.Printf("session %s: policy projection failed, launching unprojected: %v", lctx.Session.Key(), err)
+		return
+	}
+	if !wrote {
+		return
+	}
+	lctx.PolicyProjectionPath = target.Path
+	m.emitProjected(lctx.Session, lctx.Role.Policy, target.Path, "projected at spawn")
+}
+
+// Reproject rewrites the projected settings file for every live session
+// whose role references a policy, and emits a policy.projected event for
+// each session whose on-disk contract actually changed. This is the live
+// re-projection beat of finding-024: the daemon calls it after applying a
+// manifest, an edited policy's new settings land in the running agents'
+// files, and Claude Code's file watcher picks them up without a restart.
+//
+// Returns the number of files rewritten with changed content, for the
+// caller's logs.
+func (m *Manager) Reproject() int {
+	if m.ProjectionDir == "" {
+		return 0
+	}
+	changedCount := 0
+	for _, sess := range m.store.ListSessions() {
+		if !sess.State.CountsAsAlive() {
+			continue
+		}
+		lctx, adapter, ok := m.reprojectContext(sess)
+		if !ok {
+			continue
+		}
+		target, wrote, changed, err := m.projectPolicy(lctx, adapter)
+		if err != nil {
+			log.Printf("session %s: re-projection failed: %v", sess.Key(), err)
+			continue
+		}
+		if wrote && changed {
+			changedCount++
+			m.emitProjected(lctx.Session, lctx.Role.Policy, target.Path, "re-projected after manifest change")
+		}
+	}
+	return changedCount
+}
+
+// reprojectContext rebuilds the adapter and launch context for a live
+// session from current store state — the same team/role/workspace lookups
+// planLaunch does at spawn, minus the stream sink (re-projection touches
+// only the settings file, never the pane). Reports false when any resource
+// is missing, in which case the session cannot be re-projected.
+func (m *Manager) reprojectContext(sess api.Session) (*runtime.LaunchContext, runtime.Adapter, bool) {
+	team, err := m.store.GetTeam(fmt.Sprintf("%s/%s", sess.Workspace, sess.Team))
+	if err != nil {
+		return nil, nil, false
+	}
+	var role *api.Role
+	for i := range team.Roles {
+		if team.Roles[i].Name == sess.Role {
+			role = &team.Roles[i]
+			break
+		}
+	}
+	if role == nil {
+		return nil, nil, false
+	}
+	ws, err := m.store.GetWorkspace(sess.Workspace)
+	if err != nil {
+		return nil, nil, false
+	}
+	// GetSession/GetTeam/GetWorkspace return value snapshots; taking
+	// addresses of these locals is safe because the LaunchContext is
+	// read-only and does not outlive this call chain (finding-032).
+	sessCopy := sess
+	return &runtime.LaunchContext{
+		Session:    &sessCopy,
+		Role:       role,
+		Team:       &team,
+		Workspace:  &ws,
+		SocketPath: m.SocketPath,
+	}, m.adapters.Resolve(sess.Runtime.Name), true
+}
+
+// projectPolicy is the shared spawn/re-projection core. It resolves the
+// role's policy, asks the adapter where the file goes, and writes it when
+// the adapter has a settings surface. Returns the projection target, whether
+// a file was written, and whether the written content differed from what
+// was already on disk.
+//
+// A role with no policy yields wrote=false, no error. An adapter with no
+// settings surface logs the policy as advisory and yields wrote=false. A
+// referenced policy that is not in the store is an error (validation should
+// prevent it, so reaching here means drift worth surfacing).
+func (m *Manager) projectPolicy(lctx *runtime.LaunchContext, adapter runtime.Adapter) (runtime.ProjectionTarget, bool, bool, error) {
+	if m.ProjectionDir == "" || lctx.Role.Policy == "" {
+		return runtime.ProjectionTarget{}, false, false, nil
+	}
+
+	target := adapter.ProjectionFor(lctx, m.ProjectionDir)
+	if !target.Supported {
+		log.Printf("session %s: runtime %q has no settings surface; policy %q is advisory, not projected",
+			lctx.Session.Key(), adapter.Name(), lctx.Role.Policy)
+		return target, false, false, nil
+	}
+
+	key := fmt.Sprintf("%s/%s", lctx.Workspace.Name, lctx.Role.Policy)
+	policy, err := m.store.GetPolicy(key)
+	if err != nil {
+		return target, false, false, fmt.Errorf("resolve policy %s: %w", key, err)
+	}
+
+	changed, err := writeProjectionFile(target.Path, policy.Settings)
+	if err != nil {
+		return target, false, false, err
+	}
+	return target, true, changed, nil
+}
+
+// writeProjectionFile renders settings as indented JSON and writes it to
+// path, creating the parent directory. It reports whether the new content
+// differs from what was already there, so callers can emit an event only on
+// a real contract change. Files are 0600: a settings fragment can carry an
+// allow/deny list an operator would not want world-readable.
+func writeProjectionFile(path string, settings map[string]any) (bool, error) {
+	// A nil settings map projects an empty object rather than the JSON
+	// literal null, so the harness always reads a well-formed settings file.
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal policy settings for %s: %w", path, err)
+	}
+	data = append(data, '\n')
+
+	existing, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if bytes.Equal(existing, data) {
+			return false, nil
+		}
+	case !errors.Is(err, os.ErrNotExist):
+		return false, fmt.Errorf("read existing projection %s: %w", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return false, fmt.Errorf("create projection dir for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return false, fmt.Errorf("write projection %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func (m *Manager) emitProjected(sess *api.Session, policyName, path, detail string) {
+	events.Emit(m.Events, events.Event{
+		Kind:      events.KindPolicyProjected,
+		Workspace: sess.Workspace,
+		Team:      sess.Team,
+		Role:      sess.Role,
+		Session:   sess.Key(),
+		Message:   fmt.Sprintf("policy %q %s: %s", policyName, detail, path),
+	})
+}

--- a/internal/session/projection_test.go
+++ b/internal/session/projection_test.go
@@ -1,0 +1,208 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	"github.com/arcavenae/marvel/internal/runtime"
+)
+
+const projectionManifest = `
+[workspace]
+name = "acme"
+
+[[policy]]
+name = "reviewer-contract"
+version = "1.0"
+
+  [policy.settings.permissions]
+  allow = ["Read", "Grep"]
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "reviewer"
+  replicas = 1
+  policy = "reviewer-contract"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"
+`
+
+// projectionManager builds a Manager wired only for projection: a store, a
+// tempdir projection root, an event ring, and no tmux driver. Reproject and
+// the projection helpers never touch the driver, so nil is safe here and
+// keeps the test hermetic (no tmux server required).
+func projectionManager(t *testing.T) (*Manager, *events.Ring) {
+	t.Helper()
+	store := api.NewStore()
+	ring := events.NewRing(64)
+	mgr := &Manager{
+		store:         store,
+		adapters:      runtime.NewRegistry(),
+		ProjectionDir: t.TempDir(),
+		Events:        ring,
+	}
+	return mgr, ring
+}
+
+// seedRunningSession registers a Running session for the given role so
+// Reproject treats it as live. Returns the session key.
+func seedRunningSession(t *testing.T, mgr *Manager, workspace, team, role, name, image string) string {
+	t.Helper()
+	sess := &api.Session{
+		Name:      name,
+		Workspace: workspace,
+		Team:      team,
+		Role:      role,
+		Runtime:   api.Runtime{Name: image, Command: image},
+	}
+	if err := mgr.store.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := mgr.store.UpdateSession(sess.Key(), func(live *api.Session) error {
+		live.State = api.SessionRunning
+		live.PaneID = "%1"
+		return nil
+	}); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	return sess.Key()
+}
+
+func readProjection(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read projection %s: %v", path, err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal projection: %v", err)
+	}
+	return out
+}
+
+func TestReprojectRewritesOnPolicyChange(t *testing.T) {
+	t.Parallel()
+	mgr, ring := projectionManager(t)
+
+	m, err := api.ParseManifestBytes([]byte(projectionManifest))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := m.Apply(mgr.store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	key := seedRunningSession(t, mgr, "acme", "squad", "reviewer", "squad-reviewer-g1-0", "claude")
+
+	// First projection: fresh file, counts as a change.
+	if n := mgr.Reproject(); n != 1 {
+		t.Fatalf("first Reproject changed = %d, want 1", n)
+	}
+	path := filepath.Join(mgr.ProjectionDir, strings.ReplaceAll(key, "/", "-")+".settings.json")
+	got := readProjection(t, path)
+	perms, ok := got["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("projection missing permissions block: %v", got)
+	}
+	if allow, ok := perms["allow"].([]any); !ok || len(allow) != 2 {
+		t.Fatalf("permissions.allow = %v, want two entries", perms["allow"])
+	}
+
+	// Re-projecting with no change writes nothing new.
+	if n := mgr.Reproject(); n != 0 {
+		t.Fatalf("no-op Reproject changed = %d, want 0", n)
+	}
+
+	// Edit the policy: a second version tightening the allow list.
+	edited := strings.Replace(projectionManifest,
+		`allow = ["Read", "Grep"]`, `allow = ["Read"]`, 1)
+	m2, err := api.ParseManifestBytes([]byte(edited))
+	if err != nil {
+		t.Fatalf("parse edited: %v", err)
+	}
+	if err := m2.Apply(mgr.store); err != nil {
+		t.Fatalf("apply edited: %v", err)
+	}
+
+	// Re-projection after the edit rewrites the running session's file.
+	if n := mgr.Reproject(); n != 1 {
+		t.Fatalf("post-edit Reproject changed = %d, want 1", n)
+	}
+	got2 := readProjection(t, path)
+	perms2 := got2["permissions"].(map[string]any)
+	if allow, ok := perms2["allow"].([]any); !ok || len(allow) != 1 {
+		t.Fatalf("post-edit permissions.allow = %v, want one entry", perms2["allow"])
+	}
+
+	// Both changes emitted an observable event.
+	evs := ring.Snapshot(events.Filter{Kind: events.KindPolicyProjected, Session: key}, 0)
+	if len(evs) != 2 {
+		t.Fatalf("policy.projected events = %d, want 2", len(evs))
+	}
+	if !strings.Contains(evs[1].Message, "re-projected") {
+		t.Errorf("second event message = %q, want re-projection detail", evs[1].Message)
+	}
+}
+
+func TestReprojectSkipsUnsupportedRuntime(t *testing.T) {
+	t.Parallel()
+	mgr, ring := projectionManager(t)
+
+	// A codex role referencing a policy: codex has no settings surface, so
+	// the policy is advisory — nothing written, nothing counted, but the
+	// session is otherwise valid.
+	manifest := strings.Replace(projectionManifest,
+		`    image = "claude"
+    command = "claude"`,
+		`    image = "codex"
+    command = "codex"`, 1)
+	m, err := api.ParseManifestBytes([]byte(manifest))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := m.Apply(mgr.store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	key := seedRunningSession(t, mgr, "acme", "squad", "reviewer", "squad-reviewer-g1-0", "codex")
+
+	if n := mgr.Reproject(); n != 0 {
+		t.Fatalf("Reproject changed = %d, want 0 for advisory policy", n)
+	}
+	path := filepath.Join(mgr.ProjectionDir, strings.ReplaceAll(key, "/", "-")+".settings.json")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("advisory policy wrote a file at %s (err=%v)", path, err)
+	}
+	if n := len(ring.Snapshot(events.Filter{Kind: events.KindPolicyProjected}, 0)); n != 0 {
+		t.Errorf("advisory policy emitted %d projection events, want 0", n)
+	}
+}
+
+func TestReprojectNoPolicyIsNoOp(t *testing.T) {
+	t.Parallel()
+	mgr, _ := projectionManager(t)
+
+	// Same manifest without the role policy reference.
+	manifest := strings.Replace(projectionManifest,
+		"  policy = \"reviewer-contract\"\n", "", 1)
+	m, err := api.ParseManifestBytes([]byte(manifest))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := m.Apply(mgr.store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	seedRunningSession(t, mgr, "acme", "squad", "reviewer", "squad-reviewer-g1-0", "claude")
+
+	if n := mgr.Reproject(); n != 0 {
+		t.Fatalf("Reproject changed = %d, want 0 with no policy reference", n)
+	}
+}


### PR DESCRIPTION
Marvel can declare who an agent is and how it runs, but it cannot yet say what an agent may do beyond one passthrough permission-mode string. This adds the contract half of finding-024: a Policy resource whose Claude Code settings fragment marvel writes into a per-session file the harness reads, re-projected live when the manifest changes so a running agent's permissions shift without a restart. That live re-projection is the most legible control-plane beat marvel can show.

Additive throughout. Manifests with no policies keep working unchanged.

## What lands

- **api**: a `Policy` type (name, version, a verbatim Claude Code settings map), workspace-scoped and referenced by a new `Role.Policy` field. Store CRUD returning deep-cloned snapshots (finding-032), a bolt bucket + rehydrate, manifest `[[policy]]` parsing with validation (name required, unique, role references resolve), and `Apply` create-or-update so an edited policy lands in place.
- **runtime**: projection is now an `Adapter` interface method. `ProjectionFor` declares where a session's settings file goes and whether the harness can read one. claude and forestage support it (claude via a top-level `--settings`; forestage via the same flag inside its claude `--` passthrough). codex, opencode, and generic have no Claude Code settings surface, so they report `Supported=false` and marvel logs the policy as advisory for that runtime rather than dropping it silently. Every adapter implements the method.
- **session**: the manager writes the projected file at spawn and re-projects running sessions on manifest apply, emitting a `policy.projected` event only when the on-disk contract actually changed. The daemon calls `Reproject` after `Apply`, before reconcile.
- **cmd**: `marvel get policies`.
- **examples**: `policy-projection` (.toml + .yaml) plus a `v2` pair that tightens the same policy, for the live swap.

## Demo path

```
./marvel work examples/policy-projection.toml    # policy.projected at spawn
./marvel get policies
./marvel work examples/policy-projection-v2.toml  # re-projected, no restart
./marvel events --kind policy.projected
```

## Scope

The sandbox half of finding-024 (a curtain profile) stays parked with aae-orc-10x; curtain is unimplemented on every platform. Tamper-proofing the projected file is the filed child aae-orc-wbqi. Policy composition (a role referencing multiple policies with a deterministic merge) is deferred; a role references one policy today.

## Tests

Policy parse + validation, adapter projection (table-driven per adapter, incl. the advisory runtimes), flag injection for claude and forestage, and a manager-level test that editing a policy re-projects the file for a running session and emits the event. `go build/vet/test ./...` pass, `-race` clean on api/runtime/session, golangci-lint clean.