### PR TITLE
feat(usage): derive CTX% from harness streams via a session usage accountant

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ Written in Go. The daemon manages agent sessions through a tmux substrate:
 - **Health evaluation**: checks heartbeat staleness, applies restart policies
 - **Shift state machine**: launching → draining → complete, driven by
   the reconciliation loop
+- **Usage accountant**: derives context-window occupancy from each harness's
+  own usage reporting, feeding the CTX% column (see
+  [user-guide](docs/user-guide.md#list-sessions))
 - **Simulator**: context pressure simulation for testing without real agents
 
 ## BYOA

--- a/_kos/findings/finding-007-context-pressure-extraction.md
+++ b/_kos/findings/finding-007-context-pressure-extraction.md
@@ -226,3 +226,33 @@ for the simulator.
 - **Version-pinned.** Claude 2.1.220, codex 0.146.0, opencode 1.18.5. A harness
   version bump that changes the usage/stream schema changes the read; re-verify
   on upgrade.
+
+## Addendum 2026-08-01 (aae-orc-w5su implementation): the SP1 Claude numerator reads a cumulative total, not a level
+
+SP1 prescribed the Claude numerator from the terminal line:
+`result.usage.input_tokens + cache_read_input_tokens +
+cache_creation_input_tokens`. Measured during the w5su build on the
+repo's own fixture (`internal/runtime/claudecode/testdata/tool_call.ndjson`,
+three distinct `message.id` values, `num_turns: 3`): per-request
+occupancy levels are 33377, 33481, and 34136, while `result.usage`
+reports 11701 / 17162 / 72131, each class the exact column-wise sum
+across the three requests (total 100994). `result.usage` and
+`result.modelUsage` are session-cumulative spend totals, not the final
+request's level.
+
+Consequence: the SP1 numerator reads 10.1% against a 1M window where
+the truth is 3.4%, and the error grows linearly with request count, so
+the longest sessions (the ones a shift trigger exists for) are the most
+wrong. This finding's own four-turn live measurement missed it because
+each turn was a separate `claude -p --resume` invocation, a
+single-request session where sum equals level by coincidence. The
+"Claude's four-turn accumulation is the pattern the others should
+follow" line in the gaps section inherits the same caveat.
+
+Correction, as shipped in the accountant (`internal/usage/doc.go`):
+occupancy is a LEVEL, taken per API request from each assistant
+message's usage (deduplicated on `message.id`), latest-wins. The
+terminal `result` line is a spend total and a reconciliation check,
+never an occupancy source. The in-stream denominator
+(`result.modelUsage.<model>.contextWindow`) remains valid as SP1
+stated.

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -405,6 +405,7 @@ Examples:
   marvel events --kind session.crashed       # only crashes
   marvel events --kind agent.tool.call       # what the agents are doing
   marvel events --kind agent.session.ended   # per-session cost and timing
+  marvel events --kind context.limit-unresolved  # why a CTX% cell is blank
   marvel events --warnings                   # only warning-severity events
   marvel --cluster desk events               # remote daemon via mrvl://`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -1477,12 +1478,32 @@ func renderSessionTable(sessions []api.Session) string {
 		if agent == "" {
 			agent = s.Runtime.Command
 		}
-		// CTX% has exactly one producer, the heartbeat RPC, and no
-		// runtime adapter implements it yet. Without a heartbeat there is
-		// no context reading to show, and "0%" would read as a fresh
-		// session with an empty window.
+		// CTX% has two producers: the cooperative heartbeat RPC (the
+		// simulator) and the usage accountant fed by adapter streams.
+		// Both stamp ContextAt, so that is the single "measured" sentinel.
+		//
+		// Three states, not two. "-" means marvel never measured this
+		// session's context: no stream, so an interactive launch, a pane
+		// adopted from a prior daemon, or a non-stream adapter. "?" means
+		// the tokens are real but the model's window could not be
+		// resolved, so a percentage would be a fiction against a guessed
+		// denominator. `marvel describe session` carries the reason, and
+		// the fix is usually one runtime.context_window line.
+		//
+		// The two producers report different shapes, which is why "?" is
+		// keyed on the request count rather than on the window alone. The
+		// accountant stamps ContextRequests on every reading and may have
+		// no window; a heartbeat reports a percentage the agent computed
+		// itself, with no token count and no window to report. Keying "?"
+		// on ContextLimit alone would blank the simulator's column.
 		ctx := "-"
-		if !s.LastHeartbeat.IsZero() {
+		switch {
+		case s.ContextAt.IsZero():
+		case s.ContextLimit > 0:
+			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)
+		case s.ContextRequests > 0:
+			ctx = "?"
+		default:
 			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)
 		}
 		// Likewise for the sampler: a session the sampler has not

--- a/cmd/marvel/render_test.go
+++ b/cmd/marvel/render_test.go
@@ -49,27 +49,101 @@ func column(t *testing.T, table, name string) string {
 	return ""
 }
 
-// CTX% had one producer, the heartbeat RPC, and no runtime adapter
-// implements it. A session that has never sent one has no context
-// reading, and "0%" would read as a fresh window rather than as silence.
-func TestRenderSessionTableNoHeartbeat(t *testing.T) {
+// A session marvel has never measured has no context reading at all, and
+// "0%" would read as a fresh window rather than as silence. That is the
+// interactive launch, the pane adopted from a prior daemon, and the
+// harness with no stream.
+func TestRenderSessionTableNeverMeasured(t *testing.T) {
 	table := renderSessionTable([]api.Session{{
 		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
 		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
 	}})
 	if got := column(t, table, "CTX%"); got != "-" {
-		t.Errorf("CTX%% = %q with no heartbeat, want %q", got, "-")
+		t.Errorf("CTX%% = %q with no reading, want %q", got, "-")
 	}
 }
 
-func TestRenderSessionTableWithHeartbeat(t *testing.T) {
+// A measured session reporting 0% must be distinguishable from an
+// unmeasured one.
+func TestRenderSessionTableMeasuredIdle(t *testing.T) {
 	table := renderSessionTable([]api.Session{{
 		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
 		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "forestage"},
-		ContextPercent: 0, LastHeartbeat: time.Now().UTC(),
+		SessionContext: api.SessionContext{
+			ContextPercent: 0, ContextLimit: 200_000, ContextAt: time.Now().UTC(),
+		},
 	}})
 	if got := column(t, table, "CTX%"); got != "0%" {
-		t.Errorf("CTX%% = %q after a heartbeat reporting 0, want %q", got, "0%")
+		t.Errorf("CTX%% = %q for a measured empty window, want %q", got, "0%")
+	}
+}
+
+func TestRenderSessionTableMeasured(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "claude"},
+		SessionContext: api.SessionContext{
+			ContextTokens: 34136, ContextLimit: 1_000_000, ContextPercent: 3.4136,
+			ContextAt: time.Now().UTC(),
+		},
+	}})
+	if got := column(t, table, "CTX%"); got != "3%" {
+		t.Errorf("CTX%% = %q, want %q", got, "3%")
+	}
+}
+
+// The third state: tokens are real, the window is not. A percentage here
+// would be a fiction against a guessed denominator, so the cell says the
+// reading exists but cannot be scaled. See orc finding-055.
+func TestRenderSessionTableMeasuredWithoutLimit(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "codex"},
+		SessionContext: api.SessionContext{
+			ContextTokens: 13992, ContextRequests: 1, ContextLimit: 0,
+			ContextAt: time.Now().UTC(),
+		},
+	}})
+	if got := column(t, table, "CTX%"); got != "?" {
+		t.Errorf("CTX%% = %q with tokens but no window, want %q", got, "?")
+	}
+}
+
+// The cooperative heartbeat RPC is still a producer, and it was the only
+// one before the accountant existed, so the simulator must keep lighting
+// the column.
+//
+// Driven through the real store rather than a hand-built struct: the
+// heartbeat path reports a percentage with no token count and no window,
+// a shape no hand-written fixture would think to reproduce, and a
+// renderer keyed on the window alone blanks it. That is exactly how this
+// regressed once.
+func TestRenderSessionTableWithHeartbeat(t *testing.T) {
+	store := api.NewStore()
+	if err := store.CreateWorkspace(&api.Workspace{Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := store.CreateSession(&api.Session{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		Runtime: api.Runtime{Name: "simulator", Command: "simulator"},
+		State:   api.SessionRunning, PaneID: "%3",
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := store.UpdateSessionHeartbeat("ws/agent-0", 55.4); err != nil {
+		t.Fatalf("heartbeat: %v", err)
+	}
+
+	sess, err := store.GetSession("ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.ContextLimit != 0 || sess.ContextTokens != 0 {
+		t.Fatalf("the heartbeat path produced a window or a token count: %+v", sess.SessionContext)
+	}
+	table := renderSessionTable([]api.Session{sess})
+	if got := column(t, table, "CTX%"); got != "55%" {
+		t.Errorf("CTX%% = %q after a heartbeat reporting 55.4, want %q", got, "55%")
 	}
 }
 

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -15,6 +15,12 @@
 > - The runtime set is a runtime-adapter framework (forestage, claude,
 >   generic, plus Claude Code stream observation), not the `top`/`shell`
 >   demo runtimes.
+> - FR-07 names the `"heartbeat"` RPC as the only producer of
+>   `ContextPercent`. It is now one of two: marvel also derives occupancy
+>   from harness usage reporting in the headless stream adapters
+>   (`internal/usage`), and the reading carries its own timestamp,
+>   token count, window, and window provenance rather than a bare
+>   percentage.
 
 Probe: marvel-mvp-probe | Confidence: frontier
 

--- a/docs/spec/stories.md
+++ b/docs/spec/stories.md
@@ -13,6 +13,11 @@
 >   stream observation).
 > - State persistence (BoltDB), SSH remote clients, named clusters, keys,
 >   events, capture, and inject all shipped after this MVP scope was frozen.
+> - Story 7.1 tracks the heartbeat RPC as the whole of the CTX% column.
+>   Real harness sessions now light it from parsed usage reporting
+>   (`internal/usage`), and `ContextPercent` has moved into a
+>   `SessionContext` group alongside the token count, window, and window
+>   provenance.
 
 Probe: marvel-mvp-probe | Confidence: frontier
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -181,8 +181,8 @@ marvel get sessions
 Output:
 ```
 WORKSPACE  TEAM       ROLE    GEN  NAME                   STATE    HEALTH   CTX%  CPU%   RSS   DESK  AGENT
-dev        squad      worker  1    squad-worker-g1-0      running  unknown  -     99.9   412M  1     claude
-dev        squad      worker  1    squad-worker-g1-1      running  unknown  -     0.4    380M  2     claude
+dev        squad      worker  1    squad-worker-g1-0      running  unknown  3%    99.9   412M  1     claude
+dev        squad      worker  1    squad-worker-g1-1      running  unknown  ?     0.4    380M  2     codex
 ```
 
 `CPU%` and `RSS` come from a sampler that runs every 5 seconds and rolls
@@ -193,12 +193,37 @@ reads about 200.
 A `-` means the value has never been measured, which is not the same as
 zero:
 
-- `CTX%` is `-` until the agent sends a heartbeat. No runtime adapter
-  implements the heartbeat yet, so today only the bundled simulator
-  reports context pressure.
+- `CTX%` is `-` until marvel has a context reading for the session.
+  Two things produce one: the harness's own usage reporting, parsed out
+  of a headless `claude`, `codex`, or `opencode` stream, and the
+  cooperative `heartbeat` RPC that the bundled simulator calls. An
+  interactive pane publishes neither. After a daemon restart, a
+  stream-derived reading goes back to `-`, because nothing can refresh
+  one for a stream marvel is no longer reading; a heartbeat reading
+  survives the restart and is refreshed by the next heartbeat.
 - `CPU%` and `RSS` are `-` before the first sampler pass, and on
   platforms where marvel has no process-table reader (anything other
   than macOS and Linux).
+
+`CTX%` has a third state. A `?` means the token count is real but the
+window to divide it by is not known, so there is no honest percentage to
+print; `marvel describe session` shows the tokens either way. Codex and
+opencode declare no window in their streams, so a model marvel has no
+figure for reads `?` until you give it one:
+
+```toml
+[team.role.runtime]
+image = "codex"
+context_window = 258400
+```
+
+The percentage is raw occupancy: the prompt sent to the model, cache
+reads and cache writes included, over the model's full window. Harnesses
+show a different number in their own status lines, measured against a
+compaction threshold below the window and net of a reserve for the
+response, so marvel reads lower than the harness for the same session.
+Marvel's figure answers "how full is the window", not "how long until
+this session compacts".
 
 Per-process IO counters are read on Linux only; `marvel describe session`
 reports `IOAvailable: false` elsewhere.

--- a/internal/api/bolt.go
+++ b/internal/api/bolt.go
@@ -19,9 +19,20 @@ import (
 // Persisted: Workspaces, Teams (incl. Roles + ShiftState), Sessions
 // (incl. PaneID, State, Generation, Runtime, restart counters, CreatedAt),
 // Endpoints, RoleHealth. Volatile session fields (LastHeartbeat,
-// ContextPercent, HealthState, LastHealthCheck, PID) are persisted with
-// the rest of the struct but treated as may-be-stale on rehydrate; the
-// reconciler refreshes them.
+// HealthState, LastHealthCheck, PID) are persisted with the rest of the
+// struct but treated as may-be-stale on rehydrate; the reconciler
+// refreshes them.
+//
+// A STREAM-DERIVED SessionContext block is the exception: rehydrate zeroes
+// it, because nothing refreshes it after a restart. The FIFO reader is gone
+// and an adopted pane has no instance entry, so marvel will never produce
+// another reading for a session it inherits. An absent CTX% after a restart
+// is honest; a frozen percentage indistinguishable from a live one is not.
+//
+// A cooperative-heartbeat reading survives, as it did before the accountant
+// existed: the agent that sent it keeps sending, so it is may-be-stale in
+// the same way as the LastHeartbeat beside it, not orphaned. The two are
+// told apart by ContextRequests, which only the accountant writes.
 //
 // RoleHealth is the one bucket with no in-memory mirror here: its live
 // copy is team.Controller's roleHealth map, and the Store is only the
@@ -204,6 +215,14 @@ func (s *Store) rehydrate() error {
 			var sess Session
 			if err := json.Unmarshal(v, &sess); err != nil {
 				return fmt.Errorf("unmarshal session: %w", err)
+			}
+			// Nothing can refresh a STREAM reading for a session this
+			// daemon did not launch, so drop it rather than serve a frozen
+			// percentage. A heartbeat reading (percentage only, no request
+			// count) is refreshed by the agent itself and survives. See the
+			// persistence note at the top of the file.
+			if sess.ContextRequests > 0 {
+				sess.SessionContext = SessionContext{}
 			}
 			s.sessions[sess.Key()] = &sess
 			return nil

--- a/internal/api/bolt_test.go
+++ b/internal/api/bolt_test.go
@@ -324,3 +324,113 @@ func itoa(n int) string {
 	}
 	return string(buf[i:])
 }
+
+// A STREAM reading cannot survive a restart: the FIFO reader is gone and
+// an adopted pane has no instance, so marvel will never produce another
+// reading for a session it inherits. Absence is honest; a frozen
+// percentage indistinguishable from a live one is not.
+func TestBoltStore_StreamContextReadingZeroedOnRehydrate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "marvel.bolt")
+
+	s1 := NewStore()
+	if err := s1.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #1: %v", err)
+	}
+	if err := s1.CreateWorkspace(&Workspace{Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &Session{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		Runtime: Runtime{Name: "claude", Command: "claude"},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s1.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// The accountant's own setter does not persist, so a reading reaches
+	// disk only when something else writes the record. That is the path
+	// this guards.
+	s1.UpdateSessionContext("ws/agent-0", SessionContext{
+		ContextTokens: 34136, ContextLimit: 1_000_000, ContextPercent: 3.4136,
+		ContextRequests: 3, ContextModel: "claude-fable-5[1m]",
+	})
+	if err := s1.UpdateSession("ws/agent-0", func(live *Session) error {
+		live.PaneID = "%7"
+		return nil
+	}); err != nil {
+		t.Fatalf("persist session: %v", err)
+	}
+	if err := s1.CloseBolt(); err != nil {
+		t.Fatalf("CloseBolt: %v", err)
+	}
+
+	s2 := NewStore()
+	if err := s2.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #2: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.CloseBolt() })
+
+	got, err := s2.GetSession("ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session after rehydrate: %v", err)
+	}
+	if got.ContextPercent != 0 || got.ContextTokens != 0 || got.ContextLimit != 0 {
+		t.Errorf("stream context survived rehydrate: %+v", got.SessionContext)
+	}
+	if !got.ContextAt.IsZero() {
+		t.Error("ContextAt survived rehydrate, so a stale percentage would render as live")
+	}
+	// The rest of the record must still rehydrate.
+	if got.State != SessionRunning || got.Runtime.Name != "claude" || got.PaneID != "%7" {
+		t.Errorf("rehydrate dropped more than the context block: %+v", got)
+	}
+}
+
+// The other half: a cooperative-heartbeat percentage is refreshed by the
+// agent that sent it, so it rehydrates like the LastHeartbeat beside it.
+// It was persisted and restored before the accountant existed, and the
+// simulator is the producer that would otherwise lose its column.
+func TestBoltStore_HeartbeatContextReadingSurvivesRehydrate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "marvel.bolt")
+
+	s1 := NewStore()
+	if err := s1.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #1: %v", err)
+	}
+	if err := s1.CreateWorkspace(&Workspace{Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := s1.CreateSession(&Session{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		Runtime: Runtime{Name: "simulator", Command: "simulator"},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := s1.UpdateSessionHeartbeat("ws/agent-0", 64.0); err != nil {
+		t.Fatalf("heartbeat: %v", err)
+	}
+	if err := s1.CloseBolt(); err != nil {
+		t.Fatalf("CloseBolt: %v", err)
+	}
+
+	s2 := NewStore()
+	if err := s2.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #2: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.CloseBolt() })
+
+	got, err := s2.GetSession("ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session after rehydrate: %v", err)
+	}
+	if got.ContextPercent != 64.0 {
+		t.Errorf("heartbeat percent = %v after rehydrate, want 64", got.ContextPercent)
+	}
+	if got.ContextAt.IsZero() {
+		t.Error("ContextAt dropped, so the restored percentage would render as absence")
+	}
+	if got.LastHeartbeat.IsZero() {
+		t.Error("LastHeartbeat dropped")
+	}
+}

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -105,6 +105,8 @@ type ManifestRuntime struct {
 	Script  string      `toml:"script,omitempty" yaml:"script,omitempty"`
 	Mode    RuntimeMode `toml:"mode,omitempty"  yaml:"mode,omitempty"`
 	Prompt  string      `toml:"prompt,omitempty" yaml:"prompt,omitempty"`
+	// ContextWindow overrides the model-to-limit table, in tokens.
+	ContextWindow int `toml:"context_window,omitempty" yaml:"context_window,omitempty"`
 }
 
 // ManifestEndpoint is an endpoint section of a manifest.
@@ -190,6 +192,11 @@ func validateManifest(m *Manifest) (*Manifest, error) {
 			}
 			if r.Runtime.Image == "" && r.Runtime.Command == "" {
 				return nil, fmt.Errorf("parse manifest: team[%d].role[%d].runtime needs image or command", i, j)
+			}
+			// A negative window would silently produce a negative
+			// denominator and a nonsense percentage; 0 means unset.
+			if r.Runtime.ContextWindow < 0 {
+				return nil, fmt.Errorf("parse manifest: team[%d].role[%d].runtime.context_window must be >= 0", i, j)
 			}
 			if r.Policy != "" && !policyNames[r.Policy] {
 				return nil, fmt.Errorf("parse manifest: team[%d].role[%d] references undefined policy %q", i, j, r.Policy)
@@ -309,12 +316,13 @@ func (m *Manifest) Apply(store *Store) error {
 		var roles []Role
 		for _, mr := range mt.Roles {
 			rt := Runtime{
-				Name:    mr.Runtime.Image,
-				Command: mr.Runtime.Command,
-				Args:    mr.Runtime.Args,
-				Script:  mr.Runtime.Script,
-				Mode:    mr.Runtime.Mode,
-				Prompt:  mr.Runtime.Prompt,
+				Name:          mr.Runtime.Image,
+				Command:       mr.Runtime.Command,
+				Args:          mr.Runtime.Args,
+				Script:        mr.Runtime.Script,
+				Mode:          mr.Runtime.Mode,
+				Prompt:        mr.Runtime.Prompt,
+				ContextWindow: mr.Runtime.ContextWindow,
 			}
 			if rt.Name == "" {
 				rt.Name = rt.Command

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -511,7 +511,44 @@ func (s *Store) UpdateSessionHeartbeat(key string, contextPercent float64) error
 	}
 	sess.ContextPercent = contextPercent
 	sess.LastHeartbeat = time.Now().UTC()
+	// ContextAt is the single "measured" sentinel for the context column,
+	// shared with the usage accountant's path below. A cooperative
+	// heartbeat is a measurement too, so it stamps it.
+	//
+	// A percentage is ALL this path produces: the agent computed it
+	// itself, so there is no token count, no window, and no request count
+	// to record. That shape is what tells the two producers apart
+	// downstream (bolt rehydrate keeps this one, the renderer prints it as
+	// a percentage rather than as an unresolved window).
+	sess.ContextAt = sess.LastHeartbeat
 	return s.persistPut(bucketSessions, sess.Key(), sess)
+}
+
+// UpdateSessionContext records one context-window reading.
+//
+// Like UpdateSessionMetrics and unlike UpdateSessionHeartbeat this does
+// not persist, and a missing session is ignored rather than reported: a
+// reading is meaningless once the harness process is gone, and the
+// accountant works from a live stream that can outlive a delete by one
+// event.
+//
+// It deliberately does NOT touch LastHeartbeat. LastHeartbeat is a
+// liveness contract consumed by the team controller's heartbeat health
+// check and by shift readiness. Stamping it from stream activity would
+// silently redefine "the agent reported in" as "the harness emitted
+// bytes", marking a hung-but-still-streaming session healthy and
+// declaring a shifting generation ready. That may eventually be wanted;
+// it has to be a ruled decision, not a side effect of picking the
+// convenient setter.
+func (s *Store) UpdateSessionContext(key string, c SessionContext) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[key]
+	if !ok {
+		return
+	}
+	c.ContextAt = time.Now().UTC()
+	sess.SessionContext = c
 }
 
 // UpdateSessionMetrics records one process-sampler reading. m.MetricsAt

--- a/internal/api/store_test.go
+++ b/internal/api/store_test.go
@@ -302,3 +302,85 @@ func TestUpdateSessionMetrics(t *testing.T) {
 	// not an error worth reporting.
 	s.UpdateSessionMetrics("test-ws/nonexistent", SessionMetrics{CPUPercent: 1})
 }
+
+func TestUpdateSessionContext(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+
+	sess := &Session{
+		Name:      "agent-0",
+		Workspace: "test-ws",
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   Runtime{Name: "claude", Command: "claude"},
+		State:     SessionRunning,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	s.UpdateSessionContext("test-ws/agent-0", SessionContext{
+		ContextTokens:      34136,
+		ContextLimit:       1_000_000,
+		ContextPercent:     3.4136,
+		ContextLimitSource: "stream",
+		ContextModel:       "claude-fable-5[1m]",
+		ContextRequests:    3,
+	})
+
+	got, err := s.GetSession("test-ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.ContextTokens != 34136 || got.ContextLimit != 1_000_000 {
+		t.Errorf("context = %d/%d tokens/limit, want 34136/1000000", got.ContextTokens, got.ContextLimit)
+	}
+	if got.ContextAt.IsZero() {
+		t.Error("ContextAt not stamped; the renderer keys absence on it")
+	}
+	// LastHeartbeat is a liveness contract consumed by the heartbeat health
+	// check and by shift readiness. A context reading is not a heartbeat.
+	if !got.LastHeartbeat.IsZero() {
+		t.Error("a context reading stamped LastHeartbeat, silently redefining liveness as stream activity")
+	}
+
+	// A session deleted between the accountant's snapshot and its write is
+	// ignored, not reported: the reading is meaningless by then.
+	s.UpdateSessionContext("test-ws/nonexistent", SessionContext{ContextTokens: 1})
+}
+
+func TestUpdateSessionHeartbeatStampsContextAt(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	sess := &Session{
+		Name: "agent-0", Workspace: "test-ws", Team: "agents", Role: "worker",
+		Runtime: Runtime{Name: "simulator", Command: "simulator"},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := s.UpdateSessionHeartbeat("test-ws/agent-0", 42.5); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+	got, _ := s.GetSession("test-ws/agent-0")
+	// The cooperative heartbeat is still a producer, and the renderer keys
+	// on one sentinel, so the simulator must keep lighting the column.
+	if got.ContextAt.IsZero() {
+		t.Error("a heartbeat did not stamp ContextAt, so CTX% would render absent")
+	}
+	if got.LastHeartbeat.IsZero() {
+		t.Error("a heartbeat must still stamp LastHeartbeat")
+	}
+	if got.ContextPercent != 42.5 {
+		t.Errorf("context percent = %v, want 42.5", got.ContextPercent)
+	}
+	// The shape this path produces, pinned because two consumers branch on
+	// it: the renderer prints the percentage rather than an unresolved
+	// window, and bolt rehydrate keeps the reading rather than dropping it.
+	// Both key on ContextRequests, which only the accountant writes.
+	if got.ContextLimit != 0 || got.ContextTokens != 0 || got.ContextRequests != 0 {
+		t.Errorf("a heartbeat invented a window, a token count, or a request count: %+v", got.SessionContext)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -113,6 +113,12 @@ type Runtime struct {
 	// headless mode: a harness given no prompt reads stdin, and stdin in
 	// a detached pane is a tty nobody types into.
 	Prompt string `toml:"prompt,omitempty"`
+	// ContextWindow overrides the model-to-limit table for this runtime,
+	// in tokens. The escape hatch for a model marvel does not know: a
+	// shipped table tracks the vendor's release cadence, not marvel's. A
+	// window the harness declares itself outranks this, because the
+	// harness's own belief is what enforces compaction.
+	ContextWindow int `toml:"context_window,omitempty"`
 }
 
 // Session is the atomic unit: a tmux pane running one process (pod equivalent).
@@ -130,7 +136,6 @@ type Session struct {
 	State           SessionState `toml:"-"`
 	PaneID          string       `toml:"-"`
 	PID             int          `toml:"-"`
-	ContextPercent  float64      `toml:"-"`
 	LastHeartbeat   time.Time    `toml:"-"`
 	HealthState     HealthState  `toml:"-"`
 	FailureCount    int          `toml:"-"`
@@ -138,6 +143,34 @@ type Session struct {
 	LastHealthCheck time.Time    `toml:"-"`
 	CreatedAt       time.Time    `toml:"-"`
 	SessionMetrics  `toml:"-"`
+	SessionContext  `toml:"-"`
+}
+
+// SessionContext is one context-window reading for a session.
+//
+// ContextAt separates "measured" from "never measured", exactly as
+// SessionMetrics.MetricsAt does. ContextLimit == 0 further separates
+// "tokens measured, window unknown" from both, so callers render three
+// states rather than a convincing percentage against a guessed window.
+// See orc finding-055 for the recorded cost of a wrong denominator.
+//
+// The reading is raw occupancy against the model's window, which is not
+// the figure a harness displays to its own user (see internal/usage).
+type SessionContext struct {
+	ContextPercent float64
+	ContextTokens  int
+	ContextLimit   int
+	// ContextLimitSource names the rung of the resolution ladder that
+	// produced ContextLimit, so a consumer can tell a measured window
+	// from a table guess. Values are usage.LimitSource.
+	ContextLimitSource string
+	ContextModel       string
+	ContextRequests    int
+	ContextCompactions int
+	// ContextPeak is the high-water ContextPercent, valid when
+	// ContextLimit > 0.
+	ContextPeak float64
+	ContextAt   time.Time
 }
 
 // SessionMetrics is one process-sampler reading for a session, rolled up

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -30,6 +30,7 @@ import (
 	"github.com/arcavenae/marvel/internal/session"
 	"github.com/arcavenae/marvel/internal/team"
 	"github.com/arcavenae/marvel/internal/tmux"
+	"github.com/arcavenae/marvel/internal/usage"
 )
 
 const (
@@ -104,6 +105,10 @@ type Daemon struct {
 	// Always non-nil.
 	events *events.Ring
 
+	// Per-session context and token accountant, fed by the adapter
+	// streams through the session manager. Always non-nil.
+	usage *usage.Accountant
+
 	// metricsWarn keeps a sampler that cannot read the process table
 	// from writing the same line every interval for the life of the
 	// daemon.
@@ -145,6 +150,10 @@ type Options struct {
 	// timeout without a 10-minute wait) via the daemon's --shift-timeout
 	// flag or MARVEL_SHIFT_TIMEOUT. See aae-orc-sape / ArcavenAE/marvel#88.
 	ShiftTimeout time.Duration
+	// ContextLimits, when non-nil, replaces the shipped model-to-window
+	// table the usage accountant resolves denominators against. Tests set
+	// it so a fixture's model does not have to be a real shipped entry.
+	ContextLimits usage.Table
 }
 
 // New creates a new daemon with default options.
@@ -191,6 +200,15 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	sessMgr.Events = evRing
 	teamCtrl.Events = evRing
 
+	// The usage accountant is event-driven, so it needs no goroutine and
+	// no interval of its own. *api.Store satisfies its Sink directly.
+	limits := opts.ContextLimits
+	if limits == nil {
+		limits = usage.DefaultTable()
+	}
+	acct := usage.New(store, usage.NewResolver(limits), usage.WithEvents(evRing))
+	sessMgr.Usage = acct
+
 	return &Daemon{
 		store:    store,
 		sessMgr:  sessMgr,
@@ -199,9 +217,15 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 		pidFile:  opts.PidFile,
 		logs:     buf,
 		events:   evRing,
+		usage:    acct,
 		reexec:   syscall.Exec,
 	}, nil
 }
+
+// Usage returns the daemon's context and token accountant. Exported for
+// tests and for the read-side consumers (admission control, shift
+// triggers) that will hold it as a usage.Reader.
+func (d *Daemon) Usage() *usage.Accountant { return d.usage }
 
 // LogBuffer returns the daemon's in-memory log ring. Callers can
 // hook it into log.SetOutput to tee stderr into the buffer; the

--- a/internal/daemon/metrics.go
+++ b/internal/daemon/metrics.go
@@ -38,6 +38,17 @@ func (d *Daemon) RunMetrics(ctx context.Context, interval time.Duration) {
 // CLI renders absence rather than zero usage.
 func (d *Daemon) SampleMetricsOnce(sampler *procstat.Sampler) {
 	sessions := d.store.ListSessions()
+
+	// The accountant is event-driven and needs no timer of its own, but a
+	// missed Forget would leak per-session state for the daemon's life.
+	// One map intersection on the pass that already has the session list
+	// is cheaper than a second ticker.
+	live := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		live[s.Key()] = true
+	}
+	d.usage.Sweep(live)
+
 	pids := make([]int, 0, len(sessions))
 	for _, s := range sessions {
 		if s.PID > 0 && s.State.CountsAsAlive() {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -38,6 +38,13 @@ const (
 	// signal of a policy landing at spawn and of live re-projection after
 	// a manifest change. See finding-024.
 	KindPolicyProjected Kind = "policy.projected"
+	// KindContextLimitUnresolved records that marvel measured a session's
+	// context tokens but could not resolve the model's context window, so
+	// CTX% stays blank rather than showing a percentage against a guessed
+	// denominator. Fires once per session. This is the operator's answer
+	// to "why is that column empty", and the fix is usually one
+	// runtime.context_window line in the manifest.
+	KindContextLimitUnresolved Kind = "context.limit-unresolved"
 )
 
 // Agent-stream kinds. These are the runtime adapter vocabulary

--- a/internal/runtime/claudecode/mapping.md
+++ b/internal/runtime/claudecode/mapping.md
@@ -36,13 +36,45 @@ what claude actually emits with the sketch in
    the vendor line in `raw`. Follow-on: consider promoting to a
    `message.thinking` first-class kind.
 
-3. **`turn.started` / `turn.completed` are not emitted.** The design
-   sketch says "message boundaries → turn.*", but in `-p` mode the
-   turn envelope is degenerate: one turn per invocation, delimited
-   by the outer system/init and result lines. We emit
-   session.started/ended for that scope and reserve turn.* for the
-   multi-turn interactive case (`--resume` sessions, or future
-   session-server usage).
+3. **`turn.completed` IS emitted; `turn.started` is not.** REVISED. This
+   parser previously emitted neither, on the grounds that the `-p` turn
+   envelope is degenerate (one invocation, delimited by system/init and
+   result). That reasoning does not survive contact with context
+   accounting: every `assistant` line carries a `message.usage` object
+   with the three prompt-token classes for the request that produced it,
+   and that is the only LIVE context-occupancy signal this harness gives.
+   The result line's totals arrive after the session is over.
+
+   So each assistant line's usage now rides a `turn.completed` carrying
+   `TurnData.Request`. The harness itself agrees an API request is a
+   turn: `result.num_turns` is 3 on `testdata/tool_call.ndjson`, against
+   three distinct `message.id` values.
+
+   Emission is deduped on `message.id`, not per line: one API response is
+   split into one vendor line per content block, so the six assistant
+   lines in the tool-call fixture repeat three ids and produce three
+   events. `usage` is decoded as a pointer because `user` and
+   `tool_result` lines carry `"usage": null`; emitting a zero for those
+   would land in the occupancy series and read as a compaction on every
+   tool result.
+
+   `turn.started` still has no source. Rejected alternatives: attaching
+   usage to `MessageData` (usage is not message content, it repeats per
+   block, and a thinking-only line maps to `error{unmapped}`, so the
+   usage would ride an error event); adding a thirteenth event kind.
+
+   **Subagent lines are marked, not merged.** Every assistant line carries
+   a top-level `parent_tool_use_id`, null for the main agent in both
+   fixtures and set to the `Task` tool's id for a subagent turn. A
+   subagent fills its own context window with a much smaller prompt, so
+   folding its usage into the session's occupancy level would drop the
+   reading for the length of the tool call and read as a compaction on the
+   way in and out. The field rides `Request.ParentToolUseID` rather than
+   suppressing the event, because the subagent's tokens are real spend:
+   the accountant bills them and excludes them from occupancy, the same
+   split it already applies to a non-primary model. Not measured here (no
+   captured fixture carries a subagent turn); the null field in both
+   fixtures is what names the case.
 
 4. **`init` carries far more fields than the spec calls out.** The
    spec names model/cwd/resumed; claude also ships tools (a big
@@ -62,6 +94,17 @@ what claude actually emits with the sketch in
    breakdown, and `permission_denials`. Cache counts live on Metering
    rather than Usage because Usage's three fields are spec-fixed and
    shared with turn events.
+
+   `modelUsage` entries also carry `contextWindow` and `maxOutputTokens`,
+   both now surfaced on `events.ModelUsage`. `contextWindow` is the
+   authoritative denominator for context occupancy, and it must be
+   selected by the init model (`system/init.model`), never by ranging the
+   map: a session that routes across models carries one entry per model
+   with different windows (200000 for haiku and 1000000 for
+   claude-fable-5[1m] in both fixtures), and Go map iteration order is
+   randomized. Note that `system/init.model` and the `modelUsage` key
+   carry the `[1m]` suffix while per-request `message.model` does not, so
+   the two names are not interchangeable for a window lookup.
 
    Still dropped: `result` (the final assistant text, already carried by
    the preceding message.completed event), `terminal_reason`,

--- a/internal/runtime/claudecode/parser.go
+++ b/internal/runtime/claudecode/parser.go
@@ -34,6 +34,15 @@ type Parser struct {
 	seq    *events.SeqAssigner
 	sessID string
 	clock  func() time.Time
+	// model is the init model, which is also the key into the result
+	// line's modelUsage map. Per-request message.model omits the [1m]
+	// suffix the init model carries, so the two are not interchangeable
+	// for a window lookup.
+	model string
+	// lastRequestID dedupes the per-request usage emission: one API
+	// response arrives as one vendor line per content block, each
+	// repeating the same message.id and the same usage object.
+	lastRequestID string
 }
 
 // NewParser constructs a parser with an internal SeqAssigner. Provide
@@ -151,6 +160,7 @@ func (p *Parser) handleSystem(subtype string, raw json.RawMessage, emit func(eve
 		}, raw))
 		return
 	}
+	p.model = body.Model
 	emit(p.newEvent(events.KindSessionStarted, events.SessionStartedData{
 		Model:   body.Model,
 		Cwd:     body.Cwd,
@@ -174,12 +184,30 @@ type contentBlock struct {
 	IsError   bool            `json:"is_error,omitempty"`
 }
 
+// messageUsage is the per-request accounting on an assistant line. A
+// pointer in the wrapper below because `user` and `tool_result` lines
+// carry "usage": null.
+type messageUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+
 func (p *Parser) handleMessage(vendorType string, raw json.RawMessage, emit func(events.Event)) {
 	var wrapper struct {
 		Message struct {
+			ID      string         `json:"id"`
+			Model   string         `json:"model"`
 			Role    string         `json:"role"`
 			Content []contentBlock `json:"content"`
+			Usage   *messageUsage  `json:"usage"`
 		} `json:"message"`
+		// ParentToolUseID is top-level, beside `message`, and is null on
+		// every main-agent line in both fixtures. Non-null marks a
+		// subagent turn, whose usage belongs to a different context
+		// window than the session's own.
+		ParentToolUseID string `json:"parent_tool_use_id"`
 	}
 	if err := json.Unmarshal(raw, &wrapper); err != nil {
 		emit(p.newEvent(events.KindError, events.ErrorData{
@@ -196,11 +224,70 @@ func (p *Parser) handleMessage(vendorType string, raw json.RawMessage, emit func
 		role = vendorType
 	}
 
+	p.emitRequestUsage(requestLine{
+		id:              wrapper.Message.ID,
+		model:           wrapper.Message.Model,
+		parentToolUseID: wrapper.ParentToolUseID,
+		usage:           wrapper.Message.Usage,
+	}, emit)
+
 	// One vendor line may carry several blocks (thinking + tool_use,
 	// text + tool_use, etc.). Emit one event per block.
 	for _, blk := range wrapper.Message.Content {
 		p.emitBlock(role, blk, raw, emit)
 	}
+}
+
+// requestLine is the per-request accounting lifted off one vendor line.
+type requestLine struct {
+	id              string
+	model           string
+	parentToolUseID string
+	usage           *messageUsage
+}
+
+// emitRequestUsage lifts the assistant line's prompt accounting into a
+// turn.completed event, which is marvel's only live context-occupancy
+// signal for this harness. Four guards, each load-bearing:
+//
+//   - usage is a pointer, because user/tool_result lines carry null. A
+//     zero emitted for those would land in the occupancy level series
+//     and read as a compaction on every tool result.
+//   - one event per LINE, not per content block: an assistant line whose
+//     only block is `thinking` or `tool_use` still carries usage, and
+//     those blocks do not map to message.completed.
+//   - dedupe on message.id: one API response is split into one vendor
+//     line per block, repeating id and usage. Occupancy is a level so a
+//     missed dedupe would only inflate the request count, but the count
+//     is reported.
+//   - parent_tool_use_id rides the event rather than suppressing it. A
+//     subagent's prompt is real spend but a different window, so the
+//     consumer must be able to tell the two apart; dropping the line
+//     would lose the spend, and folding it in silently would replace the
+//     session's occupancy level with the subagent's for the duration of
+//     the tool call.
+func (p *Parser) emitRequestUsage(line requestLine, emit func(events.Event)) {
+	u := line.usage
+	if u == nil || line.id == "" || line.id == p.lastRequestID {
+		return
+	}
+	p.lastRequestID = line.id
+	emit(p.newEvent(events.KindTurnCompleted, events.TurnData{
+		UsageDelta: events.Usage{In: u.InputTokens, Out: u.OutputTokens},
+		Request: &events.RequestUsage{
+			RequestID:       line.id,
+			Model:           line.model,
+			Layout:          events.LayoutAdditive,
+			In:              u.InputTokens,
+			Out:             u.OutputTokens,
+			CacheReadIn:     u.CacheReadInputTokens,
+			CacheCreationIn: u.CacheCreationInputTokens,
+			ParentToolUseID: line.parentToolUseID,
+			// Total stays 0: Claude publishes no per-request total, so
+			// the TotalMismatch invariant is disabled for this harness
+			// and the exact session-end reconciliation is its guard.
+		},
+	}, nil))
 }
 
 func (p *Parser) emitBlock(role string, blk contentBlock, raw json.RawMessage, emit func(events.Event)) {
@@ -326,6 +413,13 @@ type resultBody struct {
 		CacheCreationInputTokens int     `json:"cacheCreationInputTokens"`
 		WebSearchRequests        int     `json:"webSearchRequests"`
 		CostUSD                  float64 `json:"costUSD"`
+		// ContextWindow is the authoritative denominator for context
+		// occupancy. Select the entry by the init model, never by
+		// ranging the map: a session that routes across models carries
+		// several entries with different windows (200000 and 1000000 in
+		// the fixtures) and Go map iteration is randomized.
+		ContextWindow   int `json:"contextWindow"`
+		MaxOutputTokens int `json:"maxOutputTokens"`
 	} `json:"modelUsage"`
 	// Entry shape is unverified — every fixture we have carries an empty
 	// array. The length is authoritative; tool_name/tool_use_id are
@@ -361,6 +455,8 @@ func (b *resultBody) metering() *events.Metering {
 			CacheCreationIn:   u.CacheCreationInputTokens,
 			WebSearchRequests: u.WebSearchRequests,
 			Cost:              &cost,
+			ContextWindow:     u.ContextWindow,
+			MaxOutputTokens:   u.MaxOutputTokens,
 		}
 	}
 	for _, d := range b.PermissionDenials {

--- a/internal/runtime/claudecode/parser_test.go
+++ b/internal/runtime/claudecode/parser_test.go
@@ -53,9 +53,12 @@ func TestParseHelloFixture(t *testing.T) {
 	got := collectFixture(t, "hello.ndjson")
 
 	// hello fixture: system/init + assistant(text) + result.
-	// Expected: session.started + message.completed + session.ended.
+	// Expected: session.started, then the assistant line's per-request
+	// usage as turn.completed, then message.completed for its text block,
+	// then session.ended.
 	wantKinds := []events.Kind{
 		events.KindSessionStarted,
+		events.KindTurnCompleted,
 		events.KindMessageCompleted,
 		events.KindSessionEnded,
 	}
@@ -87,9 +90,9 @@ func TestParseHelloFixture(t *testing.T) {
 	}
 
 	// message.completed — role must be assistant, text must be non-empty.
-	msg, ok := got[1].Data.(events.MessageData)
+	msg, ok := got[2].Data.(events.MessageData)
 	if !ok {
-		t.Fatalf("event[1].Data type = %T, want MessageData", got[1].Data)
+		t.Fatalf("event[2].Data type = %T, want MessageData", got[2].Data)
 	}
 	if msg.Role != "assistant" {
 		t.Errorf("message.completed role = %q, want assistant", msg.Role)
@@ -100,9 +103,9 @@ func TestParseHelloFixture(t *testing.T) {
 
 	// session.ended — reason should map from stop_reason, exit_code 0,
 	// usage populated.
-	ended, ok := got[2].Data.(events.SessionEndedData)
+	ended, ok := got[3].Data.(events.SessionEndedData)
 	if !ok {
-		t.Fatalf("event[2].Data type = %T, want SessionEndedData", got[2].Data)
+		t.Fatalf("event[3].Data type = %T, want SessionEndedData", got[3].Data)
 	}
 	if ended.Reason == "" {
 		t.Error("session.ended missing reason")
@@ -175,29 +178,33 @@ func TestParseToolCallFixture(t *testing.T) {
 	t.Parallel()
 	got := collectFixture(t, "tool_call.ndjson")
 
-	// tool_call fixture (10 vendor lines):
-	//   1  system/init                    → session.started
-	//   2  assistant [thinking]           → error{unmapped}  (thinking not in v1)
-	//   3  assistant [tool_use]           → tool.call
-	//   4  user      [tool_result]        → tool.result
-	//   5  assistant [thinking]           → error{unmapped}
-	//   6  assistant [text]               → message.completed
-	//   7  assistant [tool_use]           → tool.call
-	//   8  user      [tool_result]        → tool.result
-	//   9  assistant [text]               → message.completed
-	//  10  result                         → session.ended
+	// tool_call fixture (10 vendor lines). Each line carries one content
+	// block, and each assistant line also carries its request's usage,
+	// emitted once per message.id rather than once per line. Three
+	// distinct ids across six assistant lines, hence three turn.completed.
 	//
-	// Total: 10 events (1:1 with vendor lines because each line
-	// carries exactly one content block).
+	//   1  system/init                    → session.started
+	//   2  assistant [thinking] id=SQ     → turn.completed, error{unmapped}
+	//   3  assistant [tool_use] id=SQ     → tool.call            (id repeats)
+	//   4  user      [tool_result]        → tool.result          (usage null)
+	//   5  assistant [thinking] id=Uf     → turn.completed, error{unmapped}
+	//   6  assistant [text]     id=Uf     → message.completed    (id repeats)
+	//   7  assistant [tool_use] id=Uf     → tool.call            (id repeats)
+	//   8  user      [tool_result]        → tool.result          (usage null)
+	//   9  assistant [text]     id=Bn     → turn.completed, message.completed
+	//  10  result                         → session.ended
 	wantKinds := []events.Kind{
 		events.KindSessionStarted,
+		events.KindTurnCompleted,
 		events.KindError,
 		events.KindToolCall,
 		events.KindToolResult,
+		events.KindTurnCompleted,
 		events.KindError,
 		events.KindMessageCompleted,
 		events.KindToolCall,
 		events.KindToolResult,
+		events.KindTurnCompleted,
 		events.KindMessageCompleted,
 		events.KindSessionEnded,
 	}
@@ -488,5 +495,237 @@ func TestSessionEndedMeteringOmittedFromJSONWhenAbsent(t *testing.T) {
 	}
 	if bytes.Contains(b, []byte("metering")) {
 		t.Errorf("metering leaked into JSON: %s", b)
+	}
+}
+
+// TestParseAssistantOccupancyIsALevelNotASum is the regression guard for
+// the load-bearing correction in this slice: context occupancy is a LEVEL
+// taken per API request, latest-wins, never a sum over requests.
+//
+// The result line's usage is a session-cumulative total. On this fixture
+// its occupancy sum is 100994, while real final occupancy is 34136. A
+// numerator built from the result line therefore reads 10.1% against a 1M
+// window where the truth is 3.4%, and the error grows with request count.
+func TestParseAssistantOccupancyIsALevelNotASum(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "tool_call.ndjson")
+
+	var reqs []*events.RequestUsage
+	for i, ev := range got {
+		if ev.Event != events.KindTurnCompleted {
+			continue
+		}
+		d, ok := ev.Data.(events.TurnData)
+		if !ok {
+			t.Fatalf("event[%d].Data = %T, want TurnData", i, ev.Data)
+		}
+		if d.Request == nil {
+			t.Fatalf("event[%d] turn.completed carries no Request", i)
+		}
+		reqs = append(reqs, d.Request)
+	}
+
+	// Six assistant lines, three distinct message ids: the dedupe proof.
+	if len(reqs) != 3 {
+		t.Fatalf("got %d per-request usage events, want 3 (six assistant lines, three ids)", len(reqs))
+	}
+
+	wantOccupancy := []int{33377, 33481, 34136}
+	for i, r := range reqs {
+		if got := r.Occupancy(); got != wantOccupancy[i] {
+			t.Errorf("request[%d] occupancy = %d, want %d", i, got, wantOccupancy[i])
+		}
+		if r.Layout != events.LayoutAdditive {
+			t.Errorf("request[%d] layout = %q, want additive", i, r.Layout)
+		}
+		// message.model omits the [1m] suffix the init model carries.
+		if r.Model != "claude-fable-5" {
+			t.Errorf("request[%d] model = %q, want claude-fable-5", i, r.Model)
+		}
+		if r.RequestID == "" {
+			t.Errorf("request[%d] carries no request id", i)
+		}
+		// Claude publishes no per-request total, so the mismatch
+		// invariant must stay disabled for this harness.
+		if r.Total != 0 {
+			t.Errorf("request[%d] total = %d, want 0", i, r.Total)
+		}
+	}
+
+	// The trap: the result line's classes sum to 100994 across the three
+	// requests. No emitted occupancy may equal it.
+	for i, r := range reqs {
+		if r.Occupancy() == 100994 {
+			t.Errorf("request[%d] occupancy is the result-line sum (100994), not a level", i)
+		}
+	}
+}
+
+// TestParseSingleRequestSessionAgrees documents why the level-vs-sum bug
+// hid for so long: in a single-request session the cumulative total and
+// the final level are the same number, so every one-shot fixture and every
+// single-request live measurement agrees with the wrong formula.
+func TestParseSingleRequestSessionAgrees(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "hello.ndjson")
+
+	var req *events.RequestUsage
+	for _, ev := range got {
+		if ev.Event == events.KindTurnCompleted {
+			req = ev.Data.(events.TurnData).Request
+		}
+	}
+	if req == nil {
+		t.Fatal("no per-request usage in the hello fixture")
+	}
+	// 11368 + 0 cache_read + 22005 cache_creation.
+	if got := req.Occupancy(); got != 33373 {
+		t.Errorf("request occupancy = %d, want 33373", got)
+	}
+
+	ended := got[len(got)-1].Data.(events.SessionEndedData)
+	m := ended.Metering
+	if m == nil {
+		t.Fatal("session.ended carries no metering")
+	}
+	resultSum := ended.Usage.In + m.CacheReadIn + m.CacheCreationIn
+	if resultSum != req.Occupancy() {
+		t.Errorf("single-request session: result sum %d != level %d", resultSum, req.Occupancy())
+	}
+}
+
+// TestParseResultContextWindowSelectsInitModel guards the map-range
+// hazard. Both fixtures route across two models with 5x-different
+// windows; ranging the map would pick the wrong one about half the time.
+func TestParseResultContextWindowSelectsInitModel(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "tool_call.ndjson")
+
+	started, ok := got[0].Data.(events.SessionStartedData)
+	if !ok {
+		t.Fatalf("event[0].Data = %T, want SessionStartedData", got[0].Data)
+	}
+	if started.Model != "claude-fable-5[1m]" {
+		t.Fatalf("init model = %q, want claude-fable-5[1m]", started.Model)
+	}
+
+	m := got[len(got)-1].Data.(events.SessionEndedData).Metering
+	if m == nil {
+		t.Fatal("session.ended carries no metering")
+	}
+	primary, ok := m.ModelUsage[started.Model]
+	if !ok {
+		t.Fatalf("model_usage has no entry for the init model: %+v", m.ModelUsage)
+	}
+	if primary.ContextWindow != 1_000_000 {
+		t.Errorf("init-model context window = %d, want 1000000", primary.ContextWindow)
+	}
+	if primary.MaxOutputTokens != 64_000 {
+		t.Errorf("init-model max output = %d, want 64000", primary.MaxOutputTokens)
+	}
+
+	haiku, ok := m.ModelUsage["claude-haiku-4-5-20251001"]
+	if !ok {
+		t.Fatalf("model_usage has no haiku entry: %+v", m.ModelUsage)
+	}
+	if haiku.ContextWindow != 200_000 {
+		t.Errorf("haiku context window = %d, want 200000", haiku.ContextWindow)
+	}
+	// The point of the test: selecting by anything other than the init
+	// model would resolve 200000 here, which is wrong by 5x.
+	if primary.ContextWindow == haiku.ContextWindow {
+		t.Error("fixture no longer exercises the two-window case")
+	}
+}
+
+// TestParseUserToolResultEmitsNoRequest pins the usage-is-a-pointer
+// guard: user/tool_result lines carry "usage": null, and a zero folded
+// into the level series would read as a compaction on every tool result.
+func TestParseUserToolResultEmitsNoRequest(t *testing.T) {
+	t.Parallel()
+	line := `{"type":"user","session_id":"s1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}],"usage":null}}`
+	p := NewParser(Config{Clock: fixedClock()})
+	var got []events.Event
+	if err := p.Parse(context.Background(), strings.NewReader(line+"\n"), func(e events.Event) {
+		got = append(got, e)
+	}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(got) != 1 || got[0].Event != events.KindToolResult {
+		t.Fatalf("kinds = %v, want [tool.result] only", kinds(got))
+	}
+}
+
+// TestParseThinkingOnlyLineStillCarriesUsage is the test an
+// attach-usage-to-MessageData design would fail: line 2 of the tool_call
+// fixture has one content block, `thinking`, which maps to
+// error{unmapped} and never to message.completed. Its usage must still
+// reach a consumer.
+func TestParseThinkingOnlyLineStillCarriesUsage(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "tool_call.ndjson")
+	if len(got) < 3 {
+		t.Fatalf("got %d events, want at least 3", len(got))
+	}
+	turn, ok := got[1].Data.(events.TurnData)
+	if !ok {
+		t.Fatalf("event[1].Data = %T, want TurnData", got[1].Data)
+	}
+	if turn.Request == nil || turn.Request.Occupancy() != 33377 {
+		t.Errorf("thinking-only line lost its usage: %+v", turn.Request)
+	}
+	if got[2].Event != events.KindError {
+		t.Errorf("event[2].kind = %s, want error{unmapped} for the thinking block", got[2].Event)
+	}
+}
+
+// TestParseSubagentUsageIsMarked: a Task-tool turn accounts against its
+// own context window, so its usage must arrive labelled. Unlabelled, it
+// would overwrite the session's occupancy level with a much smaller
+// number for the length of the tool call. Both shipped fixtures carry
+// "parent_tool_use_id":null on every assistant line, which is the field
+// this reads; the non-null shape below is synthetic.
+func TestParseSubagentUsageIsMarked(t *testing.T) {
+	t.Parallel()
+	stream := `{"type":"assistant","session_id":"s1","parent_tool_use_id":null,"message":{"id":"msg_main","model":"claude-fable-5","role":"assistant","content":[{"type":"text","text":"delegating"}],"usage":{"input_tokens":331,"output_tokens":1,"cache_read_input_tokens":33479,"cache_creation_input_tokens":326}}}
+{"type":"assistant","session_id":"s1","parent_tool_use_id":"toolu_01Sub","message":{"id":"msg_sub","model":"claude-haiku-4-5","role":"assistant","content":[{"type":"text","text":"subagent work"}],"usage":{"input_tokens":900,"output_tokens":40,"cache_read_input_tokens":1200,"cache_creation_input_tokens":0}}}
+`
+	p := NewParser(Config{Clock: fixedClock()})
+	var reqs []*events.RequestUsage
+	if err := p.Parse(context.Background(), strings.NewReader(stream), func(e events.Event) {
+		if e.Event == events.KindTurnCompleted {
+			reqs = append(reqs, e.Data.(events.TurnData).Request)
+		}
+	}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("got %d per-request usage events, want 2", len(reqs))
+	}
+	if reqs[0].Subagent() {
+		t.Errorf("main-agent line marked as a subagent: %q", reqs[0].ParentToolUseID)
+	}
+	if !reqs[1].Subagent() {
+		t.Error("subagent line lost its parent_tool_use_id, so its tokens would land in the session's occupancy level")
+	}
+	if reqs[1].ParentToolUseID != "toolu_01Sub" {
+		t.Errorf("parent tool use id = %q, want toolu_01Sub", reqs[1].ParentToolUseID)
+	}
+	// The usage itself is still carried: a subagent's prompt is billed.
+	if reqs[1].Occupancy() != 2100 {
+		t.Errorf("subagent occupancy = %d, want 2100", reqs[1].Occupancy())
+	}
+}
+
+func TestTurnDataRequestOmittedFromJSONWhenAbsent(t *testing.T) {
+	t.Parallel()
+	// Request is additive under schema_version 1, so a turn event without
+	// it must serialize exactly as it did before the field existed.
+	b, err := json.Marshal(events.TurnData{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(b, []byte("request")) {
+		t.Errorf("request leaked into JSON: %s", b)
 	}
 }

--- a/internal/runtime/codex/mapping.md
+++ b/internal/runtime/codex/mapping.md
@@ -45,11 +45,31 @@ Compares what codex actually emits with the sketch in
    codex cost is reachable only from the rollout files
    (`~/.codex/sessions/.../rollout-*.jsonl`), not the JSONL event stream.
 
-4. **Cache/reasoning token counts are dropped from the event.** `TurnData`
-   carries only the shared `Usage` shape (In, Out, Cost). `cached_input_tokens`,
-   `cache_write_input_tokens`, and `reasoning_output_tokens` are not
-   surfaced. They remain in `raw` if a consumer needs them; promoting them
-   would parallel claudecode's `Metering` follow-on.
+4. **Cache/reasoning token counts now ride `TurnData.Request`.** RESOLVED.
+   `TurnData.UsageDelta` still carries only the shared `Usage` shape (In,
+   Out, Cost), whose three fields are spec-fixed. The additive
+   `TurnData.Request` field carries the rest: `cached_input_tokens` as
+   CacheReadIn, `cache_write_input_tokens` as CacheCreationIn, and
+   `reasoning_output_tokens` as ReasoningOut.
+
+   `Request.Layout` is `subsumptive` for this harness: `input_tokens`
+   already contains `cached_input_tokens` (measured 13992 with 11008
+   cached), so context occupancy is `input_tokens` alone and summing the
+   cache class would double-count. Consumers must call
+   `RequestUsage.Occupancy()` rather than summing fields.
+
+   `turn.completed` publishes no `total_tokens`, so `Request.Total` stays
+   0 and the `TotalMismatch` arithmetic check is disabled here. Combined
+   with divergence 1 (no `session.ended`, so no end-of-session
+   reconciliation either), codex is the one harness whose declared layout
+   and cumulation have no runtime guard. Both rest on one live turn plus
+   the fixtures; `codex exec resume` is the command that settles the
+   multi-turn cumulation question.
+
+   Not read anywhere: the rollout file's
+   `rate_limits.primary.used_percent` (observed 95.0) is the WEEKLY PLAN
+   budget, not context occupancy. Nothing in the context accountant reads
+   it; recorded here so nobody wires it to CTX%.
 
 5. **`reasoning` items are unmapped.** Codex emits
    `item.completed{type:reasoning}` (the thinking analog). There is no v1

--- a/internal/runtime/codex/parser.go
+++ b/internal/runtime/codex/parser.go
@@ -171,6 +171,22 @@ func (p *Parser) handleTurnCompleted(raw json.RawMessage, emit func(events.Event
 			In:  body.Usage.InputTokens,
 			Out: body.Usage.OutputTokens,
 		},
+		Request: &events.RequestUsage{
+			// Subsumptive: input_tokens already contains
+			// cached_input_tokens, so summing double-counts. The cache
+			// classes still ride along because spend and cache-hit
+			// accounting need them.
+			Layout:          events.LayoutSubsumptive,
+			In:              body.Usage.InputTokens,
+			Out:             body.Usage.OutputTokens,
+			CacheReadIn:     body.Usage.CachedInputTokens,
+			CacheCreationIn: body.Usage.CacheWriteInputTokens,
+			ReasoningOut:    body.Usage.ReasoningOutputTokens,
+			// Total stays 0: turn.completed publishes no total_tokens, so
+			// the TotalMismatch invariant is disabled here. Codex also
+			// emits no session.ended, so it is the one harness with
+			// neither guard on its declared layout.
+		},
 	}, nil))
 }
 

--- a/internal/runtime/codex/parser_test.go
+++ b/internal/runtime/codex/parser_test.go
@@ -317,3 +317,76 @@ func parseLines(t *testing.T, stream string) []events.Event {
 	}
 	return got
 }
+
+func TestParseTurnUsagePromotesCacheClasses(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "hello.jsonl")
+
+	turn, ok := got[3].Data.(events.TurnData)
+	if !ok {
+		t.Fatalf("event[3].Data type = %T, want TurnData", got[3].Data)
+	}
+	r := turn.Request
+	if r == nil {
+		t.Fatal("turn.completed carries no Request")
+	}
+	// usage: input_tokens 13992 with cached_input_tokens 11008 inside it.
+	if r.In != 13992 {
+		t.Errorf("request in = %d, want 13992", r.In)
+	}
+	if r.CacheReadIn != 11008 {
+		t.Errorf("request cache_read_in = %d, want 11008", r.CacheReadIn)
+	}
+	if r.Layout != events.LayoutSubsumptive {
+		t.Errorf("layout = %q, want subsumptive", r.Layout)
+	}
+	// The point of the subsumptive layout: cached tokens are already in
+	// In, so occupancy is In alone and never the 25000 a sum would give.
+	if got := r.Occupancy(); got != 13992 {
+		t.Errorf("occupancy = %d, want 13992 (In alone, not In+cache)", got)
+	}
+	// No total_tokens on the wire, so the layout invariant is disabled.
+	if r.Total != 0 {
+		t.Errorf("total = %d, want 0", r.Total)
+	}
+	if r.TotalMismatch() != 0 {
+		t.Errorf("total mismatch = %d, want 0 when no total is published", r.TotalMismatch())
+	}
+	if r.Cost != nil {
+		t.Errorf("cost = %v, want nil (codex reports no cost)", r.Cost)
+	}
+}
+
+// TestParseResumeOccupancyIsALevel exercises the multi-turn occupancy
+// series codex `exec` one-shot cannot produce.
+//
+// SYNTHETIC FIXTURE: resume.jsonl is hand-composed from two real
+// turn.completed payloads. Whether codex's input_tokens is a per-turn
+// level or a running session total is UNVERIFIED against a real capture;
+// `codex exec resume` is the command that settles it. This test pins the
+// level reading the parser and accountant assume.
+func TestParseResumeOccupancyIsALevel(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "resume.jsonl")
+
+	var occ []int
+	for _, ev := range got {
+		if ev.Event != events.KindTurnCompleted {
+			continue
+		}
+		r := ev.Data.(events.TurnData).Request
+		if r == nil {
+			t.Fatal("turn.completed carries no Request")
+		}
+		occ = append(occ, r.Occupancy())
+	}
+	want := []int{13992, 28110}
+	if len(occ) != len(want) {
+		t.Fatalf("got %d turn occupancies, want %d: %v", len(occ), len(want), occ)
+	}
+	for i := range want {
+		if occ[i] != want[i] {
+			t.Errorf("turn[%d] occupancy = %d, want %d", i, occ[i], want[i])
+		}
+	}
+}

--- a/internal/runtime/codex/testdata/resume.jsonl
+++ b/internal/runtime/codex/testdata/resume.jsonl
@@ -1,0 +1,7 @@
+{"type":"thread.started","thread_id":"019fba85-383c-7300-a578-d3b7c4c6f607"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"first"}}
+{"type":"turn.completed","usage":{"input_tokens":13992,"cached_input_tokens":11008,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"second"}}
+{"type":"turn.completed","usage":{"input_tokens":28110,"cached_input_tokens":24064,"cache_write_input_tokens":0,"output_tokens":76,"reasoning_output_tokens":0}}

--- a/internal/runtime/events/events.go
+++ b/internal/runtime/events/events.go
@@ -91,6 +91,114 @@ type Usage struct {
 	Cost *float64 `json:"cost,omitempty"`
 }
 
+// Layout says how a harness's cache token classes relate to In. It rides
+// the payload rather than living in a consumer-side lookup table: the
+// parser knows its own harness, so a declared Layout cannot drift out of
+// sync with the fields beside it, and an unknown harness cannot be
+// silently mis-summed.
+type Layout string
+
+const (
+	// LayoutAdditive means occupancy is In + CacheReadIn + CacheCreationIn.
+	// Claude Code. Measured: In alone understated real context roughly
+	// 3000x on a warm session (finding-007 recorded In 10 against 29903).
+	LayoutAdditive Layout = "additive"
+	// LayoutSubsumptive means occupancy is In alone. Codex, whose
+	// input_tokens already contains cached_input_tokens (measured 13992
+	// with 11008 cached), so summing double-counts.
+	LayoutSubsumptive Layout = "subsumptive"
+)
+
+// RequestUsage is one API request's token accounting as the harness
+// reported it, attached to TurnData when a harness attributes usage per
+// request. A nil pointer means "not attributed", which is distinct from
+// reporting zeros, the same discipline as SessionEndedData.Metering.
+//
+// The token fields are carried as the harness names them and are not
+// pre-interpreted. Do not sum them to get occupancy: call Occupancy(),
+// which applies Layout. The raw classes are retained because they are
+// needed for spend and cache accounting, and because keeping them is
+// what lets a consumer re-derive occupancy if a Layout is later
+// corrected.
+type RequestUsage struct {
+	RequestID       string `json:"request_id,omitempty"`
+	Model           string `json:"model,omitempty"`
+	Layout          Layout `json:"layout,omitempty"`
+	In              int    `json:"in,omitempty"`
+	Out             int    `json:"out,omitempty"`
+	CacheReadIn     int    `json:"cache_read_in,omitempty"`
+	CacheCreationIn int    `json:"cache_creation_in,omitempty"`
+	ReasoningOut    int    `json:"reasoning_out,omitempty"`
+	// Total is the harness's own token total when it publishes one, else
+	// 0. Used only for the TotalMismatch invariant, never as a numerator.
+	Total int `json:"total,omitempty"`
+	// TotalExcludesCache says Total is defined over In + Out +
+	// ReasoningOut alone, so TotalMismatch must leave the cache classes
+	// out of the comparison. OpenCode measures this way (finding-007:
+	// total 29893 against input 29879 + output 2 + reasoning 12), and
+	// without this flag every caching turn there would report a phantom
+	// mismatch equal to the cache classes.
+	TotalExcludesCache bool     `json:"total_excludes_cache,omitempty"`
+	Cost               *float64 `json:"cost,omitempty"`
+	// ContextWindow is the window the harness declared alongside this
+	// request, else 0. Claude declares it only on the terminal result
+	// line, so live requests carry 0.
+	ContextWindow int `json:"context_window,omitempty"`
+	// ParentToolUseID names the tool call this request belongs to, else
+	// "". Non-empty means a subagent turn (Claude's Task tool): its
+	// tokens are real spend against a SEPARATE context window, so a
+	// consumer must keep them out of the parent session's occupancy
+	// level. Claude ships the field on every assistant line, null for
+	// the main agent.
+	ParentToolUseID string `json:"parent_tool_use_id,omitempty"`
+}
+
+// Subagent reports a request made inside a tool call rather than by the
+// session's own agent.
+func (r RequestUsage) Subagent() bool { return r.ParentToolUseID != "" }
+
+// Occupancy is the context-window numerator implied by Layout. This is
+// the only sanctioned way to derive it.
+func (r RequestUsage) Occupancy() int {
+	if r.Layout == LayoutSubsumptive {
+		return r.In
+	}
+	return r.In + r.CacheReadIn + r.CacheCreationIn
+}
+
+// TotalMismatch reports Total minus the sum of the classes the harness's
+// own total is defined over, or 0 when the harness published no Total.
+//
+// It checks the harness's arithmetic against marvel's reading of its
+// fields, so a nonzero result means a usage schema changed under us. It
+// does NOT arbitrate Layout where TotalExcludesCache is set: a total that
+// omits the cache classes is the same number whether In subsumes
+// CacheReadIn or not. AdditiveConfirmed is the one check that speaks to
+// that question.
+func (r RequestUsage) TotalMismatch() int {
+	if r.Total == 0 {
+		return 0
+	}
+	sum := r.In + r.Out + r.ReasoningOut
+	if !r.TotalExcludesCache && r.Layout != LayoutSubsumptive {
+		sum += r.CacheReadIn + r.CacheCreationIn
+	}
+	return r.Total - sum
+}
+
+// AdditiveConfirmed reports a request that PROVES In excludes
+// CacheReadIn: In is smaller than the count served from cache, which is
+// impossible if In already contained it.
+//
+// One-sided on purpose. A true result confirms an additive declaration
+// from live data; a false one proves nothing, because a subsumptive In is
+// always the larger number. It is the only signal marvel has for
+// OpenCode's unverified cache layout, and it fires on the shape a warm
+// caching session actually has (small In against a large cache read).
+func (r RequestUsage) AdditiveConfirmed() bool {
+	return r.Layout == LayoutAdditive && r.CacheReadIn > 0 && r.In < r.CacheReadIn
+}
+
 // SessionStartedData — new harness session (or resumed one). Only the
 // three spec fields are load-bearing; adapters may attach Tools for
 // diagnostic use (bounded by the same summary discipline).
@@ -150,6 +258,11 @@ type Metering struct {
 }
 
 // ModelUsage is per-model accounting within one session.
+//
+// ContextWindow and MaxOutputTokens are the harness's own declaration of
+// the model's limits. They are the authoritative denominator for context
+// occupancy where a harness publishes them (Claude Code does, on the
+// terminal result line); 0 means the harness named none.
 type ModelUsage struct {
 	In                int      `json:"in,omitempty"`
 	Out               int      `json:"out,omitempty"`
@@ -157,6 +270,8 @@ type ModelUsage struct {
 	CacheCreationIn   int      `json:"cache_creation_in,omitempty"`
 	WebSearchRequests int      `json:"web_search_requests,omitempty"`
 	Cost              *float64 `json:"cost,omitempty"`
+	ContextWindow     int      `json:"context_window,omitempty"`
+	MaxOutputTokens   int      `json:"max_output_tokens,omitempty"`
 }
 
 // PermissionDenial names one refused tool invocation. Tool is the
@@ -169,8 +284,14 @@ type PermissionDenial struct {
 
 // TurnData — usage delta at turn boundaries. May be zero-valued when
 // the harness does not attribute usage per turn.
+//
+// Request is an additive v1 field carrying the full per-request token
+// accounting behind that delta, including the cache classes Usage cannot
+// hold (its three fields are spec-fixed and shared with session events).
+// Nil means the harness did not attribute usage to a request.
 type TurnData struct {
-	UsageDelta Usage `json:"usage_delta,omitzero"`
+	UsageDelta Usage         `json:"usage_delta,omitzero"`
+	Request    *RequestUsage `json:"request,omitempty"`
 }
 
 // MessageData — content for message.delta and message.completed. Text

--- a/internal/runtime/opencode/mapping.md
+++ b/internal/runtime/opencode/mapping.md
@@ -46,6 +46,39 @@ uses underscores (`step_start`); the nested `part.type` uses hyphens
    so opencode cost is in the event but not yet in `marvel events` output
    — a bridge-summary gap, tracked as deferred, not an adapter concern.
 
+   `step_finish.part.tokens` also carries `total`, `reasoning`, and a
+   `cache: {write, read}` sub-object. All three were previously undeclared
+   in `ocTokens` and silently dropped; they now ride
+   `TurnData.Request` (Total, ReasoningOut, CacheCreationIn, CacheReadIn).
+
+   **`Request.Layout` is `additive` on an assumption, not a
+   measurement.** Whether `tokens.input` already subsumes `cache.read` on
+   a caching model is unverified: every fixture we hold is the free
+   `opencode/deepseek-v4-flash-free` model, where `cache.write` and
+   `cache.read` are both 0 and additive and subsumptive are
+   indistinguishable. If the assumption is wrong, occupancy over-counts by
+   whatever `input` already contains; every class is carried raw, so the
+   correction is one `Layout` line and no data is lost.
+
+   **`tokens.total` cannot arbitrate that question, and is not asked to.**
+   Measured (finding-007), opencode's total is `input + output +
+   reasoning`: `{total 29893, input 29879, output 2, reasoning 12}` with
+   `cache` zero. A total defined that way is the same number whether
+   `input` subsumes `cache.read` or not, so comparing it against a sum
+   that includes the cache classes would report a mismatch equal to those
+   classes on every caching turn, under a right assumption as readily as a
+   wrong one. `Request.TotalExcludesCache` therefore holds the comparison
+   to the `input + output + reasoning` triple, where it does earn its
+   keep: a nonzero result means opencode changed what `total` covers.
+
+   The one live signal on the layout itself is
+   `RequestUsage.AdditiveConfirmed()`: `input < cache.read` is impossible
+   if `input` already contained the cached tokens, so a warm caching turn
+   (small `input`, large `cache.read`) confirms the additive reading from
+   real data. It is one-sided. Silence proves nothing, because a
+   subsumptive `input` is always the larger number. One paid caching-model
+   turn settles the question either way.
+
 3. **A tool part carries call and result in one event.** OpenCode's `tool`
    part is a small state machine (`pending` → `running` → `completed`/`error`).
    In `run --format json` the terminal state arrives; the parser emits a

--- a/internal/runtime/opencode/parser.go
+++ b/internal/runtime/opencode/parser.go
@@ -108,8 +108,14 @@ type ocToolState struct {
 }
 
 type ocTokens struct {
-	Input  int `json:"input"`
-	Output int `json:"output"`
+	Input     int `json:"input"`
+	Output    int `json:"output"`
+	Reasoning int `json:"reasoning"`
+	Total     int `json:"total"`
+	Cache     struct {
+		Write int `json:"write"`
+		Read  int `json:"read"`
+	} `json:"cache"`
 }
 
 func (p *Parser) handleLine(line []byte, emit func(events.Event)) {
@@ -178,6 +184,25 @@ func (p *Parser) handleStepFinish(raw json.RawMessage, emit func(events.Event)) 
 			In:   part.Tokens.Input,
 			Out:  part.Tokens.Output,
 			Cost: &cost,
+		},
+		Request: &events.RequestUsage{
+			// Additive is an assumption, not a measurement: every fixture
+			// we hold is a non-caching model (cache read and write both
+			// 0), where additive and subsumptive are indistinguishable.
+			// TotalExcludesCache is what keeps the total from being read as
+			// an arbiter of that assumption: opencode's total is defined
+			// over input + output + reasoning, so it is the same number
+			// under either reading. AdditiveConfirmed is the check that
+			// does speak to it, and it needs a caching turn to fire.
+			Layout:             events.LayoutAdditive,
+			In:                 part.Tokens.Input,
+			Out:                part.Tokens.Output,
+			CacheReadIn:        part.Tokens.Cache.Read,
+			CacheCreationIn:    part.Tokens.Cache.Write,
+			ReasoningOut:       part.Tokens.Reasoning,
+			Total:              part.Tokens.Total,
+			TotalExcludesCache: true,
+			Cost:               &cost,
 		},
 	}, nil))
 }

--- a/internal/runtime/opencode/parser_test.go
+++ b/internal/runtime/opencode/parser_test.go
@@ -295,3 +295,121 @@ func parseLines(t *testing.T, stream string) []events.Event {
 	}
 	return got
 }
+
+func TestParseStepFinishPromotesEveryTokenClass(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "hello.jsonl")
+
+	var r *events.RequestUsage
+	for _, ev := range got {
+		if ev.Event == events.KindTurnCompleted {
+			r = ev.Data.(events.TurnData).Request
+		}
+	}
+	if r == nil {
+		t.Fatal("turn.completed carries no Request")
+	}
+	// tokens: {total 29907, input 29878, output 2, reasoning 27,
+	//          cache {write 0, read 0}}
+	if r.In != 29878 || r.Out != 2 || r.ReasoningOut != 27 || r.Total != 29907 {
+		t.Errorf("request = in %d out %d reasoning %d total %d, want 29878/2/27/29907",
+			r.In, r.Out, r.ReasoningOut, r.Total)
+	}
+	if r.CacheReadIn != 0 || r.CacheCreationIn != 0 {
+		t.Errorf("cache = read %d write %d, want 0/0 for the free model", r.CacheReadIn, r.CacheCreationIn)
+	}
+	if r.Layout != events.LayoutAdditive {
+		t.Errorf("layout = %q, want additive", r.Layout)
+	}
+	if r.Cost == nil {
+		t.Fatal("cost unset; opencode reports one (0 for the free model)")
+	}
+	// The total covers input + output + reasoning (measured), which is
+	// what TotalExcludesCache declares, so the invariant is silent on a
+	// well-formed line.
+	if !r.TotalExcludesCache {
+		t.Error("total_excludes_cache unset; the comparison would then include classes opencode's total omits")
+	}
+	if r.TotalMismatch() != 0 {
+		t.Errorf("total mismatch = %d, want 0 on a well-formed line", r.TotalMismatch())
+	}
+	// Nothing to confirm without a cache read.
+	if r.AdditiveConfirmed() {
+		t.Error("a non-caching turn cannot confirm the cache layout")
+	}
+}
+
+// TestParseCachingTurnConfirmsAdditiveLayout covers the one unverified
+// premise in this adapter, whether tokens.input already subsumes
+// cache.read, and the one signal that speaks to it.
+//
+// SYNTHETIC FIXTURE. caching.jsonl is a warm caching turn in the shape the
+// additive reading implies: a small input against a large cache read, with
+// total == input + output + reasoning as measured on the free model
+// (finding-007). Under that shape input cannot contain cache.read, which
+// is what AdditiveConfirmed reports. The check is one-sided; see the
+// subsumptive case below.
+func TestParseCachingTurnConfirmsAdditiveLayout(t *testing.T) {
+	t.Parallel()
+	got := collectFixture(t, "caching.jsonl")
+
+	var r *events.RequestUsage
+	for _, ev := range got {
+		if ev.Event == events.KindTurnCompleted {
+			r = ev.Data.(events.TurnData).Request
+		}
+	}
+	if r == nil {
+		t.Fatal("turn.completed carries no Request")
+	}
+	if r.CacheReadIn == 0 && r.CacheCreationIn == 0 {
+		t.Fatal("fixture no longer exercises a caching model")
+	}
+	// The measured total definition must not read as a layout fault: it is
+	// the same number under either reading of input, so a mismatch here
+	// would fire on every caching turn and mean nothing.
+	if got := r.TotalMismatch(); got != 0 {
+		t.Errorf("total mismatch = %d, want 0; opencode's total omits the cache classes by definition", got)
+	}
+	if !r.AdditiveConfirmed() {
+		t.Errorf("input %d against cache read %d must confirm the additive reading", r.In, r.CacheReadIn)
+	}
+	if got := r.Occupancy(); got != 29240 {
+		t.Errorf("occupancy = %d, want 29240 (input + cache read + cache write)", got)
+	}
+}
+
+// TestParseSubsumptiveShapeCannotBeConfirmed is the other half, and the
+// reason AdditiveConfirmed is documented as one-sided: if tokens.input
+// DOES contain the cached tokens it is necessarily the larger number, so
+// no line in that world can be distinguished from a cold additive one.
+// Marvel would over-count occupancy by the cache classes and nothing in
+// the stream would say so. One paid caching turn is the only settlement.
+func TestParseSubsumptiveShapeCannotBeConfirmed(t *testing.T) {
+	t.Parallel()
+	got := parseLines(t, `{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","tokens":{"total":29257,"input":29240,"output":12,"reasoning":5,"cache":{"write":200,"read":29000}},"cost":0}}`)
+	r := got[0].Data.(events.TurnData).Request
+	if r == nil {
+		t.Fatal("turn.completed carries no Request")
+	}
+	if r.TotalMismatch() != 0 {
+		t.Errorf("total mismatch = %d, want 0: the total is well-formed under either reading", r.TotalMismatch())
+	}
+	if r.AdditiveConfirmed() {
+		t.Error("a subsumptive input must not confirm the additive reading")
+	}
+}
+
+// A total that stops matching input + output + reasoning is a vendor
+// schema change, and that is the one thing the total is asked to catch.
+func TestParseTotalDefinitionChangeIsReported(t *testing.T) {
+	t.Parallel()
+	got := parseLines(t, `{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","tokens":{"total":29257,"input":40,"output":12,"reasoning":5,"cache":{"write":200,"read":29000}},"cost":0}}`)
+	r := got[0].Data.(events.TurnData).Request
+	if r == nil {
+		t.Fatal("turn.completed carries no Request")
+	}
+	if got := r.TotalMismatch(); got != 29200 {
+		t.Errorf("total mismatch = %d, want 29200 (29257 - (40+12+5))", got)
+	}
+}

--- a/internal/runtime/opencode/testdata/caching.jsonl
+++ b/internal/runtime/opencode/testdata/caching.jsonl
@@ -1,0 +1,2 @@
+{"type":"step_start","sessionID":"ses_cache","part":{"type":"step-start"}}
+{"type":"step_finish","sessionID":"ses_cache","part":{"id":"prt_c","messageID":"msg_c","sessionID":"ses_cache","type":"step-finish","tokens":{"total":57,"input":40,"output":12,"reasoning":5,"cache":{"write":200,"read":29000}},"cost":0.0125}}

--- a/internal/session/bridge.go
+++ b/internal/session/bridge.go
@@ -94,7 +94,19 @@ func summarize(ev rtevents.Event) string {
 	case rtevents.SessionEndedData:
 		return oneLine(sessionEndedSummary(d))
 	case rtevents.TurnData:
-		return oneLine(fmt.Sprintf("tokens in=%d out=%d", d.UsageDelta.In, d.UsageDelta.Out))
+		s := fmt.Sprintf("tokens in=%d out=%d", d.UsageDelta.In, d.UsageDelta.Out)
+		// Without the occupancy the line reads as a per-turn delta, which
+		// for a warm Claude session is a misleadingly small in= (the
+		// cached prompt is the bulk of the context and is not in In).
+		if d.Request != nil {
+			s += fmt.Sprintf(" ctx=%d", d.Request.Occupancy())
+			// A subagent turn's ctx is a different window's occupancy, so
+			// unlabelled it reads as the session's level collapsing.
+			if d.Request.Subagent() {
+				s += " (subagent)"
+			}
+		}
+		return oneLine(s)
 	case rtevents.MessageData:
 		if d.Text == "" {
 			return oneLine(d.Role)

--- a/internal/session/bridge_test.go
+++ b/internal/session/bridge_test.go
@@ -158,3 +158,66 @@ func TestBridgeMessageSummaryIsOneClippedLine(t *testing.T) {
 		t.Errorf("message lost its head: %q", got.Message)
 	}
 }
+
+// A turn summary without the occupancy reads as a per-turn delta, which
+// for a warm Claude session is a misleadingly small in= (the cached prompt
+// is the bulk of the context and is not in In). Measured: in=2 against
+// 33481 tokens of real context.
+func TestBridgeTurnSummaryCarriesOccupancy(t *testing.T) {
+	t.Parallel()
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindTurnCompleted,
+		Data: rtevents.TurnData{
+			UsageDelta: rtevents.Usage{In: 2, Out: 2},
+			Request: &rtevents.RequestUsage{
+				Layout: rtevents.LayoutAdditive,
+				In:     2, CacheReadIn: 22009, CacheCreationIn: 11470,
+			},
+		},
+	})
+	for _, want := range []string{"in=2", "out=2", "ctx=33481"} {
+		if !strings.Contains(got.Message, want) {
+			t.Errorf("message missing %q: %s", want, got.Message)
+		}
+	}
+	if strings.Contains(got.Message, "subagent") {
+		t.Errorf("main-agent turn labelled as a subagent: %s", got.Message)
+	}
+}
+
+// A subagent turn's ctx is a different window's occupancy. Unlabelled in
+// the ring it reads as the session's own level collapsing mid-run, which
+// is the same misreading the accountant refuses to make.
+func TestBridgeSubagentTurnIsLabelled(t *testing.T) {
+	t.Parallel()
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindTurnCompleted,
+		Data: rtevents.TurnData{
+			UsageDelta: rtevents.Usage{In: 900, Out: 40},
+			Request: &rtevents.RequestUsage{
+				Layout: rtevents.LayoutAdditive,
+				In:     900, CacheReadIn: 1200,
+				ParentToolUseID: "toolu_01Sub",
+			},
+		},
+	})
+	if !strings.Contains(got.Message, "ctx=2100") {
+		t.Errorf("subagent turn lost its occupancy: %s", got.Message)
+	}
+	if !strings.Contains(got.Message, "(subagent)") {
+		t.Errorf("subagent turn unlabelled: %s", got.Message)
+	}
+}
+
+// A harness that does not attribute usage per request must not gain a
+// misleading ctx=0.
+func TestBridgeTurnSummaryOmitsOccupancyWhenUnattributed(t *testing.T) {
+	t.Parallel()
+	got := bridgeEvent(testCoords(), rtevents.Event{
+		Event: rtevents.KindTurnCompleted,
+		Data:  rtevents.TurnData{UsageDelta: rtevents.Usage{In: 100, Out: 5}},
+	})
+	if strings.Contains(got.Message, "ctx=") {
+		t.Errorf("message invented an occupancy: %s", got.Message)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -16,7 +16,9 @@ import (
 	"github.com/arcavenae/marvel/internal/api"
 	"github.com/arcavenae/marvel/internal/events"
 	"github.com/arcavenae/marvel/internal/runtime"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
 	"github.com/arcavenae/marvel/internal/tmux"
+	"github.com/arcavenae/marvel/internal/usage"
 )
 
 // Manager creates and destroys sessions.
@@ -40,12 +42,17 @@ type Manager struct {
 	// are rewritten at spawn and on re-projection; nothing is preserved
 	// across restarts.
 	ProjectionDir string
+	// Usage receives adapter events for token and context accounting.
+	// Nil is safe, matching Events.
+	Usage UsageObserver
 
 	// instances tracks the live Instance per session key. Sessions
 	// adopted from a previous daemon have no entry: their pane predates
 	// this process, so marvel supervises them without observing them.
+	// drains holds the usage tap for the same keys.
 	imu       sync.Mutex
 	instances map[string]*runtime.TmuxInstance
+	drains    map[string]*usageDrain
 }
 
 // NewManager creates a session manager with the default runtime adapter registry.
@@ -57,6 +64,7 @@ func NewManager(store *api.Store, driver *tmux.Driver) *Manager {
 		StreamDir:     defaultStreamDir(),
 		ProjectionDir: defaultProjectionDir(),
 		instances:     make(map[string]*runtime.TmuxInstance),
+		drains:        make(map[string]*usageDrain),
 	}
 }
 
@@ -390,12 +398,76 @@ func discardSink(fifo *runtime.FIFO) {
 	}
 }
 
+// UsageObserver receives adapter events for token and context
+// accounting. Declared here beside its consumer so package session keeps
+// no hard dependency on a concrete accountant, and so tests can drive the
+// tap with a recorder. Nil is safe, matching Events.
+//
+// The event ring cannot serve this purpose: bridgeEvent flattens the
+// typed payload into a one-line string clipped at 160 bytes, so token
+// counts survive only as prose.
+type UsageObserver interface {
+	Bind(c usage.Coords, b usage.Bind)
+	Observe(c usage.Coords, ev rtevents.Event)
+	Forget(agentID string)
+}
+
+// usageDrain is the tap one session's drain goroutine folds through.
+//
+// It exists to order Forget AFTER the last fold. The events channel is
+// buffered 256 deep on purpose, and stream teardown joins the parser
+// goroutine only, so a session deleted mid-stream leaves a tail the drain
+// is still consuming. A Forget issued beside the delete would be followed
+// by folds that recreate the session's state from nothing: the team's
+// retired totals would count it twice, its Partial flag would latch on the
+// requestless replacement, and a live CTX% cell could be re-blanked by a
+// windowless reading.
+type usageDrain struct {
+	done chan struct{}
+
+	// mu serializes a fold against the retiring Forget, so the bounded
+	// wait can time out on a wedged drain without reopening that window.
+	// Held across one Observe only, which its contract bounds to
+	// arithmetic plus one non-persisting store write.
+	mu      sync.Mutex
+	retired bool
+}
+
+func (d *usageDrain) observe(u UsageObserver, c usage.Coords, ev rtevents.Event) {
+	if u == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.retired {
+		return
+	}
+	u.Observe(c, ev)
+}
+
+func (d *usageDrain) retire(u UsageObserver, key string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.retired = true
+	u.Forget(key)
+}
+
 // attachInstance records the instance and drains its event stream into
 // the ring. The goroutine ends when the harness's output ends, so its
 // lifetime is the session's.
+//
+// The accountant is called inline rather than through a tee:
+// TmuxInstance.Events() is a single-sender/single-receiver channel whose
+// reader owns and closes it, and fanning it out would add a second
+// back-pressure path against a chain that back-pressures the harness on
+// purpose. The cost is that Observe sits in that path, which is why its
+// contract bounds it to arithmetic plus one non-persisting store write.
 func (m *Manager) attachInstance(sess *api.Session, inst *runtime.TmuxInstance) {
+	drain := &usageDrain{done: make(chan struct{})}
+
 	m.imu.Lock()
 	m.instances[sess.Key()] = inst
+	m.drains[sess.Key()] = drain
 	m.imu.Unlock()
 
 	c := coords{
@@ -404,20 +476,65 @@ func (m *Manager) attachInstance(sess *api.Session, inst *runtime.TmuxInstance) 
 		Role:      sess.Role,
 		Session:   sess.Key(),
 	}
+	uc := usage.Coords{
+		AgentID:   sess.Key(),
+		Workspace: sess.Workspace,
+		Team:      sess.Team,
+		Role:      sess.Role,
+	}
+	// Bind before the drain starts so the denominator is resolved from
+	// launch args on the first fold, not after a round trip.
+	if m.Usage != nil {
+		m.Usage.Bind(uc, usage.Bind{
+			Harness: sess.Runtime.Name,
+			Args:    sess.Runtime.Args,
+			Window:  sess.Runtime.ContextWindow,
+		})
+	}
 	go func() {
+		defer close(drain.done)
 		for ev := range inst.Events() {
+			drain.observe(m.Usage, uc, ev)
 			events.Emit(m.Events, bridgeEvent(c, ev))
 		}
 	}()
 }
 
-// takeInstance removes and returns the instance for a session key.
-func (m *Manager) takeInstance(key string) *runtime.TmuxInstance {
+// takeInstance removes and returns the instance for a session key, with
+// the usage tap the caller must retire once the stream is down.
+func (m *Manager) takeInstance(key string) (*runtime.TmuxInstance, *usageDrain) {
 	m.imu.Lock()
 	defer m.imu.Unlock()
 	inst := m.instances[key]
+	drain := m.drains[key]
 	delete(m.instances, key)
-	return inst
+	delete(m.drains, key)
+	return inst, drain
+}
+
+// usageDrainGrace bounds the wait for a drain goroutine to finish the
+// buffered tail of a stream. The tail is arithmetic over at most one
+// channel buffer, and the reconciler is the caller, so this is a wedge
+// bound rather than a working budget.
+const usageDrainGrace = 2 * time.Second
+
+// forgetUsage retires a session's accounting after its drain goroutine
+// has folded the last buffered event. See usageDrain for why the order
+// matters. A nil drain is an adopted pane, which never had one.
+func (m *Manager) forgetUsage(key string, drain *usageDrain) {
+	if m.Usage == nil {
+		return
+	}
+	if drain == nil {
+		m.Usage.Forget(key)
+		return
+	}
+	select {
+	case <-drain.done:
+	case <-time.After(usageDrainGrace):
+		log.Printf("warning: session %s: usage drain still running after %v, retiring its accounting anyway", key, usageDrainGrace)
+	}
+	drain.retire(m.Usage, key)
 }
 
 // Instance returns the live instance for a session key, or nil when
@@ -442,8 +559,9 @@ const instanceTeardownGrace = 3 * time.Second
 // returned: by the time a session is being retired the pane is often
 // already gone, and that is not a failure of the retirement.
 func (m *Manager) retireInstance(key string) bool {
-	inst := m.takeInstance(key)
+	inst, drain := m.takeInstance(key)
 	if inst == nil {
+		m.forgetUsage(key, drain)
 		return false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), instanceTeardownGrace)
@@ -451,6 +569,7 @@ func (m *Manager) retireInstance(key string) bool {
 	if err := inst.Kill(ctx); err != nil {
 		log.Printf("warning: retire instance %s: %v", key, err)
 	}
+	m.forgetUsage(key, drain)
 	return true
 }
 
@@ -458,13 +577,15 @@ func (m *Manager) retireInstance(key string) bool {
 // vanished. Distinct from retireInstance so the reap path does not log a
 // kill-pane failure for a pane it knows is gone.
 func (m *Manager) detachInstance(key string) {
-	inst := m.takeInstance(key)
+	inst, drain := m.takeInstance(key)
 	if inst == nil {
+		m.forgetUsage(key, drain)
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), instanceTeardownGrace)
 	defer cancel()
 	inst.Detach(ctx)
+	m.forgetUsage(key, drain)
 }
 
 // directPlan builds the command string directly — the pre-adapter path

--- a/internal/session/stream_context_test.go
+++ b/internal/session/stream_context_test.go
@@ -1,0 +1,368 @@
+package session
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+	"github.com/arcavenae/marvel/internal/tmux"
+	"github.com/arcavenae/marvel/internal/usage"
+)
+
+// contextFixture is a claude-code stream-json transcript carrying
+// per-assistant-line usage across three distinct message ids, which is
+// where live context occupancy comes from. The numbers are the real
+// tool_call fixture's: levels 33377, 33481, 34136 against a 1M window,
+// with terminal totals that sum to 100994.
+const contextFixture = `{"type":"system","subtype":"init","session_id":"fixture-ctx","cwd":"/tmp","model":"claude-fable-5[1m]"}
+{"type":"assistant","session_id":"fixture-ctx","message":{"id":"msg_a","model":"claude-fable-5","role":"assistant","content":[{"type":"text","text":"one"}],"usage":{"input_tokens":11368,"output_tokens":3,"cache_read_input_tokens":16643,"cache_creation_input_tokens":5366}}}
+{"type":"assistant","session_id":"fixture-ctx","message":{"id":"msg_b","model":"claude-fable-5","role":"assistant","content":[{"type":"text","text":"two"}],"usage":{"input_tokens":2,"output_tokens":2,"cache_read_input_tokens":22009,"cache_creation_input_tokens":11470}}}
+{"type":"assistant","session_id":"fixture-ctx","message":{"id":"msg_c","model":"claude-fable-5","role":"assistant","content":[{"type":"text","text":"three"}],"usage":{"input_tokens":331,"output_tokens":1,"cache_read_input_tokens":33479,"cache_creation_input_tokens":326}}}
+{"type":"result","subtype":"success","is_error":false,"session_id":"fixture-ctx","duration_ms":4816,"num_turns":3,"stop_reason":"end_turn","total_cost_usd":0.4264,"usage":{"input_tokens":11701,"output_tokens":455,"cache_read_input_tokens":72131,"cache_creation_input_tokens":17162},"modelUsage":{"claude-fable-5[1m]":{"inputTokens":11701,"outputTokens":455,"cacheReadInputTokens":72131,"cacheCreationInputTokens":17162,"costUSD":0.4264,"contextWindow":1000000,"maxOutputTokens":64000}},"permission_denials":[]}
+`
+
+// codexContextFixture has no model and no window anywhere, which is the
+// unresolved-denominator case.
+const codexContextFixture = `{"type":"thread.started","thread_id":"fixture-cx-ctx"}
+{"type":"turn.started"}
+{"type":"turn.completed","usage":{"input_tokens":13992,"cached_input_tokens":11008,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}}
+`
+
+// runObservedHarness drives one stubbed harness through the whole byte
+// path with a real accountant over a real store.
+func runObservedHarness(t *testing.T, image, transcript string, window int) (*api.Store, *usage.Accountant, *events.Ring, *Manager, *api.Session) {
+	t.Helper()
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	ring := events.NewRing(200)
+	acct := usage.New(store, usage.NewResolver(usage.DefaultTable()), usage.WithEvents(ring))
+
+	mgr := NewManager(store, driver)
+	mgr.Events = ring
+	mgr.Usage = acct
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-" + image + "-context"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+	command := stubHarness(t, transcript)
+
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	rt := api.Runtime{
+		Name: image, Command: command, Mode: api.RuntimeModeHeadless,
+		Prompt: "say ok", ContextWindow: window,
+	}
+	if err := store.CreateTeam(&api.Team{
+		Name: "squad", Workspace: ws,
+		Roles: []api.Role{{Name: "worker", Replicas: 1, Runtime: rt}},
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	sess := &api.Session{
+		Name: "squad-worker-g1-0", Workspace: ws, Team: "squad", Role: "worker",
+		Runtime: rt,
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return store, acct, ring, mgr, sess
+}
+
+// waitForContext polls the store until a reading satisfying want arrives.
+func waitForContext(t *testing.T, store *api.Store, key string, want func(api.SessionContext) bool) api.SessionContext {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var last api.SessionContext
+	for time.Now().Before(deadline) {
+		sess, err := store.GetSession(key)
+		if err == nil {
+			last = sess.SessionContext
+			if want(last) {
+				return last
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("no matching context reading within the deadline; last was %+v", last)
+	return last
+}
+
+// TestClaudeStreamLightsTheContextColumn is the end-to-end proof for
+// aae-orc-w5su: a real headless claude launch populates CTX% from parsed
+// harness output, with no cooperative heartbeat anywhere.
+func TestClaudeStreamLightsTheContextColumn(t *testing.T) {
+	store, acct, _, mgr, sess := runObservedHarness(t, "claude", contextFixture, 0)
+
+	got := waitForContext(t, store, sess.Key(), func(c api.SessionContext) bool {
+		return c.ContextRequests == 3
+	})
+
+	// The level after three requests, NOT the 100994 the result line sums.
+	if got.ContextTokens != 34136 {
+		t.Errorf("tokens = %d, want 34136 (the last level, not the session total)", got.ContextTokens)
+	}
+	if got.ContextLimit != 1_000_000 {
+		t.Errorf("limit = %d, want 1000000", got.ContextLimit)
+	}
+	if got.ContextPercent < 3.4 || got.ContextPercent > 3.42 {
+		t.Errorf("percent = %v, want about 3.41", got.ContextPercent)
+	}
+	if got.ContextModel != "claude-fable-5[1m]" {
+		t.Errorf("model = %q, want claude-fable-5[1m]", got.ContextModel)
+	}
+	if got.ContextAt.IsZero() {
+		t.Error("ContextAt not stamped; the renderer would show absence")
+	}
+	// No heartbeat was ever sent: this is the whole point of the ticket.
+	live, _ := store.GetSession(sess.Key())
+	if !live.LastHeartbeat.IsZero() {
+		t.Error("the stream path stamped LastHeartbeat")
+	}
+
+	// The accountant's own view agrees, and reconciliation is clean.
+	occ, ok := acct.SessionOccupancy(sess.Key())
+	if !ok {
+		t.Fatal("accountant has no occupancy for the session")
+	}
+	if occ.Tokens != 34136 {
+		t.Errorf("accountant tokens = %d, want 34136", occ.Tokens)
+	}
+	if s := acct.Stats(); s.CumulationViolations != 0 || s.ReconcileMismatches != 0 {
+		t.Errorf("reconciliation flagged a correct session: %+v", s)
+	}
+
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	// Deleting the session retires its accounting.
+	if _, ok := acct.SessionOccupancy(sess.Key()); ok {
+		t.Error("accountant state outlived its session")
+	}
+}
+
+// TestUnresolvedWindowReportsAbsenceEndToEnd: codex names no model and no
+// window, so tokens are real and the percentage is not invented.
+func TestUnresolvedWindowReportsAbsenceEndToEnd(t *testing.T) {
+	store, _, ring, mgr, sess := runObservedHarness(t, "codex", codexContextFixture, 0)
+
+	got := waitForContext(t, store, sess.Key(), func(c api.SessionContext) bool {
+		return c.ContextRequests > 0
+	})
+
+	// Subsumptive layout: input_tokens already contains the cached tokens.
+	if got.ContextTokens != 13992 {
+		t.Errorf("tokens = %d, want 13992", got.ContextTokens)
+	}
+	if got.ContextLimit != 0 {
+		t.Errorf("limit = %d, want 0 (no model, no window, no guess)", got.ContextLimit)
+	}
+	if got.ContextPercent != 0 {
+		t.Errorf("percent = %v, want 0", got.ContextPercent)
+	}
+	if got.ContextAt.IsZero() {
+		t.Error("ContextAt not stamped; measured-without-a-window must be distinguishable from never-measured")
+	}
+	waitForKind(t, ring, events.KindContextLimitUnresolved, 10*time.Second)
+
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+}
+
+// The operator's escape hatch: one manifest line resolves the window for
+// a model marvel's table does not know.
+func TestManifestWindowResolvesUnknownModel(t *testing.T) {
+	store, _, _, mgr, sess := runObservedHarness(t, "codex", codexContextFixture, 258_400)
+
+	got := waitForContext(t, store, sess.Key(), func(c api.SessionContext) bool {
+		return c.ContextRequests > 0
+	})
+	if got.ContextLimit != 258_400 {
+		t.Errorf("limit = %d, want 258400 from runtime.context_window", got.ContextLimit)
+	}
+	if got.ContextPercent < 5.4 || got.ContextPercent > 5.42 {
+		t.Errorf("percent = %v, want about 5.41", got.ContextPercent)
+	}
+	if got.ContextLimitSource != "manifest" {
+		t.Errorf("limit source = %q, want manifest", got.ContextLimitSource)
+	}
+
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+}
+
+// gatedObserver records the order of accounting calls and can park the
+// drain goroutine inside a fold, which is what makes the ordering
+// deterministic rather than a race the test would usually win.
+type gatedObserver struct {
+	entered chan struct{}
+	release chan struct{}
+
+	mu    sync.Mutex
+	calls []string
+	once  bool
+}
+
+func newGatedObserver() *gatedObserver {
+	return &gatedObserver{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (g *gatedObserver) Bind(usage.Coords, usage.Bind) {}
+
+func (g *gatedObserver) Observe(_ usage.Coords, _ rtevents.Event) {
+	g.mu.Lock()
+	first := !g.once
+	g.once = true
+	g.mu.Unlock()
+	if first {
+		g.entered <- struct{}{}
+		<-g.release
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = append(g.calls, "observe")
+}
+
+func (g *gatedObserver) Forget(string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = append(g.calls, "forget")
+}
+
+func (g *gatedObserver) snapshot() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]string(nil), g.calls...)
+}
+
+// TestForgetFollowsTheBufferedTail: deleting a session mid-stream must
+// retire its accounting AFTER the drain goroutine folds the last buffered
+// event, never beside the delete.
+//
+// The events channel is 256 deep by design and stream teardown joins the
+// parser goroutine only, so events already queued survive the delete. A
+// Forget issued first is undone by them: the accountant recreates the
+// session from nothing, so the team's retired totals count it twice, its
+// Partial flag latches on a requestless state, and a live CTX% cell can be
+// re-blanked with a windowless reading.
+func TestForgetFollowsTheBufferedTail(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	obs := newGatedObserver()
+	mgr := NewManager(store, driver)
+	mgr.Usage = obs
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-forget-ordering"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+	command := stubHarness(t, contextFixture)
+	headlessTeam(t, store, ws, command, "say ok")
+
+	sess := &api.Session{
+		Name: "squad-worker-g1-0", Workspace: ws, Team: "squad", Role: "worker",
+		Runtime: api.Runtime{
+			Name: "claude", Command: command,
+			Mode: api.RuntimeModeHeadless, Prompt: "say ok",
+		},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Park the drain inside its first fold, so the rest of the transcript
+	// queues in the channel buffer while the delete runs.
+	select {
+	case <-obs.entered:
+	case <-time.After(15 * time.Second):
+		t.Fatal("the drain goroutine never folded an event")
+	}
+
+	deleted := make(chan error, 1)
+	go func() { deleted <- mgr.Delete(sess.Key()) }()
+
+	time.Sleep(150 * time.Millisecond)
+	close(obs.release)
+
+	select {
+	case err := <-deleted:
+		if err != nil {
+			t.Fatalf("delete session: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("delete never returned")
+	}
+
+	// Delete returns only once the drain has finished, so every fold this
+	// session will ever produce is already recorded. The wanted shape is
+	// N observes then exactly one trailing forget. A forget anywhere else,
+	// or a short run of observes, means the tail landed after the retire
+	// (or was thrown away with it).
+	calls := obs.snapshot()
+	observes := 0
+	for _, c := range calls {
+		if c == "observe" {
+			observes++
+		}
+	}
+	if observes < 3 || len(calls) != observes+1 || calls[len(calls)-1] != "forget" {
+		t.Errorf("accounting calls = %v; want at least 3 folds, then one trailing forget", calls)
+	}
+}
+
+// An interactive session produces no adapter events, so it produces no
+// reading. Headless-only is the documented scope of this slice.
+func TestInteractiveSessionHasNoContextReading(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	acct := usage.New(store, usage.NewResolver(usage.DefaultTable()))
+	mgr := NewManager(store, driver)
+	mgr.Usage = acct
+	mgr.StreamDir = filepath.Join(t.TempDir(), "streams")
+
+	ws := "test-interactive-context"
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	sess := &api.Session{
+		Name: "shell-0", Workspace: ws, Team: "util", Role: "shell",
+		Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"60"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	live, err := store.GetSession(sess.Key())
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if !live.ContextAt.IsZero() {
+		t.Errorf("an interactive session produced a context reading: %+v", live.SessionContext)
+	}
+	if err := mgr.Delete(sess.Key()); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+}

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1505,3 +1505,74 @@ func TestSaturatedRoleStaysFrozenAcrossRestart(t *testing.T) {
 		t.Fatalf("saturated role respawned after restart: %d alive session(s)", alive)
 	}
 }
+
+// TestContextReadingIsNotAHeartbeat is the coupling regression guard for
+// the usage accountant.
+//
+// The accountant writes through Store.UpdateSessionContext, which
+// deliberately does not touch LastHeartbeat. Routing it through
+// UpdateSessionHeartbeat instead would be one convenient line, and it
+// would silently redefine a heartbeat healthcheck from "the agent
+// reported in" to "the harness emitted bytes", marking a hung but still
+// streaming session healthy. This asserts the two stay separate at the
+// level where the coupling lives, not just in the store.
+func TestContextReadingIsNotAHeartbeat(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	createTeamFixture(t, store, "test-ctx-not-heartbeat", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy: api.RestartNever,
+			HealthCheck:   &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Millisecond, FailureThreshold: 1},
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	sessions := store.ListSessionsByTeamRole("test-ctx-not-heartbeat", "squad", "worker")
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	key := sessions[0].Key()
+
+	// The harness is streaming: context readings keep arriving.
+	store.UpdateSessionContext(key, api.SessionContext{
+		ContextTokens: 34136, ContextLimit: 1_000_000, ContextPercent: 3.4136,
+	})
+
+	// A session that streams but never heartbeats is still unhealthy.
+	ctrl.ReconcileOnce()
+	sess, err := store.GetSession(key)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if sess.HealthState != api.HealthUnhealthy {
+		t.Errorf("health = %s after a context reading and no heartbeat, want %s",
+			sess.HealthState, api.HealthUnhealthy)
+	}
+	if sess.ContextTokens != 34136 {
+		t.Errorf("context tokens = %d, want 34136 (the reading itself must survive)", sess.ContextTokens)
+	}
+
+	// And it is still not shift-ready: allReady requires a first heartbeat.
+	role := api.Role{
+		Name:        "worker",
+		HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: time.Hour, FailureThreshold: 3},
+	}
+	if err := store.UpdateSession(key, func(live *api.Session) error {
+		live.State = api.SessionRunning
+		live.HealthState = api.HealthUnknown
+		return nil
+	}); err != nil {
+		t.Fatalf("reset session state: %v", err)
+	}
+	fresh, err := store.GetSession(key)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if ctrl.allReady([]api.Session{fresh}, &role) {
+		t.Error("a session with a context reading but no heartbeat was declared shift-ready")
+	}
+}

--- a/internal/usage/accountant.go
+++ b/internal/usage/accountant.go
@@ -1,0 +1,717 @@
+package usage
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// Default compaction-detection hysteresis.
+//
+// Chosen to be un-fireable by ordinary variation rather than calibrated:
+// no live compaction was crossed on any harness, so the bound is reasoned,
+// not measured. Within one segment on one model the occupancy series is
+// monotone non-decreasing (measured 33377 then 33481 then 34136 while
+// input_tokens fell 11368 to 2 to 331), and the one compaction geometry
+// on record is roughly 167k down to 96k on a 200k window (orc
+// finding-066), a 71k drop. A real compaction therefore clears the guard
+// by an order of magnitude, and the threshold only has to reject sampling
+// artifacts.
+//
+// Because the numerator is a level rather than an accumulator, a
+// mis-tuned value costs a wrong Compactions count and nothing else.
+const (
+	defaultHysteresisTokens   = 2048
+	defaultHysteresisFraction = 0.10
+)
+
+// Coords is the marvel-side identity of an observed session, passed in by
+// the caller rather than recovered from the store per sample. The caller
+// already holds all four at the tap point, so a store read inside the
+// harness back-pressure path buys nothing and fails for a session
+// deleted one event earlier.
+type Coords struct {
+	AgentID   string // == api.Session.Key(), "workspace/name"
+	Workspace string
+	Team      string
+	Role      string
+}
+
+// Bind records what marvel knows at launch, before any harness output:
+// the harness, the model named in the launch args, and any operator
+// window override. Called at spawn so CTX% is resolvable on the FIRST
+// fold rather than after a round trip.
+type Bind struct {
+	Harness string
+	Args    []string
+	// Model is a launch-arg model, "" when absent.
+	Model string
+	// Window is a manifest override, 0 when unset.
+	Window int
+}
+
+// Sink receives computed readings. *api.Store satisfies it.
+type Sink interface {
+	UpdateSessionContext(key string, c api.SessionContext)
+}
+
+// Accountant folds adapter events into per-session context occupancy and
+// per-session/per-team spend.
+//
+// LOCKING: mu guards state, teams, and stats. It is held for map access
+// and arithmetic only, and is released before any sink write, event
+// emission, log line, or Resolver call. Every method is safe for
+// concurrent use, so a future OTEL receiver goroutine can share one
+// accountant with N per-session drain goroutines. All methods are
+// nil-receiver safe, matching the events.Emit convention, so callers need
+// no nil checks.
+type Accountant struct {
+	mu     sync.Mutex
+	state  map[string]*sessionState
+	teams  map[string]*teamState
+	warned map[string]struct{}
+	stats  Stats
+
+	sink   Sink
+	limits *Resolver
+	ev     events.Emitter
+	clock  func() time.Time
+
+	hystAbs  int
+	hystFrac float64
+}
+
+var _ Reader = (*Accountant)(nil)
+
+// Option configures an Accountant.
+type Option func(*Accountant)
+
+// WithEvents wires the control-plane ring so the accountant can report an
+// unresolved denominator.
+func WithEvents(e events.Emitter) Option {
+	return func(a *Accountant) { a.ev = e }
+}
+
+// WithClock overrides the accountant's clock.
+func WithClock(f func() time.Time) Option {
+	return func(a *Accountant) {
+		if f != nil {
+			a.clock = f
+		}
+	}
+}
+
+// WithCompactionHysteresis overrides the downward-step guard. See the
+// package constants for how the defaults were reasoned.
+func WithCompactionHysteresis(absTokens int, frac float64) Option {
+	return func(a *Accountant) {
+		a.hystAbs = absTokens
+		a.hystFrac = frac
+	}
+}
+
+// New builds an accountant writing readings through sink. A nil resolver
+// falls back to the shipped table.
+func New(sink Sink, limits *Resolver, opts ...Option) *Accountant {
+	if limits == nil {
+		limits = NewResolver(DefaultTable())
+	}
+	a := &Accountant{
+		state:    make(map[string]*sessionState),
+		teams:    make(map[string]*teamState),
+		warned:   make(map[string]struct{}),
+		sink:     sink,
+		limits:   limits,
+		clock:    func() time.Time { return time.Now().UTC() },
+		hystAbs:  defaultHysteresisTokens,
+		hystFrac: defaultHysteresisFraction,
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+// sessionState is one session's accumulation. Occupancy is a level
+// (tokens, latest-wins); spend accumulates.
+type sessionState struct {
+	agentID   string
+	workspace string
+	team      string
+	harness   string
+	profile   profile
+
+	// rawModel is the model as the harness names it, and the key into a
+	// terminal sample's per-model window declaration. primaryModel is its
+	// identity key, used to tell a routing side-request apart from the
+	// session's own series.
+	rawModel      string
+	primaryModel  string
+	args          []string
+	manifestLimit int
+
+	limit    int
+	limitSrc LimitSource
+
+	tokens      int
+	peak        float64
+	requests    int
+	compactions int
+	spend       Spend
+
+	// recIn, recCacheRead and recCacheCreation accumulate PRIMARY-model
+	// classes only, for the end-of-session reconciliation. Separate from
+	// spend because a terminal total covers the primary model alone (the
+	// fixture's result.usage excludes the routing model's 527 tokens), so
+	// comparing total spend against it would mismatch on any session that
+	// routed.
+	recIn            int
+	recCacheRead     int
+	recCacheCreation int
+
+	firstAt time.Time
+	lastAt  time.Time
+}
+
+type teamState struct {
+	retired      Spend
+	retiredCount int
+	partial      bool
+	since        time.Time
+}
+
+// foldResult is what a fold decided to do after the lock is released.
+type foldResult struct {
+	write       bool
+	reading     api.SessionContext
+	unresolved  bool
+	learnModel  string
+	learnWindow int
+	warnings    []string
+}
+
+// Bind records launch-time knowledge for a session and resolves its
+// denominator eagerly.
+func (a *Accountant) Bind(c Coords, b Bind) {
+	if a == nil {
+		return
+	}
+	prof, _ := profileFor(b.Harness)
+	limit, src, model := a.limits.Resolve(Request{
+		Harness:       b.Harness,
+		StreamModel:   b.Model,
+		RuntimeArgs:   b.Args,
+		ManifestLimit: b.Window,
+	})
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.state[c.AgentID] = &sessionState{
+		agentID:       c.AgentID,
+		workspace:     c.Workspace,
+		team:          c.Team,
+		harness:       b.Harness,
+		profile:       prof,
+		rawModel:      model,
+		primaryModel:  IdentityKey(model),
+		args:          b.Args,
+		manifestLimit: b.Window,
+		limit:         limit,
+		limitSrc:      src,
+	}
+}
+
+// Observe folds one adapter event and writes the resulting reading
+// through the sink.
+//
+// CONTRACT: called from the session manager's per-session drain
+// goroutine, which is the only consumer of a buffered channel that
+// back-pressures the harness by design. Observe must therefore do map
+// lookups plus arithmetic under its own mutex and one non-persisting
+// store write. No file I/O, no network, no blocking, no persist.
+func (a *Accountant) Observe(c Coords, ev rtevents.Event) {
+	if a == nil {
+		return
+	}
+	prof, known := profileFor(ev.Harness)
+	if !known {
+		a.mu.Lock()
+		a.stats.SamplesIgnored++
+		a.mu.Unlock()
+		return
+	}
+	if ev.Event == rtevents.KindSessionStarted {
+		a.observeStart(c, ev, prof)
+		return
+	}
+
+	res := a.fold(c, ev, prof)
+
+	for _, w := range res.warnings {
+		log.Print(w)
+	}
+	if res.learnWindow > 0 {
+		a.limits.Learn(res.learnModel, res.learnWindow)
+	}
+	if res.unresolved {
+		events.Emit(a.ev, events.Event{
+			Kind:      events.KindContextLimitUnresolved,
+			Severity:  events.SeverityWarning,
+			Workspace: c.Workspace,
+			Team:      c.Team,
+			Role:      c.Role,
+			Session:   c.AgentID,
+			Message: fmt.Sprintf("context tokens measured but no window resolved for model %q on %s; CTX%% stays blank",
+				orNone(res.reading.ContextModel), ev.Harness),
+		})
+	}
+	if res.write && a.sink != nil {
+		a.sink.UpdateSessionContext(c.AgentID, res.reading)
+	}
+}
+
+// observeStart captures the model a harness names at session start and
+// re-resolves the denominator against it. Claude is the only harness that
+// names one; codex and opencode leave the launch args as the only key.
+func (a *Accountant) observeStart(c Coords, ev rtevents.Event, prof profile) {
+	d, ok := ev.Data.(rtevents.SessionStartedData)
+	if !ok || d.Model == "" {
+		return
+	}
+
+	a.mu.Lock()
+	st := a.stateLocked(c, ev.Harness, prof)
+	args, manifest := st.args, st.manifestLimit
+	a.mu.Unlock()
+
+	limit, src, model := a.limits.Resolve(Request{
+		Harness:       ev.Harness,
+		StreamModel:   d.Model,
+		RuntimeArgs:   args,
+		ManifestLimit: manifest,
+	})
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	st = a.stateLocked(c, ev.Harness, prof)
+	st.rawModel = model
+	st.primaryModel = IdentityKey(model)
+	st.limit = limit
+	st.limitSrc = src
+}
+
+// fold is the whole arithmetic, under one critical section. Order matters:
+// terminal samples leave before any occupancy work, and a subagent turn
+// or a non-primary model leaves before the compaction detector, whose
+// input would otherwise be a 33k collapse every time a routing model or a
+// Task tool answered.
+func (a *Accountant) fold(c Coords, ev rtevents.Event, prof profile) foldResult {
+	var res foldResult
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	st := a.stateLocked(c, ev.Harness, prof)
+	s, ok := sampleFromEvent(c, ev, prof, st.rawModel)
+	if !ok {
+		a.stats.SamplesIgnored++
+		return res
+	}
+
+	if s.Terminal {
+		a.foldTerminalLocked(st, s, &res)
+		return res
+	}
+
+	// A subagent runs its own window, and its prompt is typically a small
+	// fraction of the parent's. Folding it in would drop the level for the
+	// duration of the tool call, book a compaction that did not happen,
+	// and hand a shift trigger a flapping series. Its tokens are real
+	// money, so they stay in spend, and they stay in the reconciliation
+	// accumulator too: the terminal totals appear to cover every request
+	// in the session, so excluding them there would report a permanent
+	// mismatch on any session that spawned one. UNVERIFIED, no captured
+	// fixture carries a subagent turn; ReconcileMismatches is the counter
+	// that will say so if this is wrong.
+	if s.Subagent {
+		a.stats.SubagentSamples++
+		a.addSpendLocked(st, s)
+		st.recIn += s.In
+		st.recCacheRead += s.CacheReadIn
+		st.recCacheCreation += s.CacheCreationIn
+		return res
+	}
+
+	// A session whose model was never named adopts the first model a
+	// sample reports, so codex and opencode (which name none anywhere)
+	// keep an empty primary and never route their own samples away.
+	if st.primaryModel == "" && s.Model != "" {
+		st.rawModel = s.Model
+		st.primaryModel = IdentityKey(s.Model)
+	}
+
+	if s.Model != "" && st.primaryModel != "" && IdentityKey(s.Model) != st.primaryModel {
+		a.stats.NonPrimarySamples++
+		a.addSpendLocked(st, s)
+		if a.warnOnceLocked("nonprimary:" + c.AgentID) {
+			res.warnings = append(res.warnings, fmt.Sprintf(
+				"session %s: model %q is not the session's primary %q; its tokens count toward spend but not context occupancy",
+				c.AgentID, s.Model, st.rawModel,
+			))
+		}
+		return res
+	}
+
+	if m := s.TotalMismatch(); m != 0 {
+		a.stats.TotalMismatches++
+		if a.warnOnceLocked("total:" + s.Harness) {
+			res.warnings = append(res.warnings, fmt.Sprintf(
+				"harness %s: token classes do not add up to its own total, off by %d; its usage schema changed or marvel misreads a field",
+				s.Harness, m,
+			))
+		}
+	}
+	if s.AdditiveConfirmed() {
+		a.stats.AdditiveConfirmations++
+	}
+
+	occ := s.Occupancy()
+	if st.requests > 0 {
+		if drop := st.tokens - occ; drop > a.hysteresis(st.tokens) {
+			st.compactions++
+			a.stats.CompactionsDetected++
+		}
+	}
+
+	st.tokens = occ
+	st.requests++
+	a.stats.SamplesObserved++
+	a.addSpendLocked(st, s)
+	st.recIn += s.In
+	st.recCacheRead += s.CacheReadIn
+	st.recCacheCreation += s.CacheCreationIn
+
+	now := a.clock()
+	if st.firstAt.IsZero() {
+		st.firstAt = now
+	}
+	st.lastAt = now
+
+	// A sample may itself declare the window (a future OTEL feed does;
+	// no stream feed does today).
+	if s.DeclaredLimit > 0 && st.limit != s.DeclaredLimit {
+		st.limit = s.DeclaredLimit
+		st.limitSrc = LimitFromStream
+		res.learnModel, res.learnWindow = st.rawModel, s.DeclaredLimit
+	}
+
+	if st.limit > 0 {
+		pct := 100 * float64(st.tokens) / float64(st.limit)
+		if pct > st.peak {
+			st.peak = pct
+		}
+	} else if a.warnOnceLocked("unresolved:" + c.AgentID) {
+		res.unresolved = true
+	}
+
+	res.write = true
+	res.reading = st.reading()
+	return res
+}
+
+// foldTerminalLocked handles a session-end sample. It NEVER touches the
+// occupancy level: a terminal sample carries session totals, and folding
+// them in is exactly the defect this package is built to prevent. It
+// reconciles, learns the declared window, and settles cost.
+func (a *Accountant) foldTerminalLocked(st *sessionState, s Sample, res *foldResult) {
+	if s.DeclaredLimit > 0 {
+		st.limit = s.DeclaredLimit
+		st.limitSrc = LimitFromStream
+		res.learnModel, res.learnWindow = st.rawModel, s.DeclaredLimit
+		if st.tokens > 0 {
+			if pct := 100 * float64(st.tokens) / float64(st.limit); pct > st.peak {
+				st.peak = pct
+			}
+			res.write = true
+			res.reading = st.reading()
+		}
+	}
+
+	// Claude reports one cost for the whole session and none per request;
+	// opencode reports per request and has no terminal. So a terminal cost
+	// replaces an unreported one and never doubles a reported one.
+	if s.CostUSD != nil && !st.spend.CostReported {
+		st.spend.CostUSD = *s.CostUSD
+		st.spend.CostReported = true
+	}
+
+	if st.requests == 0 {
+		return
+	}
+
+	// The invariant: accumulated per-request classes must equal the
+	// harness's own totals. Proven exact on
+	// internal/runtime/claudecode/testdata/tool_call.ndjson (11701 /
+	// 72131 / 17162 either way).
+	observed := st.recIn + st.recCacheRead + st.recCacheCreation
+	terminal := s.ClassSum()
+	switch {
+	case observed > terminal:
+		// Strictly greater is an arithmetic contradiction: more input
+		// tokens counted than the harness says the session used. It is
+		// what a cumulative series produces when read as levels.
+		a.stats.CumulationViolations++
+		res.warnings = append(res.warnings, fmt.Sprintf(
+			"session %s: accumulated %d prompt tokens against a harness total of %d; %s per-request usage is cumulative, not a level",
+			st.agentID, observed, terminal, s.Harness,
+		))
+	case observed != terminal:
+		a.stats.ReconcileMismatches++
+		res.warnings = append(res.warnings, fmt.Sprintf(
+			"session %s: accumulated %d prompt tokens against a harness total of %d; a sample was missed or double-counted",
+			st.agentID, observed, terminal,
+		))
+	}
+}
+
+func (a *Accountant) addSpendLocked(st *sessionState, s Sample) {
+	st.spend.In += s.In
+	st.spend.Out += s.Out
+	st.spend.CacheReadIn += s.CacheReadIn
+	st.spend.CacheCreationIn += s.CacheCreationIn
+	st.spend.ReasoningOut += s.ReasoningOut
+	st.spend.Requests++
+	if s.CostUSD != nil {
+		st.spend.CostUSD += *s.CostUSD
+		st.spend.CostReported = true
+	}
+	st.spend.ObservedAt = a.clock()
+}
+
+func (a *Accountant) hysteresis(tokens int) int {
+	frac := int(float64(tokens) * a.hystFrac)
+	if frac > a.hystAbs {
+		return frac
+	}
+	return a.hystAbs
+}
+
+// stateLocked returns the session's state, creating it if Bind never ran
+// (a session adopted mid-stream, or an Observe that beat its Bind).
+func (a *Accountant) stateLocked(c Coords, harness string, prof profile) *sessionState {
+	st, ok := a.state[c.AgentID]
+	if ok {
+		return st
+	}
+	st = &sessionState{
+		agentID:   c.AgentID,
+		workspace: c.Workspace,
+		team:      c.Team,
+		harness:   harness,
+		profile:   prof,
+		limitSrc:  LimitUnresolved,
+	}
+	a.state[c.AgentID] = st
+	return st
+}
+
+func (a *Accountant) warnOnceLocked(key string) bool {
+	if _, seen := a.warned[key]; seen {
+		return false
+	}
+	a.warned[key] = struct{}{}
+	return true
+}
+
+// Forget drops a session's state, rolling its spend into its team's
+// retired total so a fan-out's accounting survives the sessions that
+// produced it. Idempotent: an adopted pane never had state.
+func (a *Accountant) Forget(agentID string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.forgetLocked(agentID)
+}
+
+func (a *Accountant) forgetLocked(agentID string) {
+	st, ok := a.state[agentID]
+	if !ok {
+		return
+	}
+	delete(a.state, agentID)
+	delete(a.warned, "unresolved:"+agentID)
+	delete(a.warned, "nonprimary:"+agentID)
+
+	key := st.workspace + "/" + st.team
+	ts, ok := a.teams[key]
+	if !ok {
+		ts = &teamState{since: a.clock()}
+		a.teams[key] = ts
+	}
+	ts.retiredCount++
+	ts.retired.In += st.spend.In
+	ts.retired.Out += st.spend.Out
+	ts.retired.CacheReadIn += st.spend.CacheReadIn
+	ts.retired.CacheCreationIn += st.spend.CacheCreationIn
+	ts.retired.ReasoningOut += st.spend.ReasoningOut
+	ts.retired.CostUSD += st.spend.CostUSD
+	ts.retired.Requests += st.spend.Requests
+	if st.spend.CostReported {
+		ts.retired.CostReported = true
+	}
+	if st.requests == 0 {
+		ts.partial = true
+	}
+}
+
+// Sweep drops state for keys the store no longer has. Bounds memory
+// against a missed Forget and keeps Stats().Tracked honest as the leak
+// canary.
+func (a *Accountant) Sweep(live map[string]bool) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for key := range a.state {
+		if !live[key] {
+			a.forgetLocked(key)
+		}
+	}
+}
+
+// Stats returns a snapshot of the diagnostic counters.
+func (a *Accountant) Stats() Stats {
+	if a == nil {
+		return Stats{}
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := a.stats
+	out.Tracked = len(a.state)
+	out.SessionsUnresolved = 0
+	for _, st := range a.state {
+		if st.requests > 0 && st.limit <= 0 {
+			out.SessionsUnresolved++
+		}
+	}
+	return out
+}
+
+// SessionOccupancy returns one session's context accounting.
+func (a *Accountant) SessionOccupancy(agentID string) (Occupancy, bool) {
+	if a == nil {
+		return Occupancy{}, false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	st, ok := a.state[agentID]
+	if !ok {
+		return Occupancy{}, false
+	}
+	out := Occupancy{
+		Tokens:      st.tokens,
+		Limit:       st.limit,
+		LimitSource: st.limitSrc,
+		Model:       st.rawModel,
+		Requests:    st.requests,
+		Compactions: st.compactions,
+		Peak:        st.peak,
+		FirstAt:     st.firstAt,
+		ObservedAt:  st.lastAt,
+	}
+	if st.limit > 0 {
+		out.Percent = 100 * float64(st.tokens) / float64(st.limit)
+	}
+	return out, true
+}
+
+// SessionSpend returns one session's cumulative token and cost spend.
+func (a *Accountant) SessionSpend(agentID string) (Spend, bool) {
+	if a == nil {
+		return Spend{}, false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	st, ok := a.state[agentID]
+	if !ok {
+		return Spend{}, false
+	}
+	return st.spend, true
+}
+
+// TeamSpend sums a team's live and retired sessions.
+//
+// Retired spend is accumulated at Forget rather than summed over live
+// sessions on demand, because a fan-out's spend is mostly in sessions
+// that have already exited and the store deletes their records.
+func (a *Accountant) TeamSpend(workspace, team string) TeamTotals {
+	if a == nil {
+		return TeamTotals{}
+	}
+	key := workspace + "/" + team
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var out TeamTotals
+	if ts, ok := a.teams[key]; ok {
+		out.Spend = ts.retired
+		out.EndedSessions = ts.retiredCount
+		out.Partial = ts.partial
+		out.Since = ts.since
+	}
+	for _, st := range a.state {
+		if st.workspace != workspace || st.team != team {
+			continue
+		}
+		out.LiveSessions++
+		out.In += st.spend.In
+		out.Out += st.spend.Out
+		out.CacheReadIn += st.spend.CacheReadIn
+		out.CacheCreationIn += st.spend.CacheCreationIn
+		out.ReasoningOut += st.spend.ReasoningOut
+		out.CostUSD += st.spend.CostUSD
+		out.Requests += st.spend.Requests
+		if st.spend.CostReported {
+			out.CostReported = true
+		}
+		if st.requests == 0 {
+			out.Partial = true
+		}
+		if st.spend.ObservedAt.After(out.ObservedAt) {
+			out.ObservedAt = st.spend.ObservedAt
+		}
+	}
+	return out
+}
+
+func (st *sessionState) reading() api.SessionContext {
+	out := api.SessionContext{
+		ContextTokens:      st.tokens,
+		ContextLimit:       st.limit,
+		ContextLimitSource: string(st.limitSrc),
+		ContextModel:       st.rawModel,
+		ContextRequests:    st.requests,
+		ContextCompactions: st.compactions,
+		ContextPeak:        st.peak,
+	}
+	if st.limit > 0 {
+		out.ContextPercent = 100 * float64(st.tokens) / float64(st.limit)
+	}
+	return out
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(unnamed)"
+	}
+	return s
+}

--- a/internal/usage/accountant_test.go
+++ b/internal/usage/accountant_test.go
@@ -1,0 +1,861 @@
+package usage
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+	"github.com/arcavenae/marvel/internal/runtime/claudecode"
+	"github.com/arcavenae/marvel/internal/runtime/codex"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+	"github.com/arcavenae/marvel/internal/runtime/opencode"
+)
+
+// recordSink captures the last reading written per session key.
+type recordSink struct {
+	mu     sync.Mutex
+	last   map[string]api.SessionContext
+	writes int
+}
+
+func newRecordSink() *recordSink {
+	return &recordSink{last: make(map[string]api.SessionContext)}
+}
+
+func (r *recordSink) UpdateSessionContext(key string, c api.SessionContext) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.last[key] = c
+	r.writes++
+}
+
+func (r *recordSink) get(key string) (api.SessionContext, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	c, ok := r.last[key]
+	return c, ok
+}
+
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	return func() time.Time {
+		t = t.Add(time.Millisecond)
+		return t
+	}
+}
+
+var testCoords = Coords{AgentID: "ws/agent-0", Workspace: "ws", Team: "squad", Role: "worker"}
+
+func newTestAccountant(t *testing.T, table Table) (*Accountant, *recordSink, *events.Ring) {
+	t.Helper()
+	sink := newRecordSink()
+	ring := events.NewRing(50)
+	a := New(sink, NewResolver(table), WithEvents(ring), WithClock(fixedClock()))
+	return a, sink, ring
+}
+
+// turnEvent builds a per-request usage event for a harness.
+func turnEvent(harness string, r rtevents.RequestUsage) rtevents.Event {
+	return rtevents.Event{
+		SchemaVersion: rtevents.SchemaVersion,
+		Event:         rtevents.KindTurnCompleted,
+		Harness:       harness,
+		Data:          rtevents.TurnData{Request: &r},
+	}
+}
+
+// endedEvent builds a session-end event carrying session TOTALS. Claude
+// is hardcoded because it is the only harness that emits one: codex ends
+// at EOF after turn.completed, and opencode run mode has no session
+// lifecycle line at all.
+func endedEvent(u rtevents.Usage, m *rtevents.Metering) rtevents.Event {
+	return rtevents.Event{
+		SchemaVersion: rtevents.SchemaVersion,
+		Event:         rtevents.KindSessionEnded,
+		Harness:       claudecode.Harness,
+		Data:          rtevents.SessionEndedData{ExitCode: 0, Usage: u, Metering: m},
+	}
+}
+
+// startedEvent builds a session-start event. Claude is hardcoded for the
+// same reason, plus it is the only harness that names a model in-stream.
+func startedEvent(model string) rtevents.Event {
+	return rtevents.Event{
+		SchemaVersion: rtevents.SchemaVersion,
+		Event:         rtevents.KindSessionStarted,
+		Harness:       claudecode.Harness,
+		Data:          rtevents.SessionStartedData{Model: model},
+	}
+}
+
+func additive(in, cacheRead, cacheCreation int) rtevents.RequestUsage {
+	return rtevents.RequestUsage{
+		Layout:          rtevents.LayoutAdditive,
+		In:              in,
+		CacheReadIn:     cacheRead,
+		CacheCreationIn: cacheCreation,
+	}
+}
+
+// TestOccupancyIsALevelNotASum is the accountant half of the same guard
+// the claudecode parser test carries: three samples produce the LAST
+// occupancy, never their sum.
+func TestOccupancyIsALevelNotASum(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	for _, in := range []int{100, 200, 150} {
+		a.Observe(testCoords, turnEvent(claudecode.Harness, additive(in, 0, 0)))
+	}
+
+	occ, ok := a.SessionOccupancy(testCoords.AgentID)
+	if !ok {
+		t.Fatal("no occupancy recorded")
+	}
+	if occ.Tokens != 150 {
+		t.Errorf("tokens = %d, want 150 (the last level, not the 450 sum)", occ.Tokens)
+	}
+	if occ.Requests != 3 {
+		t.Errorf("requests = %d, want 3", occ.Requests)
+	}
+}
+
+// TestSpendAccumulatesWhileOccupancyDoesNot pins the asymmetry: the same
+// three samples that leave occupancy at a level sum into spend.
+func TestSpendAccumulatesWhileOccupancyDoesNot(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	for _, in := range []int{100, 200, 150} {
+		a.Observe(testCoords, turnEvent(claudecode.Harness, additive(in, 10, 5)))
+	}
+
+	spend, ok := a.SessionSpend(testCoords.AgentID)
+	if !ok {
+		t.Fatal("no spend recorded")
+	}
+	if spend.In != 450 {
+		t.Errorf("spend.in = %d, want 450", spend.In)
+	}
+	if spend.CacheReadIn != 30 || spend.CacheCreationIn != 15 {
+		t.Errorf("spend cache = read %d creation %d, want 30/15", spend.CacheReadIn, spend.CacheCreationIn)
+	}
+	if spend.Requests != 3 {
+		t.Errorf("spend.requests = %d, want 3", spend.Requests)
+	}
+}
+
+// TestTerminalSampleNeverEntersOccupancy is the regression guard for the
+// defect that would otherwise reappear the moment anyone routes the
+// result line through the same fold: session TOTALS are not a level.
+//
+// The numbers are the real tool_call fixture. Level after three requests
+// is 34136; the terminal totals sum to 100994.
+func TestTerminalSampleNeverEntersOccupancy(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{"claude-fable-5[1m]": 1_000_000})
+	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
+
+	for _, r := range []rtevents.RequestUsage{
+		{Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", RequestID: "a", In: 11368, CacheReadIn: 16643, CacheCreationIn: 5366},
+		{Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", RequestID: "b", In: 2, CacheReadIn: 22009, CacheCreationIn: 11470},
+		{Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", RequestID: "c", In: 331, CacheReadIn: 33479, CacheCreationIn: 326},
+	} {
+		a.Observe(testCoords, turnEvent(claudecode.Harness, r))
+	}
+
+	before, _ := a.SessionOccupancy(testCoords.AgentID)
+	if before.Tokens != 34136 {
+		t.Fatalf("tokens = %d before session end, want 34136", before.Tokens)
+	}
+
+	a.Observe(testCoords, endedEvent(
+		rtevents.Usage{In: 11701, Out: 455},
+		&rtevents.Metering{
+			CacheReadIn:     72131,
+			CacheCreationIn: 17162,
+			ModelUsage: map[string]rtevents.ModelUsage{
+				"claude-fable-5[1m]": {ContextWindow: 1_000_000},
+			},
+		},
+	))
+
+	after, _ := a.SessionOccupancy(testCoords.AgentID)
+	if after.Tokens != 34136 {
+		t.Errorf("tokens = %d after session end, want 34136 (the terminal total 100994 must not fold in)", after.Tokens)
+	}
+	if after.Peak != before.Peak {
+		t.Errorf("peak moved from %.4f to %.4f on a terminal sample", before.Peak, after.Peak)
+	}
+	if s := a.Stats(); s.CumulationViolations != 0 || s.ReconcileMismatches != 0 {
+		t.Errorf("reconciliation flagged a correct session: %+v", s)
+	}
+}
+
+// TestReconciliationSilentWhenClassesAgree uses the fixture's exact
+// numbers, which match class-wise in both directions.
+func TestReconciliationSilentWhenClassesAgree(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(11368, 16643, 5366)))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(2, 22009, 11470)))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(331, 33479, 326)))
+	a.Observe(testCoords, endedEvent(
+		rtevents.Usage{In: 11701},
+		&rtevents.Metering{CacheReadIn: 72131, CacheCreationIn: 17162},
+	))
+
+	s := a.Stats()
+	if s.ReconcileMismatches != 0 || s.CumulationViolations != 0 {
+		t.Errorf("clean reconciliation flagged: %+v", s)
+	}
+}
+
+// TestCumulationViolationDetected is the runtime detector for a
+// cumulative series read as levels. Strictly-greater is an arithmetic
+// contradiction, so no threshold is involved.
+func TestCumulationViolationDetected(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	// A cumulative series: each sample is the running total.
+	for _, in := range []int{100, 200, 300} {
+		a.Observe(testCoords, turnEvent(claudecode.Harness, additive(in, 0, 0)))
+	}
+	// The harness says the whole session used 300.
+	a.Observe(testCoords, endedEvent(rtevents.Usage{In: 300}, &rtevents.Metering{NumTurns: 3}))
+
+	s := a.Stats()
+	if s.CumulationViolations != 1 {
+		t.Errorf("cumulation violations = %d, want 1 (accumulated 600 against a 300 total)", s.CumulationViolations)
+	}
+	if s.ReconcileMismatches != 0 {
+		t.Errorf("a cumulation violation must not double-count as a reconcile mismatch: %+v", s)
+	}
+}
+
+// TestReconcileMismatchOnMissedSample is the other side: accumulating
+// LESS than the harness reports means a sample was missed, not that the
+// cumulation is wrong.
+func TestReconcileMismatchOnMissedSample(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(100, 0, 0)))
+	a.Observe(testCoords, endedEvent(rtevents.Usage{In: 350}, &rtevents.Metering{NumTurns: 2}))
+
+	s := a.Stats()
+	if s.ReconcileMismatches != 1 {
+		t.Errorf("reconcile mismatches = %d, want 1", s.ReconcileMismatches)
+	}
+	if s.CumulationViolations != 0 {
+		t.Errorf("cumulation violations = %d, want 0", s.CumulationViolations)
+	}
+}
+
+func TestCompactionDetectedPastHysteresis(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(167_000, 0, 0)))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(96_000, 0, 0)))
+
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Compactions != 1 {
+		t.Errorf("compactions = %d, want 1 for a 71k drop on a 167k level", occ.Compactions)
+	}
+	if occ.Tokens != 96_000 {
+		t.Errorf("tokens = %d, want 96000", occ.Tokens)
+	}
+	if s := a.Stats(); s.CompactionsDetected != 1 {
+		t.Errorf("stats compactions = %d, want 1", s.CompactionsDetected)
+	}
+}
+
+func TestCompactionNotDetectedWithinHysteresis(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	// A 1000-token dip on a 100k level: under both the absolute floor
+	// (2048) and the fractional band (10k).
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(100_000, 0, 0)))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(99_000, 0, 0)))
+
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Compactions != 0 {
+		t.Errorf("compactions = %d, want 0 for a 1k dip", occ.Compactions)
+	}
+	if occ.Tokens != 99_000 {
+		t.Errorf("tokens = %d, want 99000 (the level still follows the sample)", occ.Tokens)
+	}
+}
+
+// TestNonPrimaryModelRoutedToSpendOnly is the guard for the routing
+// side-request: the tool_call fixture proves one Claude session can touch
+// two models whose windows differ 5x, and a 527-token side call would read
+// as a 33k collapse to any downward-step detector.
+func TestNonPrimaryModelRoutedToSpendOnly(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{"claude-fable-5[1m]": 1_000_000})
+	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
+
+	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 11368, CacheReadIn: 16643, CacheCreationIn: 5366,
+	}))
+	// The routing model answers with a tiny prompt.
+	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, Model: "claude-haiku-4-5-20251001", In: 527,
+	}))
+
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Tokens != 33377 {
+		t.Errorf("tokens = %d, want 33377 (the side request must not move the series)", occ.Tokens)
+	}
+	if occ.Compactions != 0 {
+		t.Errorf("compactions = %d, want 0", occ.Compactions)
+	}
+	if occ.Requests != 1 {
+		t.Errorf("requests = %d, want 1 (the side request is not part of the series)", occ.Requests)
+	}
+	// It still costs tokens, so it still counts as spend.
+	spend, _ := a.SessionSpend(testCoords.AgentID)
+	if spend.In != 11368+527 {
+		t.Errorf("spend.in = %d, want %d", spend.In, 11368+527)
+	}
+	if s := a.Stats(); s.NonPrimarySamples != 1 {
+		t.Errorf("non-primary samples = %d, want 1", s.NonPrimarySamples)
+	}
+	// The denominator stays the primary model's window for the session's
+	// life; no switching, no averaging.
+	if occ.Limit != 1_000_000 {
+		t.Errorf("limit = %d, want 1000000 (the primary model's window)", occ.Limit)
+	}
+}
+
+// A harness that names no model anywhere (codex, opencode) must not have
+// every one of its own samples read as a model switch.
+func TestUnnamedModelDoesNotRouteAsNonPrimary(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	for _, in := range []int{13992, 28110} {
+		a.Observe(testCoords, turnEvent(codex.Harness, rtevents.RequestUsage{
+			Layout: rtevents.LayoutSubsumptive, In: in, CacheReadIn: in / 2,
+		}))
+	}
+
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Requests != 2 {
+		t.Errorf("requests = %d, want 2", occ.Requests)
+	}
+	// Subsumptive: the cache class is inside In, so occupancy is In alone.
+	if occ.Tokens != 28110 {
+		t.Errorf("tokens = %d, want 28110 (In alone under the subsumptive layout)", occ.Tokens)
+	}
+	if s := a.Stats(); s.NonPrimarySamples != 0 {
+		t.Errorf("non-primary samples = %d, want 0", s.NonPrimarySamples)
+	}
+}
+
+// TestTotalMismatchCounted: the total invariant catches a harness whose
+// classes stop adding up to its own published total, which is a usage
+// schema change, and still produces the reading.
+func TestTotalMismatchCounted(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	// opencode's total is defined over in + out + reasoning; 29257 is not.
+	a.Observe(testCoords, turnEvent(opencode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive,
+		In:     40, Out: 12, ReasoningOut: 5,
+		CacheReadIn: 29000, CacheCreationIn: 200,
+		Total: 29257, TotalExcludesCache: true,
+	}))
+
+	if s := a.Stats(); s.TotalMismatches != 1 {
+		t.Errorf("total mismatches = %d, want 1", s.TotalMismatches)
+	}
+	// The reading is still produced: a suspect number beats no number, and
+	// the counter plus the log line say it is suspect.
+	if _, ok := a.SessionOccupancy(testCoords.AgentID); !ok {
+		t.Error("no reading produced for a mismatched sample")
+	}
+}
+
+// TestOpenCodeMeasuredTotalIsSilent is the false-positive guard. OpenCode's
+// total omits the cache classes by the vendor's own definition
+// (finding-007), so a caching turn must not report a mismatch. It would
+// otherwise fire on every caching session and say nothing about the one
+// premise it was reached for.
+func TestOpenCodeMeasuredTotalIsSilent(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(opencode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive,
+		In:     40, Out: 12, ReasoningOut: 5,
+		CacheReadIn: 29000, CacheCreationIn: 200,
+		Total: 57, TotalExcludesCache: true,
+	}))
+
+	s := a.Stats()
+	if s.TotalMismatches != 0 {
+		t.Errorf("total mismatches = %d, want 0 for opencode's measured total definition", s.TotalMismatches)
+	}
+	// The one signal that does bear on the cache layout: In cannot contain
+	// a cache read larger than itself.
+	if s.AdditiveConfirmations != 1 {
+		t.Errorf("additive confirmations = %d, want 1", s.AdditiveConfirmations)
+	}
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Tokens != 29240 {
+		t.Errorf("tokens = %d, want 29240 (in + cache read + cache write)", occ.Tokens)
+	}
+}
+
+// The confirmation is one-sided: a subsumptive In is always the larger
+// number, so nothing in the stream can flag the case marvel would get
+// wrong. Pins the claim so nobody reads a zero counter as a clean bill.
+func TestSubsumptiveShapeIsNotConfirmed(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(opencode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive,
+		In:     29240, Out: 12, ReasoningOut: 5,
+		CacheReadIn: 29000, CacheCreationIn: 200,
+		Total: 29257, TotalExcludesCache: true,
+	}))
+
+	s := a.Stats()
+	if s.AdditiveConfirmations != 0 {
+		t.Errorf("additive confirmations = %d, want 0 for a subsumptive shape", s.AdditiveConfirmations)
+	}
+	if s.TotalMismatches != 0 {
+		t.Errorf("total mismatches = %d, want 0: the total is well-formed either way", s.TotalMismatches)
+	}
+}
+
+// A Claude subagent turn (Task tool) carries a much smaller prompt against
+// its own window. It must not touch the parent's occupancy level, must not
+// book a compaction, and must still be paid for.
+func TestSubagentTurnStaysOutOfOccupancy(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{"claude-fable-5": 1_000_000})
+
+	main := func(in, cacheRead int) rtevents.RequestUsage {
+		return rtevents.RequestUsage{
+			Model: "claude-fable-5", Layout: rtevents.LayoutAdditive,
+			In: in, Out: 3, CacheReadIn: cacheRead,
+		}
+	}
+	a.Observe(testCoords, turnEvent(claudecode.Harness, main(331, 33479)))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Model: "claude-fable-5", Layout: rtevents.LayoutAdditive,
+		In: 900, Out: 40, CacheReadIn: 1200,
+		ParentToolUseID: "toolu_sub",
+	}))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, main(400, 34200)))
+
+	occ, ok := a.SessionOccupancy(testCoords.AgentID)
+	if !ok {
+		t.Fatal("no occupancy for the session")
+	}
+	if occ.Tokens != 34600 {
+		t.Errorf("tokens = %d, want 34600 (the last MAIN-agent level)", occ.Tokens)
+	}
+	if occ.Requests != 2 {
+		t.Errorf("requests = %d, want 2 (the subagent turn is not a session request)", occ.Requests)
+	}
+	if occ.Compactions != 0 {
+		t.Errorf("compactions = %d, want 0; the subagent's smaller prompt is not a compaction", occ.Compactions)
+	}
+
+	s := a.Stats()
+	if s.SubagentSamples != 1 {
+		t.Errorf("subagent samples = %d, want 1", s.SubagentSamples)
+	}
+	if s.CompactionsDetected != 0 {
+		t.Errorf("compactions detected = %d, want 0", s.CompactionsDetected)
+	}
+	// Real tokens, real money: spend keeps them.
+	spend, _ := a.SessionSpend(testCoords.AgentID)
+	if spend.In != 331+900+400 {
+		t.Errorf("spend in = %d, want %d (the subagent's prompt is still billed)", spend.In, 331+900+400)
+	}
+	if spend.Requests != 3 {
+		t.Errorf("spend requests = %d, want 3", spend.Requests)
+	}
+}
+
+// TestUnresolvedLimitReportsAbsence: tokens are recorded, the percentage
+// is not invented, and the operator gets one event saying why.
+func TestUnresolvedLimitReportsAbsence(t *testing.T) {
+	t.Parallel()
+	a, sink, ring := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent(codex.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutSubsumptive, In: 13992,
+	}))
+	a.Observe(testCoords, turnEvent(codex.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutSubsumptive, In: 28110,
+	}))
+
+	got, ok := sink.get(testCoords.AgentID)
+	if !ok {
+		t.Fatal("no reading written")
+	}
+	if got.ContextTokens != 28110 {
+		t.Errorf("tokens = %d, want 28110", got.ContextTokens)
+	}
+	if got.ContextLimit != 0 {
+		t.Errorf("limit = %d, want 0", got.ContextLimit)
+	}
+	if got.ContextPercent != 0 {
+		t.Errorf("percent = %v, want 0 (never invented from a guessed window)", got.ContextPercent)
+	}
+	if got.ContextLimitSource != string(LimitUnresolved) {
+		t.Errorf("limit source = %q, want %q", got.ContextLimitSource, LimitUnresolved)
+	}
+
+	snap := ring.Snapshot(events.Filter{Kind: events.KindContextLimitUnresolved}, 0)
+	if len(snap) != 1 {
+		t.Fatalf("got %d context.limit-unresolved events, want exactly 1 per session", len(snap))
+	}
+	if snap[0].Session != testCoords.AgentID {
+		t.Errorf("event session = %q, want %q", snap[0].Session, testCoords.AgentID)
+	}
+	if s := a.Stats(); s.SessionsUnresolved != 1 {
+		t.Errorf("sessions unresolved = %d, want 1", s.SessionsUnresolved)
+	}
+}
+
+func TestUnknownHarnessIgnored(t *testing.T) {
+	t.Parallel()
+	a, sink, _ := newTestAccountant(t, Table{})
+
+	a.Observe(testCoords, turnEvent("crush", additive(1000, 0, 0)))
+
+	if _, ok := sink.get(testCoords.AgentID); ok {
+		t.Error("an unknown harness produced a reading; a blank column is the intended behavior")
+	}
+	if s := a.Stats(); s.SamplesIgnored != 1 {
+		t.Errorf("samples ignored = %d, want 1", s.SamplesIgnored)
+	}
+}
+
+func TestEventsWithoutUsageIgnored(t *testing.T) {
+	t.Parallel()
+	a, sink, _ := newTestAccountant(t, Table{})
+
+	// A turn event from a harness that does not attribute usage.
+	a.Observe(testCoords, rtevents.Event{
+		Event: rtevents.KindTurnCompleted, Harness: claudecode.Harness,
+		Data: rtevents.TurnData{},
+	})
+	a.Observe(testCoords, rtevents.Event{
+		Event: rtevents.KindToolCall, Harness: claudecode.Harness,
+		Data: rtevents.ToolCallData{Tool: "Bash"},
+	})
+
+	if _, ok := sink.get(testCoords.AgentID); ok {
+		t.Error("an event with no usage produced a reading")
+	}
+	if s := a.Stats(); s.SamplesIgnored != 2 {
+		t.Errorf("samples ignored = %d, want 2", s.SamplesIgnored)
+	}
+}
+
+func TestBindResolvesDenominatorBeforeFirstSample(t *testing.T) {
+	t.Parallel()
+	a, sink, _ := newTestAccountant(t, Table{})
+
+	a.Bind(testCoords, Bind{Harness: codex.Harness, Args: []string{"-m", "gpt-x"}, Window: 258_400})
+	a.Observe(testCoords, turnEvent(codex.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutSubsumptive, In: 25_840,
+	}))
+
+	got, ok := sink.get(testCoords.AgentID)
+	if !ok {
+		t.Fatal("no reading written")
+	}
+	if got.ContextLimit != 258_400 {
+		t.Errorf("limit = %d, want 258400 on the FIRST fold", got.ContextLimit)
+	}
+	if got.ContextLimitSource != string(LimitFromManifest) {
+		t.Errorf("limit source = %q, want %q", got.ContextLimitSource, LimitFromManifest)
+	}
+	if got.ContextPercent < 9.9 || got.ContextPercent > 10.1 {
+		t.Errorf("percent = %v, want about 10", got.ContextPercent)
+	}
+	if got.ContextModel != "gpt-x" {
+		t.Errorf("model = %q, want gpt-x (read from the launch args)", got.ContextModel)
+	}
+}
+
+// TestSessionStartUpgradesDenominator: Claude names its model in-stream,
+// which outranks whatever the launch args said.
+func TestSessionStartUpgradesDenominator(t *testing.T) {
+	t.Parallel()
+	a, sink, _ := newTestAccountant(t, Table{
+		"claude-haiku-4-5":   200_000,
+		"claude-fable-5[1m]": 1_000_000,
+	})
+
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Args: []string{"--model", "haiku"}})
+	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 100_000,
+	}))
+
+	got, _ := sink.get(testCoords.AgentID)
+	if got.ContextLimit != 1_000_000 {
+		t.Errorf("limit = %d, want 1000000 from the in-stream model", got.ContextLimit)
+	}
+	if got.ContextLimitSource != string(LimitFromTable) {
+		t.Errorf("limit source = %q, want %q", got.ContextLimitSource, LimitFromTable)
+	}
+}
+
+// The [1m] suffix has to survive the whole path, not just the resolver: a
+// session started on the 200k sibling must not read against the 1M window.
+// The per-request model drops the suffix in both cases, so the identity
+// check and the denominator lookup cannot share a key.
+func TestSiblingWindowsDoNotCollideAtSessionStart(t *testing.T) {
+	t.Parallel()
+	table := Table{"claude-sonnet-4-6": 200_000, "claude-sonnet-4-6[1m]": 1_000_000}
+
+	for _, c := range []struct {
+		start string
+		want  int
+	}{
+		{"claude-sonnet-4-6", 200_000},
+		{"claude-sonnet-4-6[1m]", 1_000_000},
+	} {
+		a, sink, _ := newTestAccountant(t, table)
+		a.Observe(testCoords, startedEvent(c.start))
+		a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+			Layout: rtevents.LayoutAdditive, Model: "claude-sonnet-4-6", In: 100_000,
+		}))
+
+		got, ok := sink.get(testCoords.AgentID)
+		if !ok {
+			t.Fatalf("%s: no reading written", c.start)
+		}
+		if got.ContextLimit != c.want {
+			t.Errorf("%s: limit = %d, want %d", c.start, got.ContextLimit, c.want)
+		}
+		if got.ContextRequests != 1 {
+			t.Errorf("%s: requests = %d, want 1; the unsuffixed per-request model is the same series", c.start, got.ContextRequests)
+		}
+	}
+}
+
+// TestTerminalDeclarationLearnsWindow: Claude declares its window only on
+// the terminal line, so the value it teaches is what serves the NEXT
+// session live. This is how the empty codex and opencode table sections
+// fill themselves from real sessions.
+func TestTerminalDeclarationLearnsWindow(t *testing.T) {
+	t.Parallel()
+	sink := newRecordSink()
+	res := NewResolver(Table{})
+	a := New(sink, res, WithClock(fixedClock()))
+
+	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
+	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 34_136,
+	}))
+	// Before the declaration the window is unknown.
+	if got, _ := sink.get(testCoords.AgentID); got.ContextLimit != 0 {
+		t.Fatalf("limit = %d before any declaration, want 0", got.ContextLimit)
+	}
+
+	a.Observe(testCoords, endedEvent(
+		rtevents.Usage{In: 34_136},
+		&rtevents.Metering{ModelUsage: map[string]rtevents.ModelUsage{
+			"claude-fable-5[1m]": {ContextWindow: 1_000_000},
+		}},
+	))
+
+	if w, ok := res.Learned("claude-fable-5[1m]"); !ok || w != 1_000_000 {
+		t.Errorf("learned window = %d (%v), want 1000000", w, ok)
+	}
+	// The [1m] suffix must survive into the cache key: it changes the
+	// window 5x, so a key that strips it collapses two models into one.
+	if _, ok := res.Learned("claude-fable-5"); ok {
+		t.Error("the learned key dropped the [1m] suffix, which changes the window 5x")
+	}
+
+	// A second session on the same daemon resolves live.
+	next := Coords{AgentID: "ws/agent-1", Workspace: "ws", Team: "squad", Role: "worker"}
+	a.Observe(next, startedEvent("claude-fable-5[1m]"))
+	a.Observe(next, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 50_000,
+	}))
+	got, ok := sink.get(next.AgentID)
+	if !ok {
+		t.Fatal("no reading for the second session")
+	}
+	if got.ContextLimit != 1_000_000 {
+		t.Errorf("second session limit = %d, want 1000000", got.ContextLimit)
+	}
+	if got.ContextLimitSource != string(LimitLearned) {
+		t.Errorf("second session limit source = %q, want %q", got.ContextLimitSource, LimitLearned)
+	}
+}
+
+func TestPeakIsAHighWaterMark(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Window: 200_000})
+
+	for _, in := range []int{100_000, 160_000, 90_000} {
+		a.Observe(testCoords, turnEvent(claudecode.Harness, additive(in, 0, 0)))
+	}
+
+	occ, _ := a.SessionOccupancy(testCoords.AgentID)
+	if occ.Peak < 79.9 || occ.Peak > 80.1 {
+		t.Errorf("peak = %v, want about 80", occ.Peak)
+	}
+	if occ.Percent < 44.9 || occ.Percent > 45.1 {
+		t.Errorf("percent = %v, want about 45 (the current level, not the peak)", occ.Percent)
+	}
+}
+
+func TestForgetRollsSpendIntoTeamTotals(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+	cost := 0.42
+
+	a.Bind(testCoords, Bind{Harness: opencode.Harness})
+	a.Observe(testCoords, turnEvent(opencode.Harness, rtevents.RequestUsage{
+		Layout: rtevents.LayoutAdditive, In: 1000, Out: 20, Total: 1020, Cost: &cost,
+	}))
+
+	live := a.TeamSpend("ws", "squad")
+	if live.LiveSessions != 1 || live.In != 1000 {
+		t.Fatalf("live team totals = %+v, want 1 session with 1000 in", live)
+	}
+
+	a.Forget(testCoords.AgentID)
+
+	after := a.TeamSpend("ws", "squad")
+	if after.LiveSessions != 0 || after.EndedSessions != 1 {
+		t.Errorf("after forget: live %d ended %d, want 0/1", after.LiveSessions, after.EndedSessions)
+	}
+	if after.In != 1000 || after.Out != 20 {
+		t.Errorf("retired spend = in %d out %d, want 1000/20", after.In, after.Out)
+	}
+	if after.CostUSD != cost {
+		t.Errorf("retired cost = %v, want %v", after.CostUSD, cost)
+	}
+	if after.Partial {
+		t.Error("a fully observed session must not mark the team total partial")
+	}
+	if s := a.Stats(); s.Tracked != 0 {
+		t.Errorf("tracked = %d after forget, want 0", s.Tracked)
+	}
+}
+
+// A session that was never observed makes the team total incomplete, and
+// a consumer must be able to tell that from a small total.
+func TestNeverObservedSessionMarksTeamTotalPartial(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness})
+	a.Forget(testCoords.AgentID)
+
+	if got := a.TeamSpend("ws", "squad"); !got.Partial {
+		t.Error("a never-observed session did not mark the team total partial")
+	}
+}
+
+func TestSweepDropsVanishedSessions(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{})
+
+	for _, id := range []string{"ws/a", "ws/b", "ws/c"} {
+		a.Bind(Coords{AgentID: id, Workspace: "ws", Team: "squad"}, Bind{Harness: claudecode.Harness})
+		a.Observe(Coords{AgentID: id, Workspace: "ws", Team: "squad"},
+			turnEvent(claudecode.Harness, additive(100, 0, 0)))
+	}
+	if s := a.Stats(); s.Tracked != 3 {
+		t.Fatalf("tracked = %d, want 3", s.Tracked)
+	}
+
+	a.Sweep(map[string]bool{"ws/b": true})
+
+	s := a.Stats()
+	if s.Tracked != 1 {
+		t.Errorf("tracked = %d after sweep, want 1 (the leak canary)", s.Tracked)
+	}
+	if _, ok := a.SessionOccupancy("ws/a"); ok {
+		t.Error("ws/a survived the sweep")
+	}
+	if _, ok := a.SessionOccupancy("ws/b"); !ok {
+		t.Error("ws/b was swept despite being live")
+	}
+	// Swept sessions still contribute their spend to the team: the total
+	// is the two retired plus the one still live.
+	got := a.TeamSpend("ws", "squad")
+	if got.EndedSessions != 2 || got.LiveSessions != 1 {
+		t.Errorf("team totals = %d ended %d live, want 2/1", got.EndedSessions, got.LiveSessions)
+	}
+	if got.In != 300 {
+		t.Errorf("team spend.in = %d, want 300 (two retired plus one live)", got.In)
+	}
+}
+
+func TestNilAccountantIsSafe(t *testing.T) {
+	t.Parallel()
+	var a *Accountant
+
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness})
+	a.Observe(testCoords, turnEvent(claudecode.Harness, additive(1, 2, 3)))
+	a.Forget(testCoords.AgentID)
+	a.Sweep(map[string]bool{})
+	if s := a.Stats(); s.Tracked != 0 {
+		t.Errorf("nil accountant stats = %+v, want zero", s)
+	}
+	if _, ok := a.SessionOccupancy("x"); ok {
+		t.Error("nil accountant reported an occupancy")
+	}
+	if _, ok := a.SessionSpend("x"); ok {
+		t.Error("nil accountant reported a spend")
+	}
+	if got := a.TeamSpend("ws", "squad"); got.LiveSessions != 0 {
+		t.Errorf("nil accountant team totals = %+v, want zero", got)
+	}
+}
+
+// The accountant is shared by N per-session drain goroutines, and will be
+// shared with an OTEL receiver goroutine later. Run under -race.
+func TestConcurrentObserveIsSafe(t *testing.T) {
+	t.Parallel()
+	a, _, _ := newTestAccountant(t, Table{"claude-fable-5[1m]": 1_000_000})
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		c := Coords{AgentID: "ws/agent-" + string(rune('a'+i)), Workspace: "ws", Team: "squad", Role: "worker"}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.Bind(c, Bind{Harness: claudecode.Harness, Window: 200_000})
+			for n := range 50 {
+				a.Observe(c, turnEvent(claudecode.Harness, additive(1000+n*10, 0, 0)))
+			}
+			_, _ = a.SessionOccupancy(c.AgentID)
+			_ = a.TeamSpend("ws", "squad")
+			a.Forget(c.AgentID)
+		}()
+	}
+	wg.Wait()
+
+	if got := a.TeamSpend("ws", "squad"); got.EndedSessions != 8 {
+		t.Errorf("ended sessions = %d, want 8", got.EndedSessions)
+	}
+}

--- a/internal/usage/doc.go
+++ b/internal/usage/doc.go
@@ -1,0 +1,89 @@
+// Package usage is marvel's context-window and token accountant: the
+// single producer of the CTX% column for sessions whose harness marvel
+// can observe.
+//
+// # Occupancy is a level, not a sum
+//
+// Occupancy is the token count the model must re-read on the next API
+// request: the whole prompt, including everything served from the prompt
+// cache. It is a LEVEL, taken per API request, latest-wins. It is never a
+// sum over requests.
+//
+// This is the correction the accountant exists to encode. Claude Code's
+// terminal `result` line reports session-CUMULATIVE totals, not the final
+// request's level. Measured on
+// internal/runtime/claudecode/testdata/tool_call.ndjson: the three
+// per-request occupancies are 33377, 33481, and 34136, while the result
+// line's classes sum to 100994. A numerator taken from the result line
+// therefore reads 10.1% against a 1M window where the truth is 3.4%, and
+// the error grows linearly with request count, so the longest sessions
+// are the most wrong. Sample.Terminal marks such a sample and the fold
+// excludes it structurally; Stats.CumulationViolations counts any
+// accumulation that exceeds a terminal total, which is the arithmetic
+// signature of a cumulative series read as levels.
+//
+// Per harness, occupancy is composed differently, and the composition
+// rides the event payload as events.Layout rather than living in a
+// lookup table here. Call events.RequestUsage.Occupancy(); never sum the
+// classes by hand.
+//
+// Two kinds of request are billed but kept out of the level, because they
+// do not fill the session's window: a request to a model other than the
+// session's primary (a routing side-call), and a subagent request made
+// inside a tool call, which fills a window of its own. Either one folded
+// in would collapse the level and register as a compaction on the way in
+// and out. Stats counts both.
+//
+// # The denominator is reported absent, never defaulted
+//
+// LimitSource grades every reading. When no rung of the resolution
+// ladder produces a window, Occupancy.Limit is 0 and Occupancy.Percent
+// is meaningless. Rendering a plausible percentage against a guessed
+// window is worse than rendering absence: a wrong denominator misreports
+// silently, and an admission gate that reads unresolved as 0% admits
+// everything. There is deliberately no fleet-wide default-window knob.
+//
+// # Raw occupancy, not the harness's displayed figure
+//
+// The reported percentage is raw occupancy against the model's context
+// window. What Claude Code DISPLAYS is a different quantity: percent
+// until auto-compaction, normalized to an operator-tunable threshold
+// plus a reserved buffer of roughly 33-45k tokens. Neither the threshold
+// override nor the effective-window override appears in the stream, so
+// marvel cannot reproduce the displayed number and does not try. An
+// operator can legitimately see "10% until auto-compact" inside the
+// harness while marvel reports about 64%. Both are correct about
+// different things.
+//
+// # Scope
+//
+// Headless only. All three stream-capable adapters gate stream support
+// on api.RuntimeModeHeadless, so an interactive session produces no
+// adapter events and its CTX% stays absent. That gap is tracked
+// separately (question-interactive-context-pressure); native harness
+// OTEL is the first plausible path to it.
+//
+// Crush and Gemini CLI are out of scope: Crush publishes no structured
+// stream (its token counts live only in a per-repo sqlite database) and
+// Gemini was not available to measure.
+//
+// # Feed-agnostic by construction
+//
+// The arithmetic lives in Sample and in Accountant.fold. A feed's only
+// job is to build Sample values. sampleFromEvent is the stream feed's
+// normalization boundary; an OTEL feed adds a sibling constructor and
+// one caller, and changes nothing in the fold. Field names differ across
+// feeds for identical quantities (the stream says
+// cache_read_input_tokens where Claude's OTEL says cache_read_tokens),
+// which is precisely why the boundary is one function.
+//
+// # Measurement provenance
+//
+// Every number in this package's tables and comments was measured on
+// macOS arm64 against Claude Code 2.1.220, codex-cli 0.146.0, and
+// OpenCode 1.18.5. Per marvel B13, stream behavior can differ by
+// platform, and a harness version bump that changes a usage schema
+// changes the read. The fixtures are captured output, so such a change
+// surfaces as a parse error, a layout mismatch, or an absent column
+// rather than as a silently wrong number.
+package usage

--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -1,0 +1,322 @@
+package usage
+
+import (
+	"log"
+	"strings"
+	"sync"
+)
+
+// LimitSource records which rung of the resolution ladder produced a
+// session's context window. Graded rather than boolean so a consumer can
+// refuse on low confidence without refusing on measurement.
+type LimitSource string
+
+const (
+	// LimitUnresolved means no rung produced a window. The reading's
+	// Percent is meaningless and must be rendered as absence.
+	LimitUnresolved LimitSource = "unresolved"
+	// LimitFromStream means the harness declared the window in this
+	// session's own stream. Authoritative.
+	LimitFromStream LimitSource = "stream"
+	// LimitLearned means a prior session on this daemon declared it.
+	LimitLearned LimitSource = "learned"
+	// LimitFromManifest means an operator set runtime.context_window.
+	LimitFromManifest LimitSource = "manifest"
+	// LimitFromTable means an exact hit in the shipped model table.
+	LimitFromTable LimitSource = "table"
+	// LimitFromTableAlias means a short alias resolved to a table entry.
+	// Graded separately because an alias means whatever the harness
+	// points it at today: a guess that happens to be right is not a
+	// keyed fact.
+	LimitFromTableAlias LimitSource = "table-alias"
+)
+
+// Table maps a normalized model id to its context window in tokens.
+type Table map[string]int
+
+// DefaultTable is the shipped fallback rung of the ladder.
+//
+// It lives in Go rather than a config file for the reason
+// api.canonicalPermissionModes gives for the same shape: this is a third
+// party's fact that silently breaks a session when wrong, so it belongs
+// where it is diff-reviewable and versioned with the binary. The
+// counter-pressure (model windows move on the vendor's cadence, not
+// marvel's) is answered by the rung above it: an operator sets
+// runtime.context_window without waiting for a marvel release. The
+// learned rung helps only where a harness declares its own window, which
+// today is Claude alone (see Learn).
+func DefaultTable() Table {
+	return Table{
+		// The first two are fixture-verified in this repo (the
+		// modelUsage.contextWindow values in
+		// internal/runtime/claudecode/testdata/*.ndjson). The rest were
+		// verified 2026-07-03 against the vendor model-config docs and
+		// platform pricing (orc finding-057, node
+		// elem-autocompact-window-posture).
+		"claude-haiku-4-5":      200_000,   // fixture-verified, max output 32000
+		"claude-fable-5[1m]":    1_000_000, // fixture-verified, max output 64000
+		"claude-sonnet-4-6":     200_000,
+		"claude-sonnet-4-6[1m]": 1_000_000,
+		"claude-sonnet-5":       1_000_000, // no 200k variant on the API
+		"claude-opus-4-7":       200_000,
+		"claude-opus-4-7[1m]":   1_000_000,
+		"claude-opus-4-8":       200_000,
+		"claude-opus-4-8[1m]":   1_000_000,
+
+		// codex: DELIBERATELY EMPTY. A window of 258400 was measured on
+		// codex 0.146.0 (the rollout file's
+		// token_count.info.model_context_window), but the model NAME was
+		// not captured, because thread.started carries only thread_id.
+		// The number therefore has no key. One `codex exec --model <m>`
+		// turn, or a read of the default in the user's codex config, keys
+		// it and this section gains a line. Nothing fills it by itself:
+		// codex declares no window in its exec stream, so Learn is never
+		// reached for it (see Learn). Until then codex CTX% renders `?`
+		// unless an operator sets runtime.context_window. Shipping 258400
+		// under a guessed key would be an invisible limitation; an empty
+		// section is a visible one with a one-line fix.
+
+		// opencode: EMPTY, and equally not self-filling. No window
+		// measurement exists for any opencode model, and opencode declares
+		// none in its stream either. OpenCode carries a model database out
+		// of band, which is worth one look before this section ships
+		// non-empty.
+	}
+}
+
+// Lookup returns the window for an already-normalized model id.
+func (t Table) Lookup(model string) (int, bool) {
+	w, ok := t[model]
+	return w, ok
+}
+
+// aliases map the short forms an operator passes to --model onto table
+// keys. A hit here resolves as LimitFromTableAlias, never LimitFromTable.
+var aliases = map[string]string{
+	"haiku":     "claude-haiku-4-5",
+	"sonnet":    "claude-sonnet-4-6",
+	"opus":      "claude-opus-4-8",
+	"fable[1m]": "claude-fable-5[1m]",
+}
+
+// NormalizeModel canonicalizes a vendor model id for WINDOW lookup. Each
+// rule is required by an observed id form:
+//
+//   - KEEP a [1m] suffix. It changes the window 5x (200k against 1M), so
+//     dropping it collapses two different models onto one key. See orc
+//     finding-055 and finding-057.
+//   - STRIP a Bedrock region prefix (us., eu., apac.) and a leading
+//     "anthropic.". Pricing differs by region; the window does not.
+//   - TOLERATE a dated suffix. This repo's own fixture carries the
+//     modelUsage key claude-haiku-4-5-20251001, which must resolve as
+//     claude-haiku-4-5.
+func NormalizeModel(model string) string {
+	m := strings.TrimSpace(model)
+	for _, p := range []string{"us.", "eu.", "apac."} {
+		m = strings.TrimPrefix(m, p)
+	}
+	m = strings.TrimPrefix(m, "anthropic.")
+	return trimDateSuffix(m)
+}
+
+// trimDateSuffix drops a trailing -YYYYMMDD segment. The [1m] forms are
+// unaffected: their final segment is "5[1m]", not eight digits.
+func trimDateSuffix(m string) string {
+	i := strings.LastIndex(m, "-")
+	if i < 0 || len(m)-i-1 != 8 {
+		return m
+	}
+	for _, r := range m[i+1:] {
+		if r < '0' || r > '9' {
+			return m
+		}
+	}
+	return m[:i]
+}
+
+// IdentityKey canonicalizes for SERIES IDENTITY, which additionally
+// strips [1m]. Claude's system/init model and its modelUsage key are
+// "claude-fable-5[1m]" while per-request message.model is
+// "claude-fable-5" (both fixture-verified). The two must compare equal or
+// every request looks like a model switch and the occupancy series never
+// accumulates.
+//
+// Deliberately NOT the key for a window: see NormalizeModel.
+func IdentityKey(model string) string {
+	return strings.TrimSuffix(NormalizeModel(model), "[1m]")
+}
+
+// ModelFromArgs extracts a model id from launch args, for harnesses that
+// name none in-stream. Marvel injects no model flag, so this reads what
+// the operator wrote. Returns "" when absent, which resolves to
+// LimitUnresolved and never to a default.
+func ModelFromArgs(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "-m" || a == "--model":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(a, "--model="):
+			return strings.TrimPrefix(a, "--model=")
+		case strings.HasPrefix(a, "-m="):
+			return strings.TrimPrefix(a, "-m=")
+		}
+	}
+	return ""
+}
+
+// Request is one denominator resolution.
+type Request struct {
+	Harness string
+	// StreamModel is the model the harness named in-stream, "" when it
+	// named none.
+	StreamModel string
+	// RuntimeArgs is the role's launch args, searched for a model flag
+	// when StreamModel is empty.
+	RuntimeArgs []string
+	// ManifestLimit is runtime.context_window, 0 when unset.
+	ManifestLimit int
+	// SampleLimit is a window declared by the feed alongside the sample,
+	// 0 when the feed carried none.
+	SampleLimit int
+}
+
+// Resolver walks the denominator ladder and caches windows a harness has
+// declared. Safe for concurrent use.
+type Resolver struct {
+	mu      sync.RWMutex
+	table   Table
+	learned map[string]int
+	warned  map[string]struct{}
+}
+
+// NewResolver builds a resolver over t. A nil table falls back to
+// DefaultTable.
+func NewResolver(t Table) *Resolver {
+	if t == nil {
+		t = DefaultTable()
+	}
+	return &Resolver{
+		table:   t,
+		learned: make(map[string]int),
+		warned:  make(map[string]struct{}),
+	}
+}
+
+// Resolve walks the ladder and returns the window, the rung that
+// produced it, and the resolved model id ("" when none could be found).
+// A zero window means unresolved; callers must report absence rather than
+// substituting a default.
+//
+// Rung order puts the in-feed declaration above the operator override on
+// purpose: the harness's own belief about the window is what enforces
+// compaction, so it is ground truth for behavior. The override's job is
+// to fill absence, not to overrule measurement. A manifest value later
+// contradicted by an in-feed declaration is logged once, naming both.
+func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
+	model := req.StreamModel
+	if model == "" {
+		model = ModelFromArgs(req.RuntimeArgs)
+	}
+
+	if req.SampleLimit > 0 {
+		if req.ManifestLimit > 0 && req.ManifestLimit != req.SampleLimit {
+			r.warnOnce("override:"+model, "context window: %s declared %d for %q, overriding the manifest's %d",
+				req.Harness, req.SampleLimit, model, req.ManifestLimit)
+		}
+		return req.SampleLimit, LimitFromStream, model
+	}
+
+	if model != "" {
+		r.mu.RLock()
+		w, ok := r.learned[NormalizeModel(model)]
+		r.mu.RUnlock()
+		if ok {
+			return w, LimitLearned, model
+		}
+	}
+
+	if req.ManifestLimit > 0 {
+		return req.ManifestLimit, LimitFromManifest, model
+	}
+
+	if model != "" {
+		n := NormalizeModel(model)
+		r.mu.RLock()
+		w, ok := r.table.Lookup(n)
+		var aw int
+		var aok bool
+		if !ok {
+			if canon, has := aliases[n]; has {
+				aw, aok = r.table.Lookup(canon)
+			}
+		}
+		r.mu.RUnlock()
+		if ok {
+			return w, LimitFromTable, model
+		}
+		if aok {
+			return aw, LimitFromTableAlias, model
+		}
+	}
+
+	return 0, LimitUnresolved, model
+}
+
+// Learn records a window a harness declared, keyed on NormalizeModel so
+// the [1m] suffix survives (see NormalizeModel). This is how the
+// authoritative rung becomes available DURING a later session for a
+// harness that only declares its window at the end, which is Claude's
+// shape: contextWindow rides the terminal result line.
+//
+// SCOPE: reached only for a feed that declares a window, so today only
+// Claude ever calls it. Codex and opencode declare none anywhere in their
+// streams, so their empty table sections do not fill themselves; they need
+// a keyed measurement in DefaultTable or runtime.context_window per role.
+// A codex OTEL feed (conversation_starts carries the model) is the first
+// plausible route to changing that.
+//
+// A declaration that contradicts the shipped table logs once per model:
+// that is the drift detector for a vendor window change.
+func (r *Resolver) Learn(model string, window int) {
+	if model == "" || window <= 0 {
+		return
+	}
+	key := NormalizeModel(model)
+
+	r.mu.Lock()
+	prev, had := r.learned[key]
+	r.learned[key] = window
+	shipped, inTable := r.table.Lookup(key)
+	r.mu.Unlock()
+
+	if inTable && shipped != window {
+		r.warnOnce("drift:"+key, "context window: harness declares %d for %q; the shipped table says %d, so the table is stale",
+			window, key, shipped)
+	}
+	if had && prev != window {
+		r.warnOnce("changed:"+key, "context window for %q changed from %d to %d", key, prev, window)
+	}
+}
+
+// Learned reports the cached window for a model, for tests and
+// diagnostics.
+func (r *Resolver) Learned(model string) (int, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	w, ok := r.learned[NormalizeModel(model)]
+	return w, ok
+}
+
+func (r *Resolver) warnOnce(key, format string, args ...any) {
+	r.mu.Lock()
+	_, seen := r.warned[key]
+	if !seen {
+		r.warned[key] = struct{}{}
+	}
+	r.mu.Unlock()
+	if !seen {
+		log.Printf(format, args...)
+	}
+}

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -1,0 +1,262 @@
+package usage
+
+import "testing"
+
+func TestNormalizeModel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// The [1m] suffix changes the window 5x and must survive.
+		{"claude-fable-5[1m]", "claude-fable-5[1m]"},
+		{"claude-sonnet-4-6[1m]", "claude-sonnet-4-6[1m]"},
+		// Region prefixes change price, not window.
+		{"us.anthropic.claude-opus-4-8[1m]", "claude-opus-4-8[1m]"},
+		{"eu.anthropic.claude-haiku-4-5", "claude-haiku-4-5"},
+		{"apac.claude-sonnet-5", "claude-sonnet-5"},
+		{"anthropic.claude-haiku-4-5", "claude-haiku-4-5"},
+		// This repo's own modelUsage key carries a dated suffix.
+		{"claude-haiku-4-5-20251001", "claude-haiku-4-5"},
+		// A trailing segment that is not eight digits is part of the name.
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"gpt-5-2026", "gpt-5-2026"},
+		{"", ""},
+		{"  claude-haiku-4-5  ", "claude-haiku-4-5"},
+	}
+	for _, c := range cases {
+		if got := NormalizeModel(c.in); got != c.want {
+			t.Errorf("NormalizeModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// An unsuffixed name must MISS rather than resolving to its 1M sibling.
+func TestNormalizeModelDoesNotInventTheSuffix(t *testing.T) {
+	t.Parallel()
+	tbl := DefaultTable()
+	if _, ok := tbl.Lookup(NormalizeModel("claude-fable-5")); ok {
+		t.Error("claude-fable-5 resolved without its [1m] suffix; only the 1M variant is a table key")
+	}
+	if w, ok := tbl.Lookup(NormalizeModel("claude-fable-5[1m]")); !ok || w != 1_000_000 {
+		t.Errorf("claude-fable-5[1m] = %d (%v), want 1000000", w, ok)
+	}
+}
+
+func TestIdentityKeyCollapsesTheSuffix(t *testing.T) {
+	t.Parallel()
+	// system/init and the modelUsage key say claude-fable-5[1m];
+	// per-request message.model says claude-fable-5. The two must compare
+	// equal or every request looks like a model switch.
+	if IdentityKey("claude-fable-5[1m]") != IdentityKey("claude-fable-5") {
+		t.Error("the init model and the per-request model do not share an identity key")
+	}
+	if IdentityKey("claude-haiku-4-5-20251001") != IdentityKey("claude-haiku-4-5") {
+		t.Error("the dated modelUsage key and the plain name do not share an identity key")
+	}
+	if IdentityKey("claude-fable-5") == IdentityKey("claude-haiku-4-5") {
+		t.Error("two different models share an identity key")
+	}
+}
+
+func TestModelFromArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"short flag", []string{"-m", "opencode/deepseek-v4-flash-free"}, "opencode/deepseek-v4-flash-free"},
+		{"long flag", []string{"--model", "haiku"}, "haiku"},
+		{"long equals", []string{"--model=haiku"}, "haiku"},
+		{"short equals", []string{"-m=haiku"}, "haiku"},
+		{"among others", []string{"-s", "read-only", "--model", "gpt-x", "--json"}, "gpt-x"},
+		{"absent", []string{"--json"}, ""},
+		{"nil", nil, ""},
+		{"dangling", []string{"--json", "-m"}, ""},
+	}
+	for _, c := range cases {
+		if got := ModelFromArgs(c.args); got != c.want {
+			t.Errorf("%s: ModelFromArgs(%v) = %q, want %q", c.name, c.args, got, c.want)
+		}
+	}
+}
+
+// TestResolveLadderPrecedence walks every rung, asserting both the value
+// and the grade. The grade is load-bearing: a consumer must be able to
+// refuse on low confidence without refusing on measurement.
+func TestResolveLadderPrecedence(t *testing.T) {
+	t.Parallel()
+	table := Table{"claude-haiku-4-5": 200_000, "claude-opus-4-8": 200_000}
+
+	cases := []struct {
+		name       string
+		req        Request
+		learn      string
+		learnValue int
+		wantLimit  int
+		wantSource LimitSource
+	}{
+		{
+			// Rung 1. The harness's own belief is what enforces
+			// compaction, so it outranks the operator override; the
+			// override's job is to fill absence, not overrule measurement.
+			name:       "stream beats manifest",
+			req:        Request{StreamModel: "claude-haiku-4-5", SampleLimit: 999_999, ManifestLimit: 111_111},
+			wantLimit:  999_999,
+			wantSource: LimitFromStream,
+		},
+		{
+			name:       "learned beats manifest",
+			req:        Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
+			learn:      "claude-haiku-4-5",
+			learnValue: 222_222,
+			wantLimit:  222_222,
+			wantSource: LimitLearned,
+		},
+		{
+			name:       "manifest beats table",
+			req:        Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
+			wantLimit:  111_111,
+			wantSource: LimitFromManifest,
+		},
+		{
+			name:       "table exact hit",
+			req:        Request{StreamModel: "claude-haiku-4-5"},
+			wantLimit:  200_000,
+			wantSource: LimitFromTable,
+		},
+		{
+			name:       "table hit through a dated key",
+			req:        Request{StreamModel: "claude-haiku-4-5-20251001"},
+			wantLimit:  200_000,
+			wantSource: LimitFromTable,
+		},
+		{
+			// An alias means whatever the harness points it at today, so a
+			// hit is graded lower than a keyed fact.
+			name:       "alias is graded separately",
+			req:        Request{RuntimeArgs: []string{"--model", "haiku"}},
+			wantLimit:  200_000,
+			wantSource: LimitFromTableAlias,
+		},
+		{
+			name:       "unknown model resolves to absence, never a default",
+			req:        Request{StreamModel: "some-model-nobody-shipped"},
+			wantLimit:  0,
+			wantSource: LimitUnresolved,
+		},
+		{
+			name:       "no model at all resolves to absence",
+			req:        Request{Harness: "codex"},
+			wantLimit:  0,
+			wantSource: LimitUnresolved,
+		},
+	}
+
+	for _, c := range cases {
+		r := NewResolver(table)
+		if c.learn != "" {
+			r.Learn(c.learn, c.learnValue)
+		}
+		limit, src, _ := r.Resolve(c.req)
+		if limit != c.wantLimit {
+			t.Errorf("%s: limit = %d, want %d", c.name, limit, c.wantLimit)
+		}
+		if src != c.wantSource {
+			t.Errorf("%s: source = %q, want %q", c.name, src, c.wantSource)
+		}
+	}
+}
+
+func TestResolveReadsModelFromArgsWhenStreamNamesNone(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{"claude-haiku-4-5": 200_000})
+	limit, src, model := r.Resolve(Request{
+		Harness:     "codex",
+		RuntimeArgs: []string{"--json", "--model", "claude-haiku-4-5"},
+	})
+	if model != "claude-haiku-4-5" {
+		t.Errorf("model = %q, want claude-haiku-4-5", model)
+	}
+	if limit != 200_000 || src != LimitFromTable {
+		t.Errorf("limit = %d source = %q, want 200000/table", limit, src)
+	}
+}
+
+func TestLearnKeepsTheSuffixInItsKey(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{})
+	r.Learn("claude-sonnet-4-6[1m]", 1_000_000)
+
+	if w, ok := r.Learned("claude-sonnet-4-6[1m]"); !ok || w != 1_000_000 {
+		t.Errorf("learned[1m] = %d (%v), want 1000000", w, ok)
+	}
+	// The 200k sibling must not inherit the 1M window.
+	if _, ok := r.Learned("claude-sonnet-4-6"); ok {
+		t.Error("the 200k sibling inherited the 1M window; the learned key must keep [1m]")
+	}
+}
+
+func TestLearnIgnoresNonsense(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{})
+	r.Learn("", 200_000)
+	r.Learn("claude-haiku-4-5", 0)
+	r.Learn("claude-haiku-4-5", -1)
+	if _, ok := r.Learned("claude-haiku-4-5"); ok {
+		t.Error("a zero or negative window was cached")
+	}
+}
+
+// The codex and opencode sections are deliberately empty. A future guessed
+// entry has to delete an assertion to land, which is the point.
+func TestDefaultTableShipsNoGuessedEntries(t *testing.T) {
+	t.Parallel()
+	tbl := DefaultTable()
+	for key := range tbl {
+		if NormalizeModel(key) != key {
+			t.Errorf("table key %q is not in normalized form", key)
+		}
+		if !hasPrefix(key, "claude-") {
+			t.Errorf("table key %q is not a Claude model; codex and opencode windows are unmeasured and must stay absent", key)
+		}
+	}
+	// The measured codex window (258400) has no model name attached to it,
+	// so it must not ship under a guessed key.
+	for key, w := range tbl {
+		if w == 258_400 {
+			t.Errorf("the unkeyed codex window shipped under %q", key)
+		}
+	}
+}
+
+func hasPrefix(s, p string) bool {
+	return len(s) >= len(p) && s[:len(p)] == p
+}
+
+// Every table entry must round-trip through the resolver, so a typo in a
+// key cannot ship as a silently unresolvable model.
+func TestEveryDefaultTableEntryResolves(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(DefaultTable())
+	for key, want := range DefaultTable() {
+		limit, src, _ := r.Resolve(Request{StreamModel: key})
+		if limit != want {
+			t.Errorf("%s: limit = %d, want %d", key, limit, want)
+		}
+		if src != LimitFromTable {
+			t.Errorf("%s: source = %q, want %q", key, src, LimitFromTable)
+		}
+	}
+}
+
+func TestEveryAliasResolvesToARealEntry(t *testing.T) {
+	t.Parallel()
+	tbl := DefaultTable()
+	for alias, canon := range aliases {
+		if _, ok := tbl.Lookup(canon); !ok {
+			t.Errorf("alias %q points at %q, which is not a table key", alias, canon)
+		}
+	}
+}

--- a/internal/usage/profiles.go
+++ b/internal/usage/profiles.go
@@ -1,0 +1,77 @@
+package usage
+
+import (
+	"github.com/arcavenae/marvel/internal/runtime/claudecode"
+	"github.com/arcavenae/marvel/internal/runtime/codex"
+	"github.com/arcavenae/marvel/internal/runtime/opencode"
+)
+
+// profile carries the per-harness facts the event payload cannot. Layout
+// deliberately is NOT here: it rides events.RequestUsage so the parser
+// that knows its own harness declares it, and a consumer-side table
+// cannot drift out of sync with the fields beside it.
+type profile struct {
+	// cumulation says whether per-request samples are levels or running
+	// totals.
+	cumulation Cumulation
+	// modelFromStream is true when the harness names its model in-stream.
+	modelFromStream bool
+	// limitInStream is true when the harness declares its own window.
+	limitInStream bool
+	// limitArrivesAtEnd is true when that declaration rides the terminal
+	// line, so it cannot serve a live reading and the table (or the
+	// learned cache) is the live path even for this harness.
+	limitArrivesAtEnd bool
+	// vendorTotal is true when the harness publishes its own token
+	// total, which is what makes Sample.TotalMismatch meaningful.
+	vendorTotal bool
+}
+
+// profiles is keyed on the Harness constant each parser package stamps
+// onto its events. Imported rather than duplicated as string literals so
+// a rename in a parser breaks the build here instead of silently
+// producing an unknown harness.
+//
+// An unknown harness is ignored, not guessed: a blank CTX% column is a
+// visible limitation, a number derived from an assumed layout is not.
+var profiles = map[string]profile{
+	claudecode.Harness: {
+		cumulation:      CumulationRequest,
+		modelFromStream: true,
+		// contextWindow rides modelUsage on the terminal result line, so
+		// for Claude the in-stream declaration reconciles and teaches;
+		// it cannot serve the live reading.
+		limitInStream:     true,
+		limitArrivesAtEnd: true,
+		vendorTotal:       false,
+	},
+	codex.Harness: {
+		// UNVERIFIED against a real multi-turn capture: codex exec
+		// one-shot has a single turn, so whether input_tokens is a level
+		// or a session total across turns rests on the field layout plus
+		// the synthetic resume fixture. `codex exec resume` settles it.
+		cumulation: CumulationRequest,
+		// thread.started carries only thread_id on 0.146.0; the parser
+		// reads a model field that arrives empty, so the model comes from
+		// the launch args or nowhere.
+		modelFromStream: false,
+		limitInStream:   false,
+		vendorTotal:     false,
+	},
+	opencode.Harness: {
+		// UNVERIFIED for the same reason as codex.
+		cumulation:      CumulationRequest,
+		modelFromStream: false,
+		limitInStream:   false,
+		// step_finish publishes tokens.total, over in + out + reasoning
+		// only (measured). It checks the harness's own arithmetic, not the
+		// unverified cache layout: see Sample.TotalMismatch and
+		// Sample.AdditiveConfirmed.
+		vendorTotal: true,
+	},
+}
+
+func profileFor(harness string) (profile, bool) {
+	p, ok := profiles[harness]
+	return p, ok
+}

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -1,0 +1,86 @@
+package usage
+
+import "time"
+
+// Occupancy is one session's context accounting.
+//
+// Limit == 0 means the denominator is unresolved and Percent is
+// meaningless. The tri-state exists so a consumer cannot read "no
+// denominator" as "0% used": orc finding-055 is the recorded instance of
+// a wrong denominator badly misreporting, and an admission gate that
+// reads unresolved as 0% admits everything.
+type Occupancy struct {
+	Tokens      int
+	Limit       int
+	Percent     float64
+	LimitSource LimitSource
+	Model       string
+	Requests    int
+	Compactions int
+	// Peak is the high-water Percent, valid only when Limit > 0.
+	Peak    float64
+	FirstAt time.Time
+	// ObservedAt is zero when the session was never observed.
+	ObservedAt time.Time
+}
+
+// Spend accumulates. Unlike Occupancy it IS additive across requests.
+type Spend struct {
+	In              int
+	Out             int
+	CacheReadIn     int
+	CacheCreationIn int
+	ReasoningOut    int
+	CostUSD         float64
+	// CostReported is false when the harness reports no cost at all
+	// (codex publishes none in its exec stream), which is distinct from
+	// reporting zero.
+	CostReported bool
+	Requests     int
+	ObservedAt   time.Time
+}
+
+// TeamTotals is a team's accumulated spend, including sessions that have
+// already exited.
+type TeamTotals struct {
+	Spend
+	LiveSessions  int
+	EndedSessions int
+	Since         time.Time
+	// Partial is true when any contributing session was never observed
+	// (an interactive launch, a pane adopted from a prior daemon, an
+	// unknown harness). A consumer refusing work against a budget must be
+	// able to tell an incomplete total from a small one.
+	Partial bool
+}
+
+// Reader is the read-only surface downstream consumers hold: admission
+// control (refuse an over-budget spawn) and automatic shift triggers
+// (rotate on context pressure). An interface so both can be tested
+// against a fake with no Accountant.
+//
+// The accountant is a METER. It defines no threshold, no policy, and no
+// refusal; a metered value becomes a gate only through a ratified written
+// decision (ADR-007 clause 3, SOUL.md section 8).
+type Reader interface {
+	SessionOccupancy(agentID string) (Occupancy, bool)
+	SessionSpend(agentID string) (Spend, bool)
+	TeamSpend(workspace, team string) TeamTotals
+}
+
+// Baseline is the per-role history an admission check needs to price
+// "what will K more of these cost".
+//
+// NOT IMPLEMENTED IN THIS SLICE. It is declared as the contract the
+// admission-control work extends this package with, because the median
+// machinery needs a retention and eviction policy this slice has no
+// basis to choose. The Samples rule is the load-bearing part and must
+// survive into that implementation: Samples == 0 means there is no
+// history, and callers must not fabricate an estimate from nothing.
+type Baseline struct {
+	MedianRequestTokens  int
+	MedianSessionTokens  int
+	MedianSessionCostUSD float64
+	MedianPeakPercent    float64
+	Samples              int
+}

--- a/internal/usage/sample.go
+++ b/internal/usage/sample.go
@@ -1,0 +1,159 @@
+package usage
+
+import (
+	"time"
+
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// Cumulation says whether a sample carries one request's own level or a
+// running total over the session. Declared per feed and asserted at
+// runtime, never inferred: getting it wrong is the measured failure this
+// package exists to prevent (see doc.go).
+type Cumulation string
+
+const (
+	CumulationRequest Cumulation = "request"
+	CumulationSession Cumulation = "session"
+)
+
+// Sample is one normalized observation. Feed-agnostic: the stream feed
+// and a future OTEL feed produce this identical shape, so the fold is
+// written once.
+type Sample struct {
+	AgentID          string
+	HarnessSessionID string
+	Harness          string
+	// Model is the model as the feed reported it, empty when the feed
+	// names none (codex and opencode name none in-stream).
+	Model     string
+	RequestID string
+	TS        time.Time
+
+	Layout     rtevents.Layout
+	Cumulation Cumulation
+
+	In              int
+	Out             int
+	CacheReadIn     int
+	CacheCreationIn int
+	ReasoningOut    int
+	Total           int
+	// TotalExcludesCache says Total is defined over In + Out +
+	// ReasoningOut alone. See events.RequestUsage.
+	TotalExcludesCache bool
+	CostUSD            *float64
+
+	// Subagent marks a request made inside a tool call (Claude's Task
+	// tool). Its tokens are real spend against a DIFFERENT context
+	// window, so it must not enter the occupancy fold.
+	Subagent bool
+
+	// DeclaredLimit is the context window the feed declared alongside
+	// this sample, 0 when it declared none.
+	DeclaredLimit int
+	// Terminal marks a session-end sample. Such a sample carries session
+	// TOTALS, not a level, and must never enter the occupancy fold. It
+	// feeds reconciliation and limit learning only.
+	Terminal bool
+}
+
+// Occupancy is the context-window numerator this sample implies.
+// Meaningless on a Terminal sample, which carries totals.
+func (s Sample) Occupancy() int {
+	if s.Layout == rtevents.LayoutSubsumptive {
+		return s.In
+	}
+	return s.In + s.CacheReadIn + s.CacheCreationIn
+}
+
+// ClassSum adds the three prompt-token classes without applying Layout.
+// It is the reconciliation quantity: comparing accumulated per-request
+// classes against a terminal total has to be layout-independent, because
+// the two sides are the same classes either way.
+func (s Sample) ClassSum() int {
+	return s.In + s.CacheReadIn + s.CacheCreationIn
+}
+
+// TotalMismatch reports the harness's own total minus the sum of the
+// classes that total is defined over, or 0 when the harness published
+// none. Nonzero means the harness's arithmetic disagrees with marvel's
+// reading of its fields, which is a usage-schema change. It does not
+// arbitrate Layout where TotalExcludesCache is set; see
+// AdditiveConfirmed and events.RequestUsage.TotalMismatch.
+func (s Sample) TotalMismatch() int {
+	if s.Total == 0 {
+		return 0
+	}
+	sum := s.In + s.Out + s.ReasoningOut
+	if !s.TotalExcludesCache && s.Layout != rtevents.LayoutSubsumptive {
+		sum += s.CacheReadIn + s.CacheCreationIn
+	}
+	return s.Total - sum
+}
+
+// AdditiveConfirmed reports a sample that PROVES In excludes CacheReadIn.
+// One-sided; see events.RequestUsage.AdditiveConfirmed.
+func (s Sample) AdditiveConfirmed() bool {
+	return s.Layout == rtevents.LayoutAdditive && s.CacheReadIn > 0 && s.In < s.CacheReadIn
+}
+
+// sampleFromEvent lifts one adapter event into a Sample. ok is false for
+// events carrying no usage, which is most of them.
+//
+// primaryRaw is the session's model as the harness names it, needed to
+// index a terminal sample's per-model window declaration. Selecting that
+// entry by anything else (first key, max, a range) is wrong: a session
+// routing across models carries several entries with windows differing
+// by 5x, and Go map iteration is randomized.
+func sampleFromEvent(c Coords, ev rtevents.Event, prof profile, primaryRaw string) (Sample, bool) {
+	base := Sample{
+		AgentID:          c.AgentID,
+		HarnessSessionID: ev.HarnessSessionID,
+		Harness:          ev.Harness,
+		TS:               ev.TS,
+		Cumulation:       prof.cumulation,
+	}
+
+	switch d := ev.Data.(type) {
+	case rtevents.TurnData:
+		r := d.Request
+		if r == nil {
+			return Sample{}, false
+		}
+		base.Model = r.Model
+		base.RequestID = r.RequestID
+		base.Layout = r.Layout
+		base.In = r.In
+		base.Out = r.Out
+		base.CacheReadIn = r.CacheReadIn
+		base.CacheCreationIn = r.CacheCreationIn
+		base.ReasoningOut = r.ReasoningOut
+		base.Total = r.Total
+		base.TotalExcludesCache = r.TotalExcludesCache
+		base.CostUSD = r.Cost
+		base.DeclaredLimit = r.ContextWindow
+		base.Subagent = r.Subagent()
+		return base, true
+
+	case rtevents.SessionEndedData:
+		if d.Metering == nil && d.Usage.In == 0 && d.Usage.Out == 0 {
+			return Sample{}, false
+		}
+		base.Terminal = true
+		base.Cumulation = CumulationSession
+		base.Model = primaryRaw
+		base.In = d.Usage.In
+		base.Out = d.Usage.Out
+		base.CostUSD = d.Usage.Cost
+		if m := d.Metering; m != nil {
+			base.CacheReadIn = m.CacheReadIn
+			base.CacheCreationIn = m.CacheCreationIn
+			if mu, ok := m.ModelUsage[primaryRaw]; ok {
+				base.DeclaredLimit = mu.ContextWindow
+			}
+		}
+		return base, true
+	}
+	return Sample{}, false
+}

--- a/internal/usage/sample_test.go
+++ b/internal/usage/sample_test.go
@@ -1,0 +1,207 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/runtime/claudecode"
+	"github.com/arcavenae/marvel/internal/runtime/codex"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+	"github.com/arcavenae/marvel/internal/runtime/opencode"
+)
+
+func TestSampleOccupancyAppliesLayout(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		sample Sample
+		want   int
+	}{
+		{
+			// Measured: In alone would read 11368 where the real prompt is
+			// 33377, because the cached bulk is not in In.
+			name:   "additive sums the cache classes",
+			sample: Sample{Layout: rtevents.LayoutAdditive, In: 11368, CacheReadIn: 16643, CacheCreationIn: 5366},
+			want:   33377,
+		},
+		{
+			// Measured: input_tokens 13992 already contains
+			// cached_input_tokens 11008, so summing gives 25000, which is
+			// wrong.
+			name:   "subsumptive uses In alone",
+			sample: Sample{Layout: rtevents.LayoutSubsumptive, In: 13992, CacheReadIn: 11008},
+			want:   13992,
+		},
+		{
+			name:   "an undeclared layout falls back to additive",
+			sample: Sample{In: 100, CacheReadIn: 10, CacheCreationIn: 1},
+			want:   111,
+		},
+	}
+	for _, c := range cases {
+		if got := c.sample.Occupancy(); got != c.want {
+			t.Errorf("%s: occupancy = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// ClassSum is the reconciliation quantity and must ignore Layout: the two
+// sides of the comparison are the same token classes either way.
+func TestSampleClassSumIgnoresLayout(t *testing.T) {
+	t.Parallel()
+	s := Sample{Layout: rtevents.LayoutSubsumptive, In: 100, CacheReadIn: 20, CacheCreationIn: 3}
+	if got := s.ClassSum(); got != 123 {
+		t.Errorf("class sum = %d, want 123", got)
+	}
+	if s.Occupancy() != 100 {
+		t.Errorf("occupancy = %d, want 100 under the subsumptive layout", s.Occupancy())
+	}
+}
+
+func TestSampleFromTurnEvent(t *testing.T) {
+	t.Parallel()
+	prof, _ := profileFor(claudecode.Harness)
+	ev := rtevents.Event{
+		Event:            rtevents.KindTurnCompleted,
+		Harness:          claudecode.Harness,
+		HarnessSessionID: "sess-1",
+		Data: rtevents.TurnData{Request: &rtevents.RequestUsage{
+			RequestID: "msg_1", Model: "claude-fable-5", Layout: rtevents.LayoutAdditive,
+			In: 331, CacheReadIn: 33479, CacheCreationIn: 326,
+		}},
+	}
+
+	s, ok := sampleFromEvent(testCoords, ev, prof, "claude-fable-5[1m]")
+	if !ok {
+		t.Fatal("turn event with a Request produced no sample")
+	}
+	if s.Terminal {
+		t.Error("a per-request sample must not be marked terminal")
+	}
+	if s.Cumulation != CumulationRequest {
+		t.Errorf("cumulation = %q, want %q", s.Cumulation, CumulationRequest)
+	}
+	if s.Occupancy() != 34136 {
+		t.Errorf("occupancy = %d, want 34136", s.Occupancy())
+	}
+	if s.HarnessSessionID != "sess-1" || s.AgentID != testCoords.AgentID {
+		t.Errorf("identity not stamped: %+v", s)
+	}
+}
+
+// A terminal sample is marked Terminal and its cumulation is SESSION, so
+// the fold can exclude it structurally rather than by inspection.
+func TestSampleFromSessionEndedIsTerminal(t *testing.T) {
+	t.Parallel()
+	prof, _ := profileFor(claudecode.Harness)
+	ev := rtevents.Event{
+		Event:   rtevents.KindSessionEnded,
+		Harness: claudecode.Harness,
+		Data: rtevents.SessionEndedData{
+			Usage: rtevents.Usage{In: 11701, Out: 455},
+			Metering: &rtevents.Metering{
+				CacheReadIn: 72131, CacheCreationIn: 17162,
+				ModelUsage: map[string]rtevents.ModelUsage{
+					"claude-fable-5[1m]":        {ContextWindow: 1_000_000},
+					"claude-haiku-4-5-20251001": {ContextWindow: 200_000},
+				},
+			},
+		},
+	}
+
+	s, ok := sampleFromEvent(testCoords, ev, prof, "claude-fable-5[1m]")
+	if !ok {
+		t.Fatal("session-ended event produced no sample")
+	}
+	if !s.Terminal {
+		t.Fatal("session-ended sample not marked terminal")
+	}
+	if s.Cumulation != CumulationSession {
+		t.Errorf("cumulation = %q, want %q", s.Cumulation, CumulationSession)
+	}
+	if s.ClassSum() != 100994 {
+		t.Errorf("class sum = %d, want 100994 (the session totals)", s.ClassSum())
+	}
+	// The window is selected by the primary model, never by ranging the
+	// map: the wrong entry here is off by 5x and Go map order is random.
+	if s.DeclaredLimit != 1_000_000 {
+		t.Errorf("declared limit = %d, want 1000000 (the primary model's window)", s.DeclaredLimit)
+	}
+}
+
+func TestSampleFromSessionEndedPicksNoWindowForAnUnknownPrimary(t *testing.T) {
+	t.Parallel()
+	prof, _ := profileFor(claudecode.Harness)
+	ev := rtevents.Event{
+		Event:   rtevents.KindSessionEnded,
+		Harness: claudecode.Harness,
+		Data: rtevents.SessionEndedData{
+			Usage: rtevents.Usage{In: 100},
+			Metering: &rtevents.Metering{ModelUsage: map[string]rtevents.ModelUsage{
+				"claude-fable-5[1m]": {ContextWindow: 1_000_000},
+			}},
+		},
+	}
+	// No primary model known, so no entry may be picked. Guessing here is
+	// how a 5x-wrong denominator gets in.
+	s, ok := sampleFromEvent(testCoords, ev, prof, "")
+	if !ok {
+		t.Fatal("no sample")
+	}
+	if s.DeclaredLimit != 0 {
+		t.Errorf("declared limit = %d, want 0 when the primary model is unknown", s.DeclaredLimit)
+	}
+}
+
+func TestSampleFromEventRejectsEventsWithoutUsage(t *testing.T) {
+	t.Parallel()
+	prof, _ := profileFor(claudecode.Harness)
+	for _, ev := range []rtevents.Event{
+		{Event: rtevents.KindTurnCompleted, Harness: claudecode.Harness, Data: rtevents.TurnData{}},
+		{Event: rtevents.KindToolCall, Harness: claudecode.Harness, Data: rtevents.ToolCallData{Tool: "Bash"}},
+		{Event: rtevents.KindMessageCompleted, Harness: claudecode.Harness, Data: rtevents.MessageData{Role: "assistant"}},
+		{Event: rtevents.KindError, Harness: claudecode.Harness, Data: rtevents.ErrorData{Kind: "parse"}},
+		{Event: rtevents.KindSessionEnded, Harness: claudecode.Harness, Data: rtevents.SessionEndedData{ExitCode: 1}},
+	} {
+		if _, ok := sampleFromEvent(testCoords, ev, prof, ""); ok {
+			t.Errorf("%s produced a sample despite carrying no usage", ev.Event)
+		}
+	}
+}
+
+func TestProfilesCoverEveryStreamCapableHarness(t *testing.T) {
+	t.Parallel()
+	for _, h := range []string{claudecode.Harness, codex.Harness, opencode.Harness} {
+		p, ok := profileFor(h)
+		if !ok {
+			t.Errorf("harness %q has no profile; its samples would be ignored", h)
+			continue
+		}
+		if p.cumulation != CumulationRequest {
+			t.Errorf("harness %q cumulation = %q, want %q", h, p.cumulation, CumulationRequest)
+		}
+	}
+	if _, ok := profileFor("crush"); ok {
+		t.Error("crush has a profile, but it publishes no structured stream")
+	}
+	if _, ok := profileFor(""); ok {
+		t.Error("the empty harness resolved to a profile")
+	}
+}
+
+// Claude declares its window only on the terminal line, so the table (or
+// the learned cache) is the live path even for the one harness that
+// declares one at all. Pinned because the opposite reading is the natural
+// assumption and it would leave Claude with no live denominator.
+func TestClaudeWindowArrivesTooLateToServeALiveReading(t *testing.T) {
+	t.Parallel()
+	p, _ := profileFor(claudecode.Harness)
+	if !p.limitInStream {
+		t.Error("claude does declare its window in-stream")
+	}
+	if !p.limitArrivesAtEnd {
+		t.Error("claude's window rides the terminal result line, so it cannot serve a live reading")
+	}
+	if c, _ := profileFor(codex.Harness); c.limitInStream {
+		t.Error("codex declares no window in its exec stream")
+	}
+}

--- a/internal/usage/stats.go
+++ b/internal/usage/stats.go
@@ -1,0 +1,55 @@
+package usage
+
+// Stats is the accountant's own diagnostic counters. Diagnostic, never a
+// gate (ADR-007): they exist so an operator can tell a quiet accountant
+// from a broken one, and so the invariants below are observable rather
+// than only asserted in tests.
+type Stats struct {
+	// Tracked is the number of live sessions with state, the leak canary
+	// for a missed Forget.
+	Tracked int
+	// SamplesObserved counts per-request samples folded into occupancy.
+	SamplesObserved uint64
+	// SamplesIgnored counts events with no usage, and events from a
+	// harness with no profile.
+	SamplesIgnored uint64
+	// SessionsUnresolved counts live sessions observed with no
+	// denominator.
+	SessionsUnresolved int
+	// CompactionsDetected counts downward steps past the hysteresis band.
+	CompactionsDetected uint64
+	// TotalMismatches counts samples whose token classes do not add up to
+	// the harness's own published total, over the classes that total is
+	// defined to cover. Nonzero means the harness's usage schema changed
+	// under us, or marvel misreads one of its fields. It does NOT decide
+	// whether a Layout is right: see AdditiveConfirmations.
+	TotalMismatches uint64
+	// AdditiveConfirmations counts samples that PROVE In excludes
+	// CacheReadIn, by carrying an In smaller than the cache read. The only
+	// live evidence for OpenCode's unverified additive layout.
+	//
+	// Two limits. It is one-sided: zero after many caching turns is a
+	// reason to look, not a verdict, because a subsumptive In is always the
+	// larger number. And it is not keyed by harness, so Claude ticks it
+	// too, where the property was already measured; it speaks to OpenCode
+	// only when read against a fleet running OpenCode.
+	AdditiveConfirmations uint64
+	// NonPrimarySamples counts samples from a model other than the
+	// session's primary. They feed spend and are excluded from occupancy.
+	NonPrimarySamples uint64
+	// SubagentSamples counts requests made inside a tool call (Claude's
+	// Task tool). They feed spend and are excluded from occupancy: a
+	// subagent fills its own window, and folding it into the parent's
+	// level would collapse the series for the length of the tool call.
+	SubagentSamples uint64
+	// ReconcileMismatches counts sessions whose accumulated per-request
+	// classes did not equal the harness's terminal totals: a missed or
+	// duplicated sample, or a stale reading.
+	ReconcileMismatches uint64
+	// CumulationViolations counts sessions whose accumulation EXCEEDED
+	// the terminal totals. Strictly greater is an arithmetic
+	// contradiction (more input tokens counted than the session used) and
+	// is the signature of a cumulative series read as levels. This is the
+	// runtime guard against reintroducing the defect doc.go describes.
+	CumulationViolations uint64
+}


### PR DESCRIPTION
CTX% in `marvel get sessions` has had exactly one producer, the cooperative heartbeat RPC, so every real harness session rendered `-`. This PR makes marvel derive context pressure from the streams it already parses, which is the first wave-4 capability: CTX% lights up for claude, codex, and opencode sessions, and the read seam it exposes is what admission control (qiay) and automatic shift triggers (M4) consume next. Additive to the API surface; the heartbeat producer keeps working.

**The correction worth reading:** occupancy is a per-request LEVEL (input + cache_read + cache_creation), latest-wins, never a sum. Claude Code's terminal `result.usage` is session-cumulative spend; on the repo's own `tool_call.ndjson` fixture the three per-request levels are 33,377 / 33,481 / 34,136 while the result line sums to 100,994. A numerator from the result line over-reports 3x on three requests and grows linearly with request count. finding-007 SP1 prescribed the result-line numerator; the finding carries a dated addendum, and `internal/usage/doc.go` records the discipline.

**Shape:**
- New `internal/usage` package: accountant folds per-request samples into per-session occupancy (level) and per-session/team spend (sum); compaction detection with hysteresis; terminal-total reconciliation; diagnostic counters (none gate).
- Feed-agnostic: stream events feed it today, an OTEL `api_request` source can attach later without touching the math.
- Denominator ladder resolves in-stream contextWindow, then learned windows, then the model table, then a manifest `context_window` override, and reports absence over guessing (no default-window knob; a wrong denominator misreports silently).
- Parsers: claude emits per-request usage deduped on `message.id`; codex and opencode declare fields that were on the wire but previously dropped.
- CLI: four-state CTX% (`-` never measured, heartbeat percent, `?` tokens without a window, `NN%`), plus a `context.limit-unresolved` event once per session.

**Verification:** 69 new tests; build/vet/gofmt/golangci-lint green; `go test -p 1 ./...` green; `-race` clean on touched packages. Independently reviewed under three lenses (contract fidelity, concurrency/lifecycle, integration); the one regression found (heartbeat sessions rendering `?`) was fixed and re-verified.

Known skew edge, deliberate: a post-PR CLI against a pre-PR daemon renders `-` for simulator sessions (old daemons send LastHeartbeat but no ContextAt). CLI/daemon skew rules are M3 scope (aae-orc-k28s).

Refs: #34, aae-orc-w5su