### PR TITLE
fix(marvel): raise tmux history-limit and validate manifest permission modes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,6 +78,31 @@ The `permissions` field controls what the Claude Code agent can do.
 Marvel injects this as `--permission-mode` at launch time. Workers get
 `plan` (must approve tool calls), the supervisor gets `auto` (autonomous).
 
+**Valid permission modes.** `permissions` must be one of Claude Code's
+`--permission-mode` values, or empty. Marvel rejects anything else at
+`marvel apply` time (a typo like `pln` no longer produces a pane that
+exits immediately). The canonical set:
+
+| Mode | Meaning |
+|------|---------|
+| `acceptEdits` | Auto-accept file edits, prompt for other tools |
+| `auto` | Run autonomously |
+| `bypassPermissions` | Auto-allow within the permission model |
+| `default` | Standard interactive prompting |
+| `dontAsk` | Suppress prompts |
+| `plan` | Plan first, approve before acting |
+
+An empty `permissions` means "unset" — the adapter's own default applies.
+
+**`dangerous_permissions` is separate.** The boolean `dangerous_permissions:
+true` appends `--dangerously-skip-permissions`, which removes the permission
+model entirely rather than choosing a mode within it. It is orthogonal to
+`permissions` and combines with any mode. Pick `permissions: bypassPermissions`
+to keep the harness's permission machinery engaged (still auditable, still
+hookable) while auto-allowing within it; pick `dangerous_permissions: true`
+for autonomous fleet agents where no approver exists and enforcement is
+delegated to a sandbox (curtain).
+
 **When to use:** Multi-agent teams where different roles need different
 trust levels. The supervisor can execute freely; workers ask before acting.
 

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -6,12 +6,44 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v3"
 )
+
+// canonicalPermissionModes is the set of values Claude Code's
+// --permission-mode flag accepts. ManifestRole.Permissions is passed
+// through verbatim as --permission-mode by the forestage/claude adapters,
+// so a value outside this set silently produces a broken session — the
+// harness rejects the flag and the pane exits immediately. Validation
+// rejects out-of-set values at parse time instead.
+//
+// An empty Permissions string is valid and means "unset — use the adapter
+// default"; only non-empty out-of-set values are errors. dangerous_permissions
+// is an orthogonal boolean (it appends --dangerously-skip-permissions) and is
+// intentionally NOT part of this set: the two combine freely. See aae-orc-6spa.
+var canonicalPermissionModes = map[string]bool{
+	"acceptEdits":       true,
+	"auto":              true,
+	"bypassPermissions": true,
+	"default":           true,
+	"dontAsk":           true,
+	"plan":              true,
+}
+
+// permissionModeList returns the canonical permission modes sorted and
+// comma-joined, for inclusion in validation error messages.
+func permissionModeList() string {
+	modes := make([]string, 0, len(canonicalPermissionModes))
+	for m := range canonicalPermissionModes {
+		modes = append(modes, m)
+	}
+	sort.Strings(modes)
+	return strings.Join(modes, ", ")
+}
 
 // Manifest represents a manifest declaring desired state.
 // Supports both YAML (default) and TOML formats.
@@ -161,6 +193,13 @@ func validateManifest(m *Manifest) (*Manifest, error) {
 			}
 			if r.Policy != "" && !policyNames[r.Policy] {
 				return nil, fmt.Errorf("parse manifest: team[%d].role[%d] references undefined policy %q", i, j, r.Policy)
+			}
+			// Permissions maps verbatim to --permission-mode; an empty
+			// value means "unset" and is allowed, but a non-empty typo
+			// silently breaks the session, so reject it here. Orthogonal
+			// to dangerous_permissions (see canonicalPermissionModes).
+			if r.Permissions != "" && !canonicalPermissionModes[r.Permissions] {
+				return nil, fmt.Errorf("parse manifest: team[%d].role[%d].permissions %q is not a valid permission mode (valid: %s)", i, j, r.Permissions, permissionModeList())
 			}
 		}
 	}

--- a/internal/api/manifest_test.go
+++ b/internal/api/manifest_test.go
@@ -644,3 +644,72 @@ func TestValidateRuntimesEmptyCommand(t *testing.T) {
 		t.Fatal("expected error on empty command")
 	}
 }
+
+// TestValidateManifestPermissionModes covers aae-orc-6spa: every canonical
+// --permission-mode value must parse, an out-of-set value must be rejected
+// with the full allowlist in the message, and an empty value must stay
+// valid (meaning "unset — adapter default").
+func TestValidateManifestPermissionModes(t *testing.T) {
+	t.Parallel()
+
+	build := func(perm string) *Manifest {
+		return &Manifest{
+			Workspace: ManifestWorkspace{Name: "perm-test"},
+			Teams: []ManifestTeam{{
+				Name: "squad",
+				Roles: []ManifestRole{{
+					Name:        "worker",
+					Replicas:    1,
+					Permissions: perm,
+					Runtime:     ManifestRuntime{Command: "bash"},
+				}},
+			}},
+		}
+	}
+
+	valid := []string{"acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan"}
+	for _, mode := range valid {
+		mode := mode
+		t.Run("valid/"+mode, func(t *testing.T) {
+			t.Parallel()
+			if _, err := validateManifest(build(mode)); err != nil {
+				t.Fatalf("mode %q should be valid, got error: %v", mode, err)
+			}
+		})
+	}
+
+	t.Run("empty-is-valid", func(t *testing.T) {
+		t.Parallel()
+		if _, err := validateManifest(build("")); err != nil {
+			t.Fatalf("empty permissions should be valid (unset), got error: %v", err)
+		}
+	})
+
+	t.Run("invalid-rejected-with-allowlist", func(t *testing.T) {
+		t.Parallel()
+		_, err := validateManifest(build("hammertime"))
+		if err == nil {
+			t.Fatal("expected error on invalid permission mode")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "hammertime") {
+			t.Errorf("error should name the bad value, got: %v", err)
+		}
+		for _, mode := range valid {
+			if !strings.Contains(msg, mode) {
+				t.Errorf("error message must list valid mode %q, got: %v", mode, err)
+			}
+		}
+	})
+
+	// dangerous_permissions is orthogonal: it must combine with any mode
+	// and must not turn a valid mode into an error.
+	t.Run("dangerous-permissions-combines-with-mode", func(t *testing.T) {
+		t.Parallel()
+		m := build("plan")
+		m.Teams[0].Roles[0].DangerousPermissions = true
+		if _, err := validateManifest(m); err != nil {
+			t.Fatalf("dangerous_permissions with a valid mode should validate, got: %v", err)
+		}
+	})
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -175,6 +175,20 @@ type Role struct {
 	// is a cooperative contract; real enforcement belongs to curtain.
 	// Combined with a curtain profile, this is the default sensible shape
 	// for autonomous fleet agents.
+	//
+	// DangerousPermissions is orthogonal to Permissions and combines with
+	// any permission mode. Permissions maps to Claude Code's
+	// --permission-mode (one of acceptEdits, auto, bypassPermissions,
+	// default, dontAsk, plan) and selects HOW the harness prompts within
+	// its cooperative permission model. DangerousPermissions instead
+	// appends --dangerously-skip-permissions, which removes that model.
+	// An operator picks permissions: bypassPermissions to keep the
+	// harness's permission machinery engaged (still auditable, still
+	// hookable) while auto-allowing within it; they pick
+	// dangerous_permissions: true to skip the machinery outright. The two
+	// are validated independently — permission_mode against the canonical
+	// mode set (see api.canonicalPermissionModes), dangerous_permissions
+	// as a free boolean.
 	DangerousPermissions bool   `toml:"dangerous_permissions,omitempty"`
 	Persona              string `toml:"persona,omitempty"`  // character slug (e.g. "naomi-nagata")
 	Identity             string `toml:"identity,omitempty"` // professional lens (e.g. "homicide detective")

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -11,6 +11,15 @@ import (
 	"sync"
 )
 
+// DefaultHistoryLimit is the tmux history-limit (scrollback lines) marvel
+// sets on every session it creates. tmux defaults to 2000, and finding-005
+// measured that a capture-pane scrape of a 20000-line burst recovers only
+// ~20% of the output at that default versus 100% at 100000. Sessions and
+// the adopt-path pipe-pane both read scrollback, so the default starves
+// them. Marvel sets this per session (never with the global -g flag) so it
+// does not mutate the user's tmux server config.
+const DefaultHistoryLimit = 100000
+
 // Driver manages tmux sessions and panes by shelling out to the tmux binary.
 type Driver struct {
 	binary string
@@ -133,6 +142,15 @@ func (d *Driver) NewSession(name string) error {
 	if out, err := d.cmd("new-session", "-d", "-s", name).CombinedOutput(); err != nil {
 		return fmt.Errorf("new-session %s: %s: %w", name, string(out), err)
 	}
+	// Raise the session's history-limit above tmux's 2000-line default so
+	// capture-pane scrapes and the adopt-path pipe-pane see full scrollback
+	// (finding-005). This is a session-scoped set-option (-t <session>,
+	// never -g), so marvel does not touch the user's global tmux config.
+	// New windows marvel opens here inherit the limit at creation; NewPane
+	// always uses new-window, so every marvel-created agent pane gets it.
+	// Best-effort, matching the driver's other set-option calls: a session
+	// that missed the raise still runs, it just scrapes less scrollback.
+	_ = d.cmd("set-option", "-t", name, "history-limit", strconv.Itoa(DefaultHistoryLimit)).Run()
 	return nil
 }
 
@@ -305,6 +323,17 @@ func (d *Driver) CapturePaneRange(paneID string, start, end int) (string, error)
 		return "", fmt.Errorf("capture-pane %s [%d:%d]: %s: %w", paneID, start, end, string(out), err)
 	}
 	return string(out), nil
+}
+
+// ShowOption returns the value of a session option (tmux show-options -v).
+// Used to verify session-scoped options marvel sets at session creation,
+// such as history-limit.
+func (d *Driver) ShowOption(session, option string) (string, error) {
+	out, err := d.cmd("show-options", "-t", session, "-v", option).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("show-options %s %s: %s: %w", session, option, string(out), err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // ListPanes lists all panes across all windows in a session.

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -96,6 +97,35 @@ func TestSessionLifecycle(t *testing.T) {
 	}
 	if d.HasSession(sessionName) {
 		t.Fatal("session should not exist after kill")
+	}
+}
+
+// TestNewSessionRaisesHistoryLimit guards the finding-005 fix (aae-orc-22sz):
+// marvel-created sessions must not inherit tmux's 2000-line history-limit
+// default, which starved capture-pane scrapes to ~20% coverage. NewSession
+// raises it to DefaultHistoryLimit; the created session must report that.
+func TestNewSessionRaisesHistoryLimit(t *testing.T) {
+	skipIfNoTmux(t)
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	sessionName := "marvel-test-history-limit"
+	t.Cleanup(func() { _ = d.KillSession(sessionName) })
+	if err := d.NewSession(sessionName); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+
+	got, err := d.ShowOption(sessionName, "history-limit")
+	if err != nil {
+		t.Fatalf("show-options history-limit: %v", err)
+	}
+	if got == "2000" {
+		t.Fatal("session inherited tmux default history-limit 2000; capture-pane scrapes would lose ~80% of scrollback (finding-005)")
+	}
+	if want := strconv.Itoa(DefaultHistoryLimit); got != want {
+		t.Fatalf("history-limit = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Two small, independent fixes that each close a way a marvel session can silently go wrong.

## Sessions were losing scrollback (aae-orc-22sz)

marvel-created tmux sessions inherited tmux's 2000-line `history-limit` default. finding-005 measured that a capture-pane scrape of a 20000-line burst recovers only about 20% of the output at that default, versus 100% at 100000. Sessions and the adopt-path pipe-pane both read scrollback, so the default was starving them, and the recently-merged CapturePaneRange scraper (aae-orc-xnkh) had less history to read than it should.

`Driver.NewSession` now sets a session-scoped `history-limit` of 100000 (`DefaultHistoryLimit`) right after creating the session. It uses `set-option -t <session>`, never the global `-g` flag, so marvel does not touch the user's tmux server config. New windows marvel opens in the session (NewPane always uses new-window) inherit the raised limit at creation. A driver test asserts a freshly created session reports the raised value rather than 2000.

## Permission-mode typos silently broke sessions (aae-orc-6spa)

`ManifestRole.Permissions` was passed through verbatim as `--permission-mode` to the forestage/claude adapters. A typo like `pln` was accepted by the manifest parser, then the harness rejected the flag and the pane exited immediately, with no signal pointing back at the manifest.

`validateManifest` now rejects any non-empty `permissions` value outside Claude Code's canonical mode set (`acceptEdits`, `auto`, `bypassPermissions`, `default`, `dontAsk`, `plan`), and the error names the bad value and lists the full allowlist. An empty value stays valid: it means "unset, use the adapter default", and that behavior is covered by a test. `dangerous_permissions` is left as the orthogonal boolean it always was (it appends `--dangerously-skip-permissions`) and combines with any mode; the two are validated independently. The `Role.DangerousPermissions` doc comment now explains when an operator picks one versus the other, and the user guide documents the canonical set.

Additive only: no existing manifest with a valid or empty `permissions` value changes behavior.

Refs: aae-orc-22sz, aae-orc-6spa