### PR TITLE
docs(marvel): add runnable three-act demo runbook, manifests, and recipes

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,284 @@
+# Marvel three-act demo
+
+Marvel is a control plane for agent sessions. It keeps a declared team
+running, notices when a session dies, and repairs it; it observes what every
+session is doing, in one event vocabulary, across different agent harnesses;
+and it changes a running agent's permission contract by editing a manifest,
+with no restart. This runbook shows those three properties as copy-pasteable
+command sequences, each mapped to the exact events marvel emits.
+
+Every command below was run top to bottom against a live daemon on 2026-07-31.
+Where the code does not produce what an operator might expect, the runbook says
+so at that beat rather than papering over it.
+
+## Prerequisites
+
+- macOS or Linux with `tmux` and `just` on PATH.
+- `just build` (produces `bin/marvel` and `bin/simulator`).
+- Act 1 and Act 3 need no model auth. Act 1 uses only `sleep`; Act 3 needs the
+  `claude` binary on PATH (the projection events fire whether or not claude is
+  authenticated, because marvel writes the settings file itself).
+- Act 2 needs the three harness binaries (`claude`, `codex`, `opencode`) and
+  working auth for each. The per-session CPU and RSS columns populate without
+  auth; the `agent.*` token and cost events need a real model turn.
+
+Start each act from a clean daemon. Marvel persists state to
+`~/.marvel/state/marvel.bolt`; to avoid one act's sessions bleeding into the
+next, tear down and clear state between acts:
+
+```sh
+./bin/marvel stop --teardown        # end the daemon and every agent
+rm -f ~/.marvel/state/marvel.bolt   # forget persisted resources
+./bin/marvel daemon &               # fresh daemon
+```
+
+`marvel events` reads a bounded in-memory ring, so it is empty on a fresh
+daemon and fills as the act runs.
+
+---
+
+## Act 1 — Recover
+
+Marvel keeps a team at its declared replica count. Three distinct loss paths
+produce three distinct events. This act runs them one at a time.
+
+### 1a. Unplanned pane loss: `session.crashed` then `session.created`
+
+`demo-act1-recovery` runs two `sleep` workers with a process-alive healthcheck
+(pane exists means healthy). Nothing removes a session on its own, so the only
+loss is the one you cause.
+
+```sh
+./bin/marvel work examples/demo-act1-recovery.toml
+sleep 5
+./bin/marvel get sessions            # two workers, STATE running, HEALTH healthy
+```
+
+Kill one worker's pane out of band, the way a crashed agent process would
+vanish. Read its pane id first, then kill the pane:
+
+```sh
+./bin/marvel describe session recover/line-worker-g1-0   # note "PaneID": "%N"
+tmux kill-pane -t %1                                     # use the PaneID you saw
+```
+
+Marvel detects the vacated pane on its next reconcile tick, marks the session
+crashed, and (after a crash-loop backoff) spawns a replacement:
+
+```sh
+./bin/marvel events --kind session.crashed     # "pane %1 gone"  (immediate)
+sleep 35
+./bin/marvel events --kind session.created     # replacement line-worker-g1-2
+./bin/marvel get sessions                       # back to two healthy workers
+```
+
+Timing note: marvel treats a vanished pane as a crash and applies a 30-second
+crash-loop backoff before respawning, so the replacement appears roughly 30 to
+60 seconds after the kill, not instantly. That backoff is deliberate: it is
+what stops a process that exits on startup from respawning in a tight loop.
+
+TODO(finding): the task brief described this beat as `session.crashed` then
+`session.restarted`. That is not what the pane-loss path emits. The recovery
+pair for an unplanned loss is `session.crashed` then `session.created`.
+`session.restarted` is a separate, health-driven event; see 1c below. The two
+are different mechanisms and marvel does not conflate them.
+
+If instead you use marvel's own kill command, the loss is an operator-initiated
+delete, not a crash, and there is no backoff:
+
+```sh
+./bin/marvel kill recover/line-worker-g1-1
+./bin/marvel events --kind session.deleted     # marvel-initiated removal
+./bin/marvel events --kind session.created     # replacement spawns promptly
+```
+
+### 1b. Role removed from the manifest: `role.removed`
+
+`demo-act1-roles` declares `primary` (1 replica) and `helper` (2 replicas).
+`demo-act1-roles-removed` is the same team with `helper` dropped.
+
+```sh
+./bin/marvel work examples/demo-act1-roles.toml
+sleep 4
+./bin/marvel get sessions            # primary + two helpers
+
+./bin/marvel work examples/demo-act1-roles-removed.toml
+sleep 4
+./bin/marvel events --kind role.removed      # "role removed from manifest, drained 2 session(s)"
+./bin/marvel events --kind session.deleted   # one per drained helper
+./bin/marvel get sessions                     # only primary remains
+```
+
+### 1c. Health-driven terminal cases: `session.restarted`, `session.failed`, `role.saturated`
+
+`demo-act1-health` runs three `sleep` roles, each with a heartbeat healthcheck.
+`sleep` never sends a heartbeat, so each role goes stale and marvel applies that
+role's restart policy. This exercises the health path with no agent and no auth.
+
+- `restarter` (restart_policy = always): restarts on every staleness, so it
+  loops through `session.restarted` with a growing backoff.
+- `failstop` (restart_policy = never): the stale session is marked failed and
+  never restarted. The reconciler keeps the replica count by launching a fresh
+  replica, so `session.failed` recurs as each replacement in turn goes stale.
+- `capped` (restart_policy = always, max_restarts = 1): restarts once, then hits
+  its cap and emits `role.saturated` plus `session.failed`, and is not respawned.
+
+```sh
+./bin/marvel work examples/demo-act1-health.toml
+sleep 12
+./bin/marvel events --workspace health --warnings
+./bin/marvel events --kind health.failed        # first staleness on each role
+./bin/marvel events --kind session.restarted     # restarter + capped, restart #1
+./bin/marvel events --kind session.failed         # failstop, restart_policy=never
+
+sleep 60
+./bin/marvel events --kind role.saturated          # capped hit max_restarts=1
+./bin/marvel events --kind session.restarted        # restarter now on restart #2
+```
+
+The healthcheck uses a 6-second timeout and a threshold of 1, so the first
+action lands about 8 to 10 seconds after spawn; `capped` saturates about a
+minute later, after one backoff window.
+
+TODO(finding): two events in the health vocabulary are not observable through
+this beat.
+
+- `health.failed` fires only on the first transition to unhealthy, and the
+  evaluator marks a session unhealthy while its failure count is still below
+  the threshold. With `failure_threshold` greater than 1 the transition is
+  therefore consumed before the threshold is reached and no `health.failed`
+  event is emitted, even though the restart or fail action still fires. This
+  manifest uses `failure_threshold = 1` precisely so `health.failed` is visible.
+- `health.crashloop-backoff` is emitted only if a live session is re-evaluated
+  inside its backoff window. On the always-restart path the session is deleted
+  the moment it restarts, so no session exists to re-evaluate during the
+  backoff, and the event does not surface in this beat. It remains in the
+  vocabulary and is covered by the controller's tests.
+
+### 1d. Stuck shift: `team.shift-timed-out`
+
+A shift that never reaches readiness is aborted and rolled back with a
+`team.shift-timed-out` event. This is real and covered by the controller tests,
+but the shift timeout defaults to 10 minutes and is not wired to a daemon flag
+or environment variable, so it is not a practical interactive beat. Shifting any
+never-heartbeats role (for example a role in `demo-act1-health`) would trigger
+it after the 10-minute default.
+
+TODO(finding): make the shift timeout configurable (flag or env) so this beat
+can run in a demo without a 10-minute wait. Today the only way to shorten it is
+in code (`team.Controller.ShiftTimeout`).
+
+---
+
+## Act 2 — Observe
+
+One team, three different agent harnesses, one event stream. `mixed-adapters`
+runs a `claude`, a `codex`, and an `opencode` role, each headless with a small
+prompt. Marvel redirects each harness's structured output through its adapter,
+normalizes the harness-specific dialect into one event vocabulary, and tags
+every event with workspace, team, role, and session.
+
+```sh
+./bin/marvel work examples/mixed-adapters.toml
+sleep 4
+./bin/marvel get sessions        # CPU% and RSS populated for all three harnesses
+```
+
+`marvel get sessions` samples the process table, so CPU% and RSS are real for
+every session regardless of harness, and need no auth. Watch the normalized
+agent stream from all three:
+
+```sh
+./bin/marvel events --workspace mixed
+./bin/marvel events --kind agent.turn.completed   # tokens in/out per turn
+./bin/marvel events --kind agent.session.ended    # per-session cost, tokens, duration
+```
+
+A verified run produced, across the three harnesses uniformly:
+`agent.session.started`, `agent.turn.started`, `agent.turn.completed` (with
+token counts), `agent.message.completed`, and `agent.session.ended` (with cost,
+token totals, and duration). That the same five event kinds describe three
+unrelated harnesses is the point of the act.
+
+Deterministic vs auth-dependent:
+
+- Deterministic (no auth): the three sessions spawn, and the CPU% and RSS
+  columns populate.
+- Auth-dependent: the `agent.*` token, message, and cost events require each
+  harness to authenticate and take a real model turn. Without auth a harness
+  exits early and you see `session.crashed` instead of an agent stream.
+
+TODO(finding): the CTX% column shows `-` for these harnesses. Context pressure
+has exactly one producer in marvel today, the heartbeat RPC, and none of the
+claude, codex, or opencode adapters send it. The column exists and is correct
+(it renders absence rather than a misleading 0%), but "context" is not an
+observable signal for these three harnesses yet. The task brief's Act 2
+"cpu/rss/context" is accurate for cpu and rss; context is not populated.
+
+Because each role is headless with a one-shot prompt, the harness exits when its
+turn completes, and marvel reaps the vacated pane with `session.crashed`. That
+is expected for a headless one-shot: the work is done, the process is gone.
+
+Minor: the claude adapter logged one `agent.error` "unmapped: assistant thinking
+block (no v1 event kind)" during the verified run. It is a benign parse gap (a
+thinking block has no mapped v1 event kind), not a session failure.
+
+---
+
+## Act 3 — Control plane
+
+Marvel projects a Policy (a Claude Code settings fragment) into a per-session
+file the harness reads, and re-projects it when the manifest changes, so a
+running agent's permission contract changes with no restart.
+
+`policy-projection.toml` declares `reviewer-contract` version 1 (read-only: allow
+Read/Grep/Glob, deny Bash/Write/Edit) and a claude reviewer that references it.
+
+```sh
+./bin/marvel work examples/policy-projection.toml
+sleep 4
+./bin/marvel get policies                       # VERSION 1
+./bin/marvel events --kind policy.projected     # "projected at spawn"
+./bin/marvel get sessions                        # reviewer running, GEN 1
+```
+
+`policy-projection-v2.toml` is the same workspace, team, and role, with the
+policy edited: version 2 now allows Edit and adds a SessionStart hook. Apply it
+over the running v1 state:
+
+```sh
+./bin/marvel work examples/policy-projection-v2.toml
+sleep 3
+./bin/marvel get policies                       # VERSION now 2
+./bin/marvel events --kind policy.projected     # a second event: "re-projected after manifest change"
+./bin/marvel get sessions                        # same session, same GEN 1, no restart
+```
+
+The second `policy.projected` event fires against the same running session
+(same name, same generation, no restart). Marvel rewrote that session's settings
+file in place; a verified run showed the file's content change from the v1
+allow/deny lists to the v2 lists plus the SessionStart hook. Claude Code's file
+watcher re-reads the settings file, so the contract change lands live.
+
+This act is deterministic given the `claude` binary on PATH. The projection
+events fire because marvel writes the file, independent of whether claude is
+authenticated. The one requirement for the live re-projection beat is that the
+reviewer session is still running when you apply v2 (an interactive claude
+session stays up while it waits for input, so it is).
+
+Roles whose harness has no Claude Code settings surface (codex, opencode,
+generic) log the policy as advisory and are not projected. Nothing is dropped
+silently.
+
+---
+
+## Cleanup
+
+```sh
+./bin/marvel stop --teardown
+rm -f ~/.marvel/state/marvel.bolt
+```
+
+`just clean` also removes `bin/` and the default socket, but it only kills the
+`marvel-demo` tmux session; `stop --teardown` is what ends every agent across
+all workspaces.

--- a/examples/demo-act1-health.toml
+++ b/examples/demo-act1-health.toml
@@ -1,0 +1,85 @@
+# Marvel demo — Act 1, health-driven terminal cases.
+#
+# Three roles run `sleep`, which keeps a live pane but never sends a
+# heartbeat. Each role has a heartbeat healthcheck, so each goes stale and
+# marvel applies that role's restart policy. This exercises the health path
+# deterministically with no agent, no model, and no auth.
+#
+#   restarter  restart_policy = always            -> health.failed, then
+#                                                     session.restarted (loops)
+#   failstop   restart_policy = never             -> health.failed, then
+#                                                     session.failed (terminal)
+#   capped     restart_policy = always, max=1     -> session.restarted once,
+#                                                     then role.saturated +
+#                                                     session.failed (terminal)
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-health.toml
+#
+# Watch the health path (heartbeat timeout is 6s, threshold 2, so the first
+# action lands ~10s after spawn; capped saturates ~30s later after one
+# backoff window):
+#   ./bin/marvel events --workspace health --warnings
+#   ./bin/marvel events --kind session.restarted
+#   ./bin/marvel events --kind session.failed
+#   ./bin/marvel events --kind role.saturated
+#   ./bin/marvel get sessions
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+[workspace]
+name = "health"
+
+[[team]]
+name = "ward"
+
+  [[team.role]]
+  name = "restarter"
+  replicas = 1
+  restart_policy = "always"
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]
+
+    [team.role.healthcheck]
+    type = "heartbeat"
+    timeout = "6s"
+    failure_threshold = 1
+
+  [[team.role]]
+  name = "failstop"
+  replicas = 1
+  restart_policy = "never"
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]
+
+    [team.role.healthcheck]
+    type = "heartbeat"
+    timeout = "6s"
+    failure_threshold = 1
+
+  [[team.role]]
+  name = "capped"
+  replicas = 1
+  restart_policy = "always"
+  max_restarts = 1
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]
+
+    [team.role.healthcheck]
+    type = "heartbeat"
+    timeout = "6s"
+    failure_threshold = 1

--- a/examples/demo-act1-health.yaml
+++ b/examples/demo-act1-health.yaml
@@ -1,0 +1,76 @@
+# Marvel demo — Act 1, health-driven terminal cases.
+#
+# Three roles run `sleep`, which keeps a live pane but never sends a
+# heartbeat. Each role has a heartbeat healthcheck, so each goes stale and
+# marvel applies that role's restart policy. This exercises the health path
+# deterministically with no agent, no model, and no auth.
+#
+#   restarter  restart_policy = always            -> health.failed, then
+#                                                     session.restarted (loops)
+#   failstop   restart_policy = never             -> health.failed, then
+#                                                     session.failed (terminal)
+#   capped     restart_policy = always, max=1     -> session.restarted once,
+#                                                     then role.saturated +
+#                                                     session.failed (terminal)
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-health.yaml
+#
+# Watch the health path (heartbeat timeout is 6s, threshold 2, so the first
+# action lands ~10s after spawn; capped saturates ~30s later after one
+# backoff window):
+#   ./bin/marvel events --workspace health --warnings
+#   ./bin/marvel events --kind session.restarted
+#   ./bin/marvel events --kind session.failed
+#   ./bin/marvel events --kind role.saturated
+#   ./bin/marvel get sessions
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+workspace:
+  name: health
+
+teams:
+  - name: ward
+    roles:
+      - name: restarter
+        replicas: 1
+        restart_policy: always
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]
+        healthcheck:
+          type: heartbeat
+          timeout: 6s
+          failure_threshold: 1
+
+      - name: failstop
+        replicas: 1
+        restart_policy: never
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]
+        healthcheck:
+          type: heartbeat
+          timeout: 6s
+          failure_threshold: 1
+
+      - name: capped
+        replicas: 1
+        restart_policy: always
+        max_restarts: 1
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]
+        healthcheck:
+          type: heartbeat
+          timeout: 6s
+          failure_threshold: 1

--- a/examples/demo-act1-recovery.toml
+++ b/examples/demo-act1-recovery.toml
@@ -1,0 +1,54 @@
+# Marvel demo — Act 1, pane-loss recovery.
+#
+# Two workers, each a `sleep` process in a pane with a process-alive
+# healthcheck (pane exists => healthy). They stay up on their own, so the
+# only thing that removes a session is an operator kill. Kill one and the
+# daemon reaps the dead pane, marks the session crashed, and the reconciler
+# spawns a replacement to restore the desired replica count.
+#
+# `sleep` stands in for any long-running agent process. It is used here
+# instead of bin/simulator because the simulator's heartbeat path needs
+# flags the generic adapter does not inject (see docs/demo.md, Act 1 gap
+# note), which would send a heartbeat role into a health restart loop and
+# muddy the pure pane-loss beat this manifest is about.
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-recovery.toml
+#   ./bin/marvel get sessions          # two running workers, HEALTH healthy
+#
+# Kill a pane and watch recovery:
+#   ./bin/marvel kill recover/line-worker-g1-0
+#   ./bin/marvel events --kind session.crashed     # the loss is detected
+#   ./bin/marvel events --kind session.created     # the replacement spawns
+#   ./bin/marvel get sessions                       # back to two healthy workers
+#
+# The recovery pair is session.crashed then session.created. The
+# session.restarted event belongs to the health-driven path, not pane loss;
+# see examples/demo-act1-health.toml for that.
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+[workspace]
+name = "recover"
+
+[[team]]
+name = "line"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 2
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]
+
+    [team.role.healthcheck]
+    type = "process-alive"
+    timeout = "10s"
+    failure_threshold = 3

--- a/examples/demo-act1-recovery.yaml
+++ b/examples/demo-act1-recovery.yaml
@@ -1,0 +1,51 @@
+# Marvel demo — Act 1, pane-loss recovery.
+#
+# Two workers, each a `sleep` process in a pane with a process-alive
+# healthcheck (pane exists => healthy). They stay up on their own, so the
+# only thing that removes a session is an operator kill. Kill one and the
+# daemon reaps the dead pane, marks the session crashed, and the reconciler
+# spawns a replacement to restore the desired replica count.
+#
+# `sleep` stands in for any long-running agent process. It is used here
+# instead of bin/simulator because the simulator's heartbeat path needs
+# flags the generic adapter does not inject (see docs/demo.md, Act 1 gap
+# note), which would send a heartbeat role into a health restart loop and
+# muddy the pure pane-loss beat this manifest is about.
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-recovery.yaml
+#   ./bin/marvel get sessions          # two running workers, HEALTH healthy
+#
+# Kill a pane and watch recovery:
+#   ./bin/marvel kill recover/line-worker-g1-0
+#   ./bin/marvel events --kind session.crashed     # the loss is detected
+#   ./bin/marvel events --kind session.created     # the replacement spawns
+#   ./bin/marvel get sessions                       # back to two healthy workers
+#
+# The recovery pair is session.crashed then session.created. The
+# session.restarted event belongs to the health-driven path, not pane loss;
+# see examples/demo-act1-health.yaml for that.
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+workspace:
+  name: recover
+
+teams:
+  - name: line
+    roles:
+      - name: worker
+        replicas: 2
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]
+        healthcheck:
+          type: process-alive
+          timeout: 10s
+          failure_threshold: 3

--- a/examples/demo-act1-roles-removed.toml
+++ b/examples/demo-act1-roles-removed.toml
@@ -1,0 +1,21 @@
+# Marvel demo — Act 1, role removal (the "after" manifest).
+#
+# Same workspace and team as examples/demo-act1-roles.toml with the helper
+# role removed. Applying this over the two-role state drains the orphaned
+# helper sessions and emits role.removed. See that file's header for the
+# full sequence.
+
+[workspace]
+name = "crew"
+
+[[team]]
+name = "shift"
+
+  [[team.role]]
+  name = "primary"
+  replicas = 1
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]

--- a/examples/demo-act1-roles-removed.yaml
+++ b/examples/demo-act1-roles-removed.yaml
@@ -1,0 +1,19 @@
+# Marvel demo — Act 1, role removal (the "after" manifest).
+#
+# Same workspace and team as examples/demo-act1-roles.yaml with the helper
+# role removed. Applying this over the two-role state drains the orphaned
+# helper sessions and emits role.removed. See that file's header for the
+# full sequence.
+
+workspace:
+  name: crew
+
+teams:
+  - name: shift
+    roles:
+      - name: primary
+        replicas: 1
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]

--- a/examples/demo-act1-roles.toml
+++ b/examples/demo-act1-roles.toml
@@ -1,0 +1,48 @@
+# Marvel demo — Act 1, role removal (the "before" manifest).
+#
+# Two roles, primary and helper, each a `sleep` process in a pane. Apply
+# this, then apply examples/demo-act1-roles-removed.toml (same workspace and
+# team, helper dropped). The reconciler drains the orphaned helper sessions
+# and emits a role.removed event alongside the per-session session.deleted
+# events.
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-roles.toml
+#   ./bin/marvel get sessions          # primary + two helpers running
+#
+# Remove the helper role and re-apply:
+#   ./bin/marvel work examples/demo-act1-roles-removed.toml
+#   ./bin/marvel events --kind role.removed
+#   ./bin/marvel events --kind session.deleted
+#   ./bin/marvel get sessions          # helpers drained, primary remains
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+[workspace]
+name = "crew"
+
+[[team]]
+name = "shift"
+
+  [[team.role]]
+  name = "primary"
+  replicas = 1
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]
+
+  [[team.role]]
+  name = "helper"
+  replicas = 2
+
+    [team.role.runtime]
+    image = "generic"
+    command = "sleep"
+    args = ["3600"]

--- a/examples/demo-act1-roles.yaml
+++ b/examples/demo-act1-roles.yaml
@@ -1,0 +1,44 @@
+# Marvel demo — Act 1, role removal (the "before" manifest).
+#
+# Two roles, primary and helper, each a `sleep` process in a pane. Apply
+# this, then apply examples/demo-act1-roles-removed.yaml (same workspace and
+# team, helper dropped). The reconciler drains the orphaned helper sessions
+# and emits a role.removed event alongside the per-session session.deleted
+# events.
+#
+# Requires: `sleep` on PATH (always present). No model auth needed.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/demo-act1-roles.yaml
+#   ./bin/marvel get sessions          # primary + two helpers running
+#
+# Remove the helper role and re-apply:
+#   ./bin/marvel work examples/demo-act1-roles-removed.yaml
+#   ./bin/marvel events --kind role.removed
+#   ./bin/marvel events --kind session.deleted
+#   ./bin/marvel get sessions          # helpers drained, primary remains
+#
+# Cleanup:
+#   ./bin/marvel stop --teardown
+
+workspace:
+  name: crew
+
+teams:
+  - name: shift
+    roles:
+      - name: primary
+        replicas: 1
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]
+
+      - name: helper
+        replicas: 2
+        runtime:
+          image: generic
+          command: sleep
+          args: ["3600"]

--- a/justfile
+++ b/justfile
@@ -113,3 +113,73 @@ clean:
     -tmux kill-session -t marvel-demo 2>/dev/null
     -rm -f /tmp/marvel.sock
     -rm -rf bin/
+
+# Three-act runnable demo. Full runbook: docs/demo.md.
+# Each recipe assumes a running daemon (`just start-bg` first).
+
+# Act 1 — Recover: set up the pane-loss recovery team, print the next steps
+demo-act1: build
+    @echo "==> Act 1 (Recover). Loading the recovery team..."
+    ./bin/marvel work examples/demo-act1-recovery.toml
+    @sleep 5
+    @echo ""
+    @echo "==> Sessions (two workers, HEALTH healthy):"
+    ./bin/marvel get sessions
+    @echo ""
+    @echo "Next, cause an unplanned pane loss and watch marvel recover it:"
+    @echo "  ./bin/marvel describe session recover/line-worker-g1-0   # note PaneID %N"
+    @echo "  tmux kill-pane -t %1                                     # use that PaneID"
+    @echo "  ./bin/marvel events --kind session.crashed              # immediate"
+    @echo "  ./bin/marvel events --kind session.created              # replacement (~30-60s, crash-loop backoff)"
+    @echo ""
+    @echo "Health-driven terminal cases (session.restarted / session.failed / role.saturated):"
+    @echo "  ./bin/marvel work examples/demo-act1-health.toml"
+    @echo "  ./bin/marvel events --workspace health --warnings"
+    @echo ""
+    @echo "Role removal (role.removed):"
+    @echo "  ./bin/marvel work examples/demo-act1-roles.toml"
+    @echo "  ./bin/marvel work examples/demo-act1-roles-removed.toml"
+    @echo "  ./bin/marvel events --kind role.removed"
+
+# Act 2 — Observe: run the three-harness matrix, print the event-watch commands
+demo-act2: build
+    @echo "==> Act 2 (Observe). Loading the {claude, codex, opencode} matrix..."
+    @echo "    Needs the three harness binaries and working auth for the agent stream."
+    ./bin/marvel work examples/mixed-adapters.toml
+    @sleep 4
+    @echo ""
+    @echo "==> Sessions (CPU% and RSS populate uniformly; CTX% is '-' for these harnesses):"
+    ./bin/marvel get sessions
+    @echo ""
+    @echo "Watch the normalized agent stream across all three harnesses:"
+    @echo "  ./bin/marvel events --workspace mixed"
+    @echo "  ./bin/marvel events --kind agent.turn.completed    # tokens in/out per turn"
+    @echo "  ./bin/marvel events --kind agent.session.ended     # per-session cost and duration"
+
+# Act 3 — Control plane: project a policy, then re-project live with no restart
+demo-act3: build
+    @echo "==> Act 3 (Control plane). Projecting reviewer-contract v1..."
+    @echo "    Needs the claude binary on PATH (auth not required for the projection events)."
+    ./bin/marvel work examples/policy-projection.toml
+    @sleep 4
+    @echo ""
+    @echo "==> Policies (VERSION 1) and the spawn projection event:"
+    ./bin/marvel get policies
+    ./bin/marvel events --kind policy.projected
+    @echo ""
+    @echo "Now swap to v2 and watch the running agent's contract change with no restart:"
+    @echo "  ./bin/marvel work examples/policy-projection-v2.toml"
+    @echo "  ./bin/marvel get policies                    # VERSION now 2"
+    @echo "  ./bin/marvel events --kind policy.projected  # second event: re-projected after manifest change"
+    @echo "  ./bin/marvel get sessions                    # same session, same GEN, no restart"
+
+# Point at the full three-act runbook
+demo-all:
+    @echo "Marvel three-act demo. Full runbook: docs/demo.md"
+    @echo ""
+    @echo "  just start-bg     # start the daemon first"
+    @echo "  just demo-act1    # Recover"
+    @echo "  just demo-act2    # Observe (needs harness auth)"
+    @echo "  just demo-act3    # Control plane"
+    @echo ""
+    @echo "Between acts: just stop && rm -f ~/.marvel/state/marvel.bolt && just start-bg"


### PR DESCRIPTION
Marvel already recovers lost sessions, observes agent work across three harnesses in one event vocabulary, and re-projects a policy into a running agent with no restart. Nothing packaged those into a sequence an operator could run top to bottom and check against the events marvel actually emits. This PR adds that: a runbook, the missing Act 1 manifests, and `just` recipes.

Additive only. No Go code changes; docs, example manifests, and justfile recipes.

## Artifacts

- `docs/demo.md`: the operator runbook. Three acts as copy-pasteable command sequences, each mapped to the exact events marvel emits, with prerequisites and a clear split between deterministic beats and ones that need harness auth.
- `examples/demo-act1-*.{toml,yaml}`: Act 1 manifests (pane-loss recovery, health-driven terminal cases, role removal), all dependency-free (they use `sleep`).
- `justfile`: `demo-act1`, `demo-act2`, `demo-act3`, `demo-all` recipes.

Act 2 reuses `examples/mixed-adapters`; Act 3 reuses `examples/policy-projection` v1 and v2.

## Accuracy

Every beat was run against a live daemon before writing it up. Where the code does not match a naive expectation, the runbook says so at that beat rather than papering over it:

- The pane-loss recovery pair is `session.crashed` then `session.created`, not `session.restarted`. `session.restarted` is the separate health-driven path.
- `marvel kill` emits `session.deleted` (operator-initiated), not `session.crashed`; an unplanned pane loss (out-of-band process death) is what emits `session.crashed`.
- `health.failed` is only observable with `failure_threshold = 1` (a higher threshold marks the session unhealthy below the threshold, consuming the transition event).
- `health.crashloop-backoff` does not surface interactively on the always-restart path (the session is deleted during its backoff window).
- The shift timeout defaults to 10 minutes and is not wired to a flag or env, so `team.shift-timed-out` is not a practical interactive beat.
- The `CTX%` column is unpopulated for the claude, codex, and opencode harnesses (context pressure has one producer, the heartbeat RPC, which those adapters do not send).

Refs: aae-orc-vaja