### PR TITLE
harvest: governance rulings 2026-08-01 — matrix frame, staged activation, runtime=harness, handoff ownership

### DIFF
--- a/_kos/nodes/bedrock/elem-agentic-resource-matrix.yaml
+++ b/_kos/nodes/bedrock/elem-agentic-resource-matrix.yaml
@@ -1,0 +1,35 @@
+id: elem-agentic-resource-matrix
+type: element
+confidence: bedrock
+title: "agentic resource matrix: the governing frame for marvel's resource model"
+content: |
+  The resources of agentic work are context, spend, cache locality,
+  access, and authority. Compute is one row of a 17-row matrix, not
+  the frame: kubernetes schedules containers by CPU and memory; marvel
+  governs agents by this matrix.
+
+  Enforcement has three loci, in maturity order:
+
+  1. **Environment construction at spawn** (BUILT): adapters construct
+     the process environment; permission-through-environment.
+  2. **Runtime admission/metering** (MISSING): qiay admission control
+     is the first brick.
+  3. **Mid-flight revocation** (MISSING): the M1 authority model is
+     its prerequisite.
+
+  Full capture, including the 17-row matrix itself: orc
+  `_kos/ideas/marvel-agentic-resource-matrix.md`. That idea file stays
+  the prop; this node is the ratification record.
+
+  Operator-ratified 2026-08-01 (marvel remap governance interview,
+  round 1; orc docs/marvel-remap-2026-08.md section 4). Promoted from
+  the orc idea file.
+edges:
+  - target: elem-k8s-resource-model
+    type: supersedes
+    note: "supersedes as governing frame only; the k8s mechanics (desired state, reconciliation, resource types) remain bedrock as a mechanics footnote"
+provenance:
+  created_by: human
+  session: marvel-remap-governance-2026-08-01
+  created_at: "2026-08-01"
+  extracted_from: "aae-orc _kos/ideas/marvel-agentic-resource-matrix.md (promoted at operator ratification)"

--- a/_kos/nodes/bedrock/elem-handoff-schema-ownership.yaml
+++ b/_kos/nodes/bedrock/elem-handoff-schema-ownership.yaml
@@ -1,0 +1,30 @@
+id: elem-handoff-schema-ownership
+type: element
+confidence: bedrock
+title: "shift handoff artifact ownership: marvel owns the schema, the departing agent owns the content"
+content: |
+  The shift handoff artifact (agentic resource matrix row 15, durable
+  agent state) has an owner split:
+
+  - **marvel owns the SCHEMA**: what a handoff artifact is; its
+    location, lifecycle, and generation binding.
+  - **the departing agent owns the CONTENT**.
+  - kos/packs may shape templates later.
+
+  Operator-ratified 2026-08-01 (marvel remap governance interview,
+  round 3; orc docs/marvel-remap-2026-08.md section 4).
+edges:
+  - target: question-shifts
+    type: derives
+    note: "grounded in the resolved shift mechanics; the handoff artifact is what a shift passes forward"
+  - target: question-shift-triggers
+    type: supports
+    note: "a schema'd handoff is what automatic shift triggers hand work through"
+  - target: elem-agentic-resource-matrix
+    type: derives
+    note: "row 15 (durable agent state) of the governing frame"
+provenance:
+  created_by: human
+  session: marvel-remap-governance-2026-08-01
+  created_at: "2026-08-01"
+  extracted_from: "orc docs/marvel-remap-2026-08.md section 4, round 3 (handoff-artifact schema ownership)"

--- a/_kos/nodes/bedrock/elem-k8s-resource-model.yaml
+++ b/_kos/nodes/bedrock/elem-k8s-resource-model.yaml
@@ -25,9 +25,21 @@ content: |
   Reconciliation loop drives desired → actual state convergence.
 
   Evidence: implemented and working in MVP. ADR: orc decisions/adr-003.
+
+  **Demotion record (2026-08-01, operator-ratified at vision adoption):**
+  the k8s analogy is demoted from governing frame to mechanics footnote.
+  What survives as bedrock is the mechanics: declarative desired state,
+  the reconciliation loop, and resource types. The governing frame is
+  the agentic resource matrix (`elem-agentic-resource-matrix`); the
+  mapping table above remains a mechanics reference, not the pitch and
+  not where design attention starts. Ruling: orc
+  docs/marvel-remap-2026-08.md section 4, round 1.
 edges:
   - target: aae-orc::elem-marvel-control-plane
     type: implements
+  - target: elem-agentic-resource-matrix
+    type: supports
+    note: "demoted 2026-08-01: the k8s mechanics (desired state, reconciliation, resource types) underpin the governing frame without being it"
 provenance:
   created_by: human
   session: session-008

--- a/_kos/nodes/bedrock/elem-runtime-names-harness.yaml
+++ b/_kos/nodes/bedrock/elem-runtime-names-harness.yaml
@@ -1,0 +1,26 @@
+id: elem-runtime-names-harness
+type: element
+confidence: bedrock
+title: "the manifest field 'runtime' names the harness, never the agent"
+content: |
+  The manifest/type field `runtime` names the HARNESS (claude, codex,
+  opencode, and so on), never the agent. `runtime` KEEPS its name; the
+  e1e rename completes for Work and Desk. B14's composition stands at
+  the orc level: Agent = Persona + Identity + Role(s) + LLM + Tools
+  (orc charter B14; no orc node exists for it yet, so the reference is
+  to charter prose).
+
+  The CLI's AGENT column header is a defect and corrects to RUNTIME.
+
+  Operator-ratified 2026-08-01 (marvel remap governance interview,
+  round 2, e1e naming ruling; orc docs/marvel-remap-2026-08.md
+  section 4).
+edges:
+  - target: elem-runtime-adapter-framework
+    type: derives
+    note: "the harness this field names is what the adapter registry resolves from Runtime.Name"
+provenance:
+  created_by: human
+  session: marvel-remap-governance-2026-08-01
+  created_at: "2026-08-01"
+  extracted_from: "orc docs/marvel-remap-2026-08.md section 4, round 2 (e1e naming)"

--- a/_kos/nodes/bedrock/elem-staged-activation-upgrades.yaml
+++ b/_kos/nodes/bedrock/elem-staged-activation-upgrades.yaml
@@ -1,0 +1,41 @@
+id: elem-staged-activation-upgrades
+type: element
+confidence: bedrock
+title: "staged-activation upgrades: bootstrap plane fetches and stages, cluster plane activates"
+content: |
+  Marvel upgrades separate fetch from activation across two planes.
+
+  1. **Bootstrap/image plane** (mise/brew now; sideshow later):
+     install first time, pre-stage new versions into a version store.
+     Always safe; never touches the running cluster.
+  2. **Cluster plane** (`marvel update`): cluster-aware; pre-flight
+     checks (deprecation/compat detection, a pluto-like function),
+     activation of a staged version, migration, rollback. The shipped
+     `daemon reexec` (PR #80) is the activation primitive, not the
+     whole story.
+  3. **Version store**: staged versions coexist, flagged
+     active-vs-present (the Nokia/Checkpoint firmware model; which
+     version is staged and which runs are separate facts owned by
+     different planes).
+
+  Reshapes roadmap M3(d) from "self-update exists, shim makes it
+  safe" into this two-plane model; reconciles obsolescence-review
+  RETIRE-5 (distribution belongs to the channel; activation belongs
+  to marvel). Zero-downtime upgrade is the long-term acceptance
+  test. Design study precedes implementation (bd aae-orc-k28s
+  carries it); version-store layout, decidable pre-flight checks,
+  and rollback-with-live-agents semantics are open design questions
+  recorded in the idea file.
+
+  Operator-ratified 2026-08-01 (marvel remap governance interview,
+  round 2; orc docs/marvel-remap-2026-08.md section 4). Near-verbatim
+  capture: orc `_kos/ideas/marvel-staged-activation-upgrades.md`.
+edges:
+  - target: elem-release-pipeline
+    type: derives
+    note: "the release pipeline feeds the bootstrap plane; activation is a separate concern"
+provenance:
+  created_by: human
+  session: marvel-remap-governance-2026-08-01
+  created_at: "2026-08-01"
+  extracted_from: "aae-orc _kos/ideas/marvel-staged-activation-upgrades.md (operator vision, near-verbatim)"

--- a/_kos/nodes/frontier/question-agent-communication-broker.yaml
+++ b/_kos/nodes/frontier/question-agent-communication-broker.yaml
@@ -32,6 +32,15 @@ content: |
 
   Tracked: `aae-orc-bga` (validate marvel agent communication
   protocol).
+
+  **2026-08-01 ruling (marvel remap governance interview, round 2; orc
+  docs/marvel-remap-2026-08.md section 4):** external NATS,
+  marvel-supervised as a declared workload (the same supervision
+  pattern as the sidecar-collector spike, `aae-orc-h6ck`). Embedded
+  NATS declined; nats-server becomes a runtime dependency via
+  mise/brew, and marvel stays thin. The envelope starts from the orc
+  draft `docs/design/director-envelope-and-adapter-events.md`;
+  schema-first codegen per the language ruling.
 edges:
   - target: aae-orc::val-gradual-elaboration
     type: derives


### PR DESCRIPTION
Files the marvel-scoped rulings from the 2026-08-01 governance interview (orc docs/marvel-remap-2026-08.md) as graph nodes, so the graph carries the commitments the newly adopted vision and roadmap reference.

Four bedrock nodes: the agentic resource matrix as the governing frame (with a dated demotion record and edges on elem-k8s-resource-model; mechanics survive as footnote); the staged-activation upgrade model (bootstrap plane fetches and stages, cluster plane activates; reexec is the activation primitive); runtime names the harness, never the agent (the e1e ruling; CLI AGENT header is the defect); handoff artifact ownership split (marvel owns the schema, the departing agent owns the content). One frontier note: the bus ruling (external NATS, marvel-supervised) on question-agent-communication-broker.

Graph only; no code changes. All nodes pass kos validate.