### PR TITLE
fix(marvel): inject simulator heartbeat flags and make shift timeout configurable

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -120,6 +120,28 @@ func main() {
 	}
 }
 
+// shiftTimeoutEnv is the environment variable that seeds the daemon's
+// shift timeout when --shift-timeout is not passed. See aae-orc-sape.
+const shiftTimeoutEnv = "MARVEL_SHIFT_TIMEOUT"
+
+// resolveShiftTimeout picks the effective shift timeout for the daemon.
+// The --shift-timeout flag wins when the operator set it; otherwise the
+// MARVEL_SHIFT_TIMEOUT env var is parsed as a Go duration; otherwise zero,
+// which leaves the team controller on its built-in 10-minute default.
+func resolveShiftTimeout(flagVal time.Duration, flagChanged bool, env string) (time.Duration, error) {
+	if flagChanged {
+		return flagVal, nil
+	}
+	if env == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(env)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", shiftTimeoutEnv, env, err)
+	}
+	return d, nil
+}
+
 func daemonCmd() *cobra.Command {
 	var mrvlAddr string
 	var listenSocket string
@@ -129,6 +151,7 @@ func daemonCmd() *cobra.Command {
 	var logMaxFiles int
 	var logMaxTotalMiB int
 	var stateBoltPath string
+	var shiftTimeout time.Duration
 
 	layout, _ := paths.Default()
 	defaultLog := ""
@@ -167,9 +190,17 @@ Examples:
 				}
 			}
 
+			shiftTO, err := resolveShiftTimeout(
+				shiftTimeout, cmd.Flags().Changed("shift-timeout"), os.Getenv(shiftTimeoutEnv),
+			)
+			if err != nil {
+				return err
+			}
+
 			d, err := daemon.NewWithOptions(daemon.Options{
-				PidFile:   pidFilePath,
-				StateBolt: stateBoltPath,
+				PidFile:      pidFilePath,
+				StateBolt:    stateBoltPath,
+				ShiftTimeout: shiftTO,
 			})
 			if err != nil {
 				return err
@@ -246,6 +277,8 @@ Examples:
 		"write pid to this file on start, remove on stop (empty string disables)")
 	cmd.Flags().StringVar(&stateBoltPath, "state-bolt", defaultBolt,
 		"bbolt L2 file for durable state (empty string disables persistence; daemon restart loses state and kills running agents per pre-L2 contract C12)")
+	cmd.Flags().DurationVar(&shiftTimeout, "shift-timeout", 0,
+		"abort and roll back a shift that has not reached readiness within this Go duration (0 uses the built-in 10m default; env "+shiftTimeoutEnv+" is the fallback when this flag is unset)")
 	// Log rotation / retention — bounds disk usage for --log-file.
 	// Motivated by desk Pi headroom (aae-orc-k0t, Skippy session-025/026).
 	// Zero for any of these disables the corresponding limit.

--- a/cmd/marvel/shift_timeout_test.go
+++ b/cmd/marvel/shift_timeout_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestResolveShiftTimeout covers the precedence the daemon uses for its
+// shift timeout: the --shift-timeout flag wins when set; otherwise
+// MARVEL_SHIFT_TIMEOUT is parsed; otherwise zero, which leaves the team
+// controller on its built-in 10-minute default. See aae-orc-sape.
+func TestResolveShiftTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		flagVal     time.Duration
+		flagChanged bool
+		env         string
+		want        time.Duration
+		wantErr     bool
+	}{
+		{name: "unset falls back to zero (controller default)", want: 0},
+		{name: "flag set wins", flagVal: 90 * time.Second, flagChanged: true, want: 90 * time.Second},
+		{name: "flag wins over env", flagVal: 30 * time.Second, flagChanged: true, env: "5m", want: 30 * time.Second},
+		{name: "env used when flag unset", env: "45s", want: 45 * time.Second},
+		{name: "env minutes", env: "2m", want: 2 * time.Minute},
+		{name: "invalid env errors", env: "not-a-duration", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveShiftTimeout(tt.flagVal, tt.flagChanged, tt.env)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (value %s)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveShiftTimeout(%s, %v, %q) = %s, want %s",
+					tt.flagVal, tt.flagChanged, tt.env, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -93,6 +93,23 @@ marvel stop              # detach: agents keep running
 marvel stop --teardown   # end every agent, then stop
 ```
 
+### Shift timeout
+
+A rolling shift that never reaches readiness (for example a heartbeat-checked
+role whose new generation never beats) is aborted and rolled back with a
+`team.shift-timed-out` event. The bound defaults to 10 minutes. Tune it with
+`--shift-timeout` (a Go duration) or the `MARVEL_SHIFT_TIMEOUT` environment
+variable:
+
+```bash
+marvel daemon --shift-timeout 2m        # abort a stuck shift after 2 minutes
+MARVEL_SHIFT_TIMEOUT=15s marvel daemon  # same, via the environment
+```
+
+The flag wins when set; otherwise `MARVEL_SHIFT_TIMEOUT` is parsed; unset keeps
+the 10-minute default. A short value is also how you demonstrate the timeout
+without a 10-minute wait (see the Act 1d beat in `docs/demo.md`).
+
 ### Detach vs teardown
 
 `marvel stop`, SIGINT, and SIGTERM all *detach*: the daemon

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -158,15 +158,26 @@ this beat.
 ### 1d. Stuck shift: `team.shift-timed-out`
 
 A shift that never reaches readiness is aborted and rolled back with a
-`team.shift-timed-out` event. This is real and covered by the controller tests,
-but the shift timeout defaults to 10 minutes and is not wired to a daemon flag
-or environment variable, so it is not a practical interactive beat. Shifting any
-never-heartbeats role (for example a role in `demo-act1-health`) would trigger
-it after the 10-minute default.
+`team.shift-timed-out` event. The shift timeout defaults to 10 minutes, but the
+daemon now takes a `--shift-timeout` flag (and the `MARVEL_SHIFT_TIMEOUT` env
+var) so you can shorten it and see the beat without a 10-minute wait. Start a
+daemon with a short timeout, apply a team with a never-heartbeats role, and
+shift it: the new generation never becomes ready, so the shift aborts.
 
-TODO(finding): make the shift timeout configurable (flag or env) so this beat
-can run in a demo without a 10-minute wait. Today the only way to shorten it is
-in code (`team.Controller.ShiftTimeout`).
+```sh
+MARVEL_SHIFT_TIMEOUT=15s ./bin/marvel daemon &   # or: --shift-timeout 15s
+./bin/marvel work examples/demo-act1-health.toml  # heartbeat roles that never beat
+sleep 3
+./bin/marvel shift health/ward
+sleep 20
+./bin/marvel events --kind team.shift-timed-out   # "shift stuck in launching past 15s, rolled back to gen 1"
+```
+
+A verified run against a one-role team with a heartbeat healthcheck and
+`MARVEL_SHIFT_TIMEOUT=15s` emitted `team.shift-timed-out` roughly 17 seconds
+after the shift started: `shift stuck in launching past 15s, rolled back to
+gen 1`. The flag wins when set; otherwise the env var is parsed as a Go
+duration; unset leaves the built-in 10-minute default.
 
 ---
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -138,6 +138,13 @@ type Options struct {
 	// this to layout.DaemonBolt() (~/.marvel/state/marvel.bolt).
 	// See orc finding-050 / aae-orc-k4e4.
 	StateBolt string
+	// ShiftTimeout bounds how long a single shift may run before the team
+	// controller declares it stuck, aborts it, and rolls back with a
+	// team.shift-timed-out event. Zero keeps the controller's built-in
+	// 10-minute default. Exposed so an operator can tune it (and demo the
+	// timeout without a 10-minute wait) via the daemon's --shift-timeout
+	// flag or MARVEL_SHIFT_TIMEOUT. See aae-orc-sape / ArcavenAE/marvel#88.
+	ShiftTimeout time.Duration
 }
 
 // New creates a new daemon with default options.
@@ -161,6 +168,9 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	}
 	sessMgr := session.NewManager(store, driver)
 	teamCtrl := team.NewController(store, sessMgr)
+	// Zero leaves the controller on its built-in default (10 minutes);
+	// a nonzero value from --shift-timeout / MARVEL_SHIFT_TIMEOUT overrides.
+	teamCtrl.ShiftTimeout = opts.ShiftTimeout
 	// Must follow OpenBolt: the controller reads its crash-loop state
 	// out of the same bolt file. Before this, a role frozen at
 	// MaxRestarts respawned on the first reconcile tick after restart.

--- a/internal/daemon/shift_timeout_test.go
+++ b/internal/daemon/shift_timeout_test.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOptionsShiftTimeoutWired asserts that a ShiftTimeout set on Options
+// reaches the team controller, and that leaving it zero keeps the
+// controller on its built-in default (surfaced as ShiftTimeout==0, which
+// the controller reads as "use defaultShiftTimeout"). See aae-orc-sape /
+// ArcavenAE/marvel#88.
+func TestOptionsShiftTimeoutWired(t *testing.T) {
+	t.Run("explicit value is applied", func(t *testing.T) {
+		d, err := NewWithOptions(Options{ShiftTimeout: 90 * time.Second})
+		if err != nil {
+			t.Fatalf("new daemon: %v", err)
+		}
+		if got := d.teamCtrl.ShiftTimeout; got != 90*time.Second {
+			t.Errorf("controller ShiftTimeout = %s, want 90s", got)
+		}
+	})
+
+	t.Run("unset leaves controller default (zero)", func(t *testing.T) {
+		d, err := NewWithOptions(Options{})
+		if err != nil {
+			t.Fatalf("new daemon: %v", err)
+		}
+		if got := d.teamCtrl.ShiftTimeout; got != 0 {
+			t.Errorf("controller ShiftTimeout = %s, want 0 (controller falls back to 10m default)", got)
+		}
+	})
+}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -103,6 +103,7 @@ func NewRegistry() *Registry {
 	r.Register(&Claude{})
 	r.Register(&Codex{})
 	r.Register(&OpenCode{})
+	r.Register(&Simulator{})
 	r.Register(&Generic{})
 	return r
 }

--- a/internal/runtime/simulator.go
+++ b/internal/runtime/simulator.go
@@ -1,0 +1,63 @@
+package runtime
+
+// Simulator is the adapter for marvel's built-in load-test simulator
+// (cmd/simulator, image "simulator"). The simulator heartbeats the daemon,
+// but only when it is given --socket, and its heartbeat session key is
+// "<workspace>/<name>", so it also needs --name and --workspace to match
+// the session marvel tracks. The generic adapter injects none of these as
+// flags: it sets the MARVEL_* env vars, which the simulator does not read.
+// A simulator launched through the generic fallback therefore never
+// heartbeats, goes stale on its heartbeat healthcheck, and under the
+// default restart_policy=always restart-loops instead of showing healthy.
+// This adapter injects the identity flags the simulator's heartbeat path
+// requires. It does not touch the generic path for any other image.
+type Simulator struct{}
+
+func (s *Simulator) Name() string { return "simulator" }
+
+// ProjectionFor reports no projection surface. The simulator has no Claude
+// Code settings mechanism, so a referenced policy is advisory — marvel logs
+// it rather than writing a file the simulator would not read.
+func (s *Simulator) ProjectionFor(_ *LaunchContext, _ string) ProjectionTarget {
+	return ProjectionTarget{Supported: false}
+}
+
+func (s *Simulator) Prepare(ctx *LaunchContext) (*LaunchResult, error) {
+	binary := resolveCommand(&ctx.Session.Runtime)
+	if binary == "" {
+		return nil, ErrNoCommand
+	}
+
+	args := make([]string, len(ctx.Session.Runtime.Args))
+	copy(args, ctx.Session.Runtime.Args)
+
+	// Inject the identity flags the simulator's heartbeat path needs.
+	// --name and --workspace form the "<workspace>/<name>" session key the
+	// daemon matches; --team and --role feed the simulator's lua env.
+	args = append(
+		args,
+		"--name", ctx.Session.Name,
+		"--workspace", ctx.Workspace.Name,
+		"--team", ctx.Team.Name,
+		"--role", ctx.Role.Name,
+	)
+	// --socket is what enables the heartbeat RPC at all; without it the
+	// simulator never wires OnHeartbeat and the session stays stale.
+	if ctx.SocketPath != "" {
+		args = append(args, "--socket", ctx.SocketPath)
+	}
+	// The simulator accepts a lua --script; the generic path dropped it.
+	if ctx.Session.Runtime.Script != "" {
+		args = append(args, "--script", ctx.Session.Runtime.Script)
+	}
+
+	return &LaunchResult{
+		Command: buildCommand(binary, args),
+		Env:     baseEnv(ctx),
+	}, nil
+}
+
+func init() {
+	// Ensure Simulator implements Adapter at compile time.
+	var _ Adapter = (*Simulator)(nil)
+}

--- a/internal/runtime/simulator_test.go
+++ b/internal/runtime/simulator_test.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// simulatorContext mirrors the demo manifests: image "simulator", a
+// relative bin/simulator command, a --tick arg, and a lua script on the
+// supervisor role.
+func simulatorContext() *LaunchContext {
+	return &LaunchContext{
+		Session: &api.Session{
+			Name:      "squad-agent-g1-0",
+			Workspace: "demo",
+			Team:      "squad",
+			Role:      "agent",
+			Runtime: api.Runtime{
+				Name:    "simulator",
+				Command: "bin/simulator",
+				Args:    []string{"--tick", "3000"},
+				Script:  "scripts/chaos.lua",
+			},
+		},
+		Role: &api.Role{
+			Name:     "agent",
+			Replicas: 3,
+			Runtime: api.Runtime{
+				Name:    "simulator",
+				Command: "bin/simulator",
+			},
+		},
+		Team:       &api.Team{Name: "squad", Workspace: "demo"},
+		Workspace:  &api.Workspace{Name: "demo"},
+		SocketPath: "/tmp/marvel.sock",
+	}
+}
+
+// TestRegistryResolveSimulator: image "simulator" must reach the dedicated
+// adapter, not the generic fallback. This is the whole point of the fix —
+// the generic adapter does not inject the heartbeat flags.
+func TestRegistryResolveSimulator(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	if a := r.Resolve("simulator"); a.Name() != "simulator" {
+		t.Fatalf(`Resolve("simulator") = %q, want "simulator"`, a.Name())
+	}
+}
+
+// TestSimulatorPrepareInjectsHeartbeatFlags asserts the simulator gets the
+// exact flags its heartbeat path reads: --socket (enables the RPC),
+// --name + --workspace (the "<workspace>/<name>" session key the daemon
+// matches), plus --team/--role and the lua --script. Without these the
+// simulator never heartbeats and restart-loops (ArcavenAE/marvel#87).
+func TestSimulatorPrepareInjectsHeartbeatFlags(t *testing.T) {
+	t.Parallel()
+	s := &Simulator{}
+	ctx := simulatorContext()
+
+	result, err := s.Prepare(ctx)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if !strings.HasPrefix(result.Command, "bin/simulator") {
+		t.Errorf("command should start with binary, got: %s", result.Command)
+	}
+	for _, want := range []string{
+		"--socket /tmp/marvel.sock",
+		"--name squad-agent-g1-0",
+		"--workspace demo",
+		"--team squad",
+		"--role agent",
+		"--script scripts/chaos.lua",
+		"--tick 3000",
+	} {
+		if !strings.Contains(result.Command, want) {
+			t.Errorf("command missing %q, got: %s", want, result.Command)
+		}
+	}
+}
+
+// TestSimulatorPrepareNoSocket: with no daemon socket there is nothing to
+// heartbeat to, so --socket must be omitted (the simulator only wires
+// OnHeartbeat when --socket is non-empty).
+func TestSimulatorPrepareNoSocket(t *testing.T) {
+	t.Parallel()
+	s := &Simulator{}
+	ctx := simulatorContext()
+	ctx.SocketPath = ""
+
+	result, err := s.Prepare(ctx)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if strings.Contains(result.Command, "--socket") {
+		t.Errorf("command should not contain --socket when SocketPath is empty, got: %s", result.Command)
+	}
+}
+
+// TestSimulatorProjectionUnsupported: the simulator has no Claude Code
+// settings surface, so it reports no projection target.
+func TestSimulatorProjectionUnsupported(t *testing.T) {
+	t.Parallel()
+	s := &Simulator{}
+	if got := s.ProjectionFor(simulatorContext(), "/tmp/x"); got.Supported {
+		t.Errorf("simulator should not support projection, got %+v", got)
+	}
+}


### PR DESCRIPTION
Two defects surfaced during the three-act demo verification, one per fix. Both are additive; the only behavior change to existing images is that `image = "simulator"` now reaches a dedicated adapter instead of the generic fallback.

## Simulator heartbeat dead under the generic adapter (#87)

A session with `image = "simulator"` resolved to the generic runtime adapter. The generic adapter sets only the `MARVEL_*` env vars and injects no CLI flags, but the simulator reads its identity from flags, not the environment, and only wires its heartbeat RPC when it is given `--socket` (keyed by `<workspace>/<name>`). So simulator sessions never heartbeated, went stale on their heartbeat healthcheck, and under the default `restart_policy=always` restart-looped. The two oldest shipped examples (`examples/demo.toml`, `examples/shift-demo.toml`) were unusable as a health or shift demo.

Fix, option (a): a dedicated `Simulator` adapter registered under `image = "simulator"`, ahead of the generic fallback, injecting exactly the flags the heartbeat path reads (`--socket`, `--name`, `--workspace`, `--team`, `--role`, and the lua `--script`). This mirrors the forestage and claude adapters and does not touch the generic path for any other image, so no generic session's health behavior changes. Option (a) over (b) keeps the injection scoped to the one image that needs it rather than teaching the generic adapter to special-case a command; option (c) was wrong because these examples exist to demonstrate a healthy, shiftable simulator team.

Live check on a fresh daemon, before and after:

- Before: all four simulator sessions `unhealthy` / `crashloop-backoff`, `session.restarted` and `health.crashloop-backoff` events, CTX% `-`.
- After: all four `running` / `healthy`, CTX% populated (6-9% on the workers), zero restart or crashloop events.

## Shift timeout not configurable outside code (#88)

`team.Controller.ShiftTimeout` defaulted to 10 minutes and was settable only in code, so the `team.shift-timed-out` beat could not be demonstrated without a 10-minute wait. This wires the timeout to a `--shift-timeout` daemon flag and a `MARVEL_SHIFT_TIMEOUT` environment variable, both parsed as a Go duration, matching the existing `daemon.Options` pattern (a field on `Options`, set from a cobra flag in `daemonCmd`). The flag wins when set; otherwise the env var is parsed; unset keeps the 10-minute default.

Live check: a one-role team with a heartbeat healthcheck and `MARVEL_SHIFT_TIMEOUT=15s` emitted `team.shift-timed-out` about 17 seconds into a stuck shift: `shift stuck in launching past 15s, rolled back to gen 1`.

## Tests

- `internal/runtime`: simulator flag injection (all heartbeat flags present, `--socket` omitted when no socket), registry resolution to the simulator adapter, projection unsupported.
- `cmd/marvel`: `resolveShiftTimeout` precedence (flag wins, env parsed, invalid env errors, unset -> default).
- `internal/daemon`: `Options.ShiftTimeout` reaches the controller; unset leaves zero (controller's built-in default).

`go build`, `go vet`, `golangci-lint` (0 issues), gofumpt clean, and the full `go test ./... -p 1` suite pass, including the pre-push race suite.

## Docs

- `docs/admin-guide.md` documents `--shift-timeout` / `MARVEL_SHIFT_TIMEOUT`.
- `docs/demo.md` Act 1d note updated; the stuck-shift beat is now runnable.

Closes #87
Closes #88
Refs: aae-orc-yvja, aae-orc-sape