### PR TITLE
harvest: finding-006 update — demo driven live, and the bug that drive found

### DIFF
--- a/_kos/findings/finding-006-three-act-demo-and-recovery-hardening.md
+++ b/_kos/findings/finding-006-three-act-demo-and-recovery-hardening.md
@@ -4,7 +4,7 @@ title: "Three-act demo build: recovery, observation, and control-plane beats mad
 question: question-permission-model
 confidence: frontier
 tags: [marvel, demo, recovery, observability, policy, harness]
-bd: [aae-orc-k3a, aae-orc-96st, aae-orc-qkfl, aae-orc-69i2, aae-orc-22sz, aae-orc-6spa, aae-orc-vaja, aae-orc-yvja, aae-orc-sape, aae-orc-w5su]
+bd: [aae-orc-k3a, aae-orc-96st, aae-orc-qkfl, aae-orc-69i2, aae-orc-22sz, aae-orc-6spa, aae-orc-vaja, aae-orc-yvja, aae-orc-sape, aae-orc-w5su, aae-orc-b6d3]
 addressed_to: aae-orc-vaja
 provenance:
   created_by: agent
@@ -32,6 +32,46 @@ code-reading, and it is not the same as an operator watching the demo. As of
 this harvest, `docs/demo.md` has not been run top to bottom by a person. The
 confidence tier here is frontier for that reason: the beats are agent-verified,
 not operator-witnessed. First operator run is the promotion signal.
+
+### Update 2026-08-01: driven live in front of the operator, and it found a bug
+
+Later the same day, at the operator's request, I drove the runbook live on kinu
+and surfaced the real event output in the session. Covered: Act 1a (killed pane
+`%1`, got `session.crashed` "pane %1 gone", then `session.created` for
+`line-worker-g1-2` on pane `%3` after the 30-second backoff, replica count
+restored), Act 1b (`role.removed` "drained 2 session(s)" plus two
+`session.deleted`), Act 1c (all three policies behaving distinctly, including
+`session.restarted` backoff growing 60s then 120s, `session.failed` under
+`restart_policy=never`, and `role.saturated` at `max_restarts=1`), Act 1d
+(`team.shift-timed-out` "shift stuck in launching past 15s, rolled back to gen
+1" under `MARVEL_SHIFT_TIMEOUT=15s`), and Act 3 (policy version 1 to 2, two
+`policy.projected` events, same session at the same generation with no restart,
+and the projected settings file rewritten in place with `Edit` moving from deny
+to allow plus a SessionStart hook appearing).
+
+Act 2 was not driven live, because it depends on authenticated harness turns and
+one-shot headless roles exit immediately, which makes for a less legible run
+than the deterministic acts.
+
+**This still does not discharge the promotion signal.** The operator watched the
+output rather than running the sequence, so the beats are now
+operator-witnessed-output but not operator-executed. The tier stays frontier.
+
+**The drive earned its keep by finding something the agent self-reports missed:**
+after Act 1d, `stop --teardown` printed "agents torn down" yet left the
+`marvel-health` tmux session alive with 6 windows, which had to be killed by
+hand. Four controlled attempts afterward (no shift, successful shift, and three
+stuck-shift-rollback runs with a churn window) all tore down clean, so it is
+intermittent and not reproducible on demand. Filed honestly as intermittent with
+the full A/B and a teardown-versus-reconcile-race hypothesis: bd `aae-orc-b6d3`,
+GH ArcavenAE/marvel#92. The general lesson is the one this finding already
+argues in its caveat: a live drive is a different instrument from an agent
+report of a live drive, and it caught a contract violation ("agents torn down"
+was false) that six clean automated runs did not.
+
+Also confirmed by eye during the drive: `CTX%` rendered `-` for every session,
+which is the gap `aae-orc-w5su` addresses and which finding-007 and finding-008
+subsequently scoped.
 
 ## The three acts, and how each maps to real commands
 


### PR DESCRIPTION
finding-006 recorded the three-act demo as agent-verified and named the first operator run as its promotion signal. The demo has since been driven live on kinu with the real event output surfaced to the operator, and that drive found something six clean automated runs had missed, so the finding needs the update.

What the drive covered: Act 1a through 1d and Act 3, with the actual events (crash and respawn after backoff, role removal draining orphans, all three restart policies behaving distinctly with backoff growing 60s then 120s, the shift timeout rolling back to gen 1, and the policy version flip re-projecting into a running session with the settings file rewritten in place). Act 2 was not driven live because it depends on authenticated harness turns.

What it found: `stop --teardown` reported "agents torn down" while leaving a workspace tmux session alive with 6 windows. Four controlled attempts afterward all tore down clean, so it is intermittent and filed as such with the full A/B and a teardown-versus-reconcile-race hypothesis (bd aae-orc-b6d3, issue #92). That is the finding's own argument about instruments, demonstrated: a live drive is a different instrument from an agent report of a live drive.

The promotion signal is explicitly NOT discharged. The operator watched the output rather than running the sequence, so the tier stays frontier.

Finding update only, additive.