### PR TITLE
docs: de-drift round 2 (CLAUDE.md, architecture.md, adapter node, charter pointer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,24 @@
 
 ## What This Is
 
-> Note: the BYOA console formerly known as "aclaude" is now named "forestage".
-> References below have been updated. Historical GitHub issue references
-> (ArcavenAE/aclaude#N) are preserved as-is.
+A control plane for AI agent workloads. Written in Go. Manages the
+lifecycle of agent sessions running in tmux panes: scheduling,
+configuration, process management, health monitoring, persistence, and
+remote access over `mrvl://`.
 
-A kubernetes-like control plane for AI agent workloads. Written in Go.
-Manages the full lifecycle of BYOA agent sessions: scheduling, configuration,
-process management, health monitoring, storage, networking, and observability.
+The governing frame is the **agentic resource matrix**. The resources of
+agentic work are context, spend, cache locality, access, and authority;
+compute is one row of seventeen, not the frame. Kubernetes schedules
+containers by CPU and memory. Marvel governs agents by this matrix.
+Ratified 2026-08-01: `_kos/nodes/bedrock/elem-agentic-resource-matrix.yaml`.
 
-Where kubernetes orchestrates containers across nodes, marvel orchestrates
-agent sessions across tmux panes — local or remote via switchboard.
+Enforcement has three loci, in maturity order:
+
+1. **Environment construction at spawn** (BUILT). Adapters construct the
+   process environment; permission-through-environment.
+2. **Runtime admission and metering** (MISSING).
+3. **Mid-flight revocation** (MISSING). The M1 authority model is its
+   prerequisite.
 
 ## Build / Run / Test
 
@@ -28,102 +36,33 @@ just fmt            # gofumpt formatting
 
 ## Resource Model
 
-Marvel's resource model maps kubernetes concepts to agent orchestration.
-Resources are declared in TOML manifests, loaded via `marvel work`.
+**Model-only, not implemented:** Pack (ConfigMap), Vault (Secret), Volume
+(PVC), Schedule (CronJob), Gateway (Ingress), Readycheck (readiness
+Probe). No type, no code, no CLI. They survive in
+`elem-k8s-resource-model` as design prose only. `HealthCheckType` has
+exactly two values, `heartbeat` and `process-alive`, so there is no
+readiness check to configure.
 
-### Primitives
+The k8s mapping below is a **mechanics footnote**, not the frame:
+declarative desired state, the reconciliation loop, and typed resources
+are the whole inheritance (`elem-k8s-resource-model`, demoted to footnote
+2026-08-01). Design attention starts at the resource matrix above.
 
-```
-Kubernetes          Marvel                  What It Is
-──────────          ──────                  ──────────
+### Primitives (implemented)
 
-Namespace           Workspace               Isolation boundary. A project, team,
-                                            or environment. Scopes all resources.
+Declared in TOML or YAML manifests, applied with `marvel work`.
 
-Pod                 Session                 The atomic unit. A tmux pane running
-                                            one BYOA console process. Has a
-                                            lifecycle: pending → running →
-                                            succeeded/failed. Restartable.
-
-Container           Runtime                 The BYOA console binary. forestage,
-                                            zclaude, dclaude, pennyfarthing,
-                                            bare `claude` CLI, or any agent
-                                            that accepts a prompt on stdin.
-                                            Runtime images are just paths to
-                                            executables + their config.
-
-Deployment          Team                    A cohesive unit of agents with
-                                            heterogeneous roles. Each role has
-                                            its own runtime and replica count.
-                                            A team binds a supervisor to its
-                                            agents. Handles per-role scaling,
-                                            rolling updates, shift changes.
-
-(none)              Role                    One kind of agent within a team.
-                                            Has a name, replica count, and
-                                            runtime. "supervisor" (replicas: 1)
-                                            and "worker" (replicas: 5) are
-                                            roles within the same team.
-
-Service             Endpoint                A stable name for an agent capability.
-                                            "the-reviewer" resolves to whichever
-                                            session currently holds that role.
-                                            Enables director to route by role,
-                                            not by session ID.
-
-CronJob             Schedule                Timed agent tasks. "Run a code review
-                                            agent every 2 hours." "Shift change
-                                            at 06:00 UTC." Creates Sessions on
-                                            the cron schedule.
-
-ConfigMap           Pack                    Content packs (spectacle, bmad, etc.)
-                                            mounted into sessions. Packs provide
-                                            commands, templates, themes, workflows.
-                                            4-scope resolution: repo → shared →
-                                            user → system.
-
-Secret              Vault                   Auth delegation references. Marvel
-                                            never stores credentials. Vaults
-                                            point to where auth lives (Claude
-                                            Code OAuth, API keys in keychain,
-                                            Bedrock/Vertex config). Sessions
-                                            inherit vault references at launch.
-
-PVC                 Volume                  Workspace storage for a session.
-                                            Git worktrees, sandboxes, shared
-                                            directories. A volume can be:
-                                            - worktree: git worktree (isolated
-                                              branch, auto-cleaned or kept)
-                                            - sandbox: temp directory (destroyed
-                                              on session teardown)
-                                            - shared: mounted read-write across
-                                              sessions (coordination artifacts)
-                                            - host: bind-mount of a host path
-
-Probe (liveness)    Healthcheck             Is the session alive? Is the process
-                                            running? Is the tmux pane responsive?
-                                            Marvel restarts sessions that fail
-                                            health checks.
-
-Probe (readiness)   Readycheck              Is the session ready to accept work?
-                                            Has the agent loaded its context,
-                                            packs, and persona? Marvel doesn't
-                                            route work until readycheck passes.
-
-Ingress             Gateway                 External access to the agent cluster.
-                                            Three types:
-                                            - switchboard: remote tmux access
-                                              (KVM for agent sessions)
-                                            - director: inter-agent supervisor
-                                              protocol (internal routing)
-                                            - gateway: external API/webhook
-                                              interface (not yet designed)
-
-Node                Host                    A machine running marvel. Local host
-                                            by default. Remote hosts reachable
-                                            via switchboard. Marvel schedules
-                                            sessions to available hosts.
-```
+| K8s | Marvel | What it is |
+|---|---|---|
+| Namespace | **Workspace** | Isolation boundary: a project, team, or environment. Scopes every other resource. |
+| Pod | **Session** | The atomic unit. One tmux pane running one harness process. Lifecycle pending → running → succeeded/failed, plus crashed and crashloop-backoff. Restartable. |
+| Container | **Runtime** | The harness binary, args, and mode, plus `context_window` to override the model-to-window table for CTX%. `runtime` names the HARNESS (claude, codex, opencode), never the agent: `elem-runtime-names-harness`. |
+| Deployment | **Team** | Heterogeneous roles, each with its own runtime and replica count. Per-role scaling, shifts. Binds a supervisor to its agents. |
+| (none) | **Role** | One kind of agent within a team: name, replicas, runtime, restart policy, `max_restarts`, `permissions`, `dangerous_permissions`, `policy`, persona, identity. |
+| Service | **Endpoint** | A named record of `{name, workspace, team}` and nothing else. Created from a manifest `[[endpoint]]` section, read with `marvel get endpoints` and `marvel describe endpoint`. No role field, and no code resolves an endpoint to a session, so it is a name in the store rather than a routing target. Role-based routing waits on director (roadmap M2). |
+| ConfigMap | **Policy** | Named Claude Code settings fragment marvel projects into a per-session file the harness reads. Workspace-scoped, referenced by `Role.Policy`. Marvel writes it verbatim and does not interpret it. See orc finding-024 and `examples/policy-projection.toml`. |
+| Probe (liveness) | **Healthcheck** | `heartbeat` (staleness) or `process-alive`. Failures feed the restart policy. |
+| Node | **Host** | A machine running marvel. Local only today; multi-host is roadmap M5. |
 
 ### Resource Manifests (TOML)
 
@@ -139,37 +78,45 @@ name = "review-squad"
   [[team.role]]
   name = "supervisor"
   replicas = 1
+  permissions = "plan"
 
     [team.role.runtime]
-    image = "forestage"
-    args = ["--persona", "dune/supervisor"]
+    image = "claude"
+    command = "claude"
 
   [[team.role]]
   name = "reviewer"
   replicas = 3
+  permissions = "plan"
 
     [team.role.runtime]
-    image = "forestage"
-    args = ["--persona", "dune/reviewer"]
-
-# future: readychecks, healthchecks, packs, volumes per role
+    image = "claude"
+    command = "claude"
 ```
+
+Healthchecks, policies, endpoints, and headless launches: see `examples/`.
 
 ## Architecture
 
-This tree reflects the packages that exist today. Several resource
-types in the model above (Pack, Volume, Gateway, Schedule) are not yet
-implemented as their own packages; they live in the model, not the code.
+This tree reflects the packages that exist today.
 
 ```
 cmd/marvel/                 CLI entry point (cobra commands) + table rendering
 
 internal/
-  api/                      Resource types + store
-    types.go                Core type definitions (Workspace, Session, Team, ...)
+  api/                      Resource types + store + persistence
+    types.go                Core type definitions (Workspace, Session, Team, Role, Endpoint, Policy, Host)
     manifest.go             Manifest parsing and validation (TOML + YAML)
-    store.go                Resource store interface
-    bolt.go                 BoltDB-backed store (persistence across restarts)
+    store.go                Store struct (L1 in-memory synchronization
+                            boundary; reads return value snapshots)
+    bolt.go                 L2 durable record: bbolt write-ahead behind the
+                            in-memory store. Buckets workspaces/teams/sessions/
+                            endpoints/policies/role_health/meta, schema version 1
+                            with refuse-on-higher, rehydrate on OpenBolt. A nil
+                            bolt handle means in-memory only. Rehydrate zeroes
+                            stream-derived SessionContext (an adopted pane has no
+                            attached stream to refresh it), so CTX% renders "-"
+                            for adopted sessions; heartbeat readings survive.
 
   daemon/                   Daemon process + RPC surface
     daemon.go               Reconciliation loop, lifecycle, adopt-on-restart
@@ -182,19 +129,28 @@ internal/
   session/                  Session lifecycle
     manager.go              Create, monitor, restart, teardown sessions
     bridge.go               Stream bridge between agent runtime and daemon
+    projection.go           Policy projection writer (per-session settings file,
+                            live re-projection, policy.projected event)
 
-  runtime/                  BYOA console runtime adapters (the adapter framework)
-    adapter.go              Runtime adapter interface + Instance layer
-    forestage.go            forestage adapter (deep integration)
-    claude.go               Bare claude CLI adapter
-    generic.go              Generic adapter (any CLI that accepts stdin)
+  runtime/                  Harness runtime adapters (the adapter framework)
+    adapter.go              Adapter interface (Name, Prepare, ProjectionFor) + registry
+    claude.go               Claude Code adapter
+    codex.go                Codex adapter
+    opencode.go             opencode adapter
+    forestage.go            forestage adapter (frozen deep-integration reference)
+    simulator.go            Simulator adapter (injects the identity flags its
+                            heartbeat path needs, so it does not restart-loop
+                            under the generic fallback)
+    generic.go              Fallback adapter (any CLI) + GenericScraper, a
+                            capture-pane history scrape with no production
+                            call site yet
     instance.go             Running-instance abstraction
     instance_tmux.go        tmux-backed instance
-    fifo.go                 Named-pipe cooperative stream
-    stream.go               Stream observation
+    fifo.go                 Named pipe carrying a harness's structured stdout to the daemon
+    stream.go               Stream observation + SupportsStream
     claudecode/             Claude Code stream-json parser + event mapping
-    codex/                  Codex adapter notes
-    opencode/               opencode adapter notes
+    codex/                  Codex JSONL event-stream parser + event mapping
+    opencode/               opencode JSONL event-stream parser + event mapping
     events/                 Runtime → director event envelopes
 
   tmux/                     tmux substrate
@@ -204,14 +160,20 @@ internal/
     procstat.go, proc.go, ps.go
     read_darwin.go, read_linux.go, read_other.go   platform samplers
 
+  usage/                    Context-window and token accountant, the stream-fed
+                            CTX% producer. Occupancy is a per-request level,
+                            never a sum; unresolved windows report absence over
+                            a guessed denominator (internal/usage/doc.go)
+
   events/                   Structured event ring (control-plane + agent.* events)
   keys/                     SSH client keypair management (~/.marvel/keys)
   knownhosts/               Host-key trust (~/.marvel/known_hosts)
   config/                   Named-cluster config (~/.marvel/config.yaml)
   paths/                    ~/.marvel/ path resolution
-  logbuf/                   In-memory log buffer
+  logbuf/                   In-memory log buffer (serves `marvel daemon logs`)
   rlog/                     Structured request/run logging
-  otel/                     Observability metrics
+  otel/                     34-line producer stub (stdout meter + one gauge).
+                            Imported only by cmd/simulator; see Observability below.
   upgrade/                  Self-upgrade (Homebrew / direct binary)
   simulator/                Context-pressure simulation for testing without real agents
 ```
@@ -220,74 +182,117 @@ internal/
 
 Marvel manages agent processes through the tmux substrate:
 
-**Start:** create tmux pane → set environment → exec runtime binary.
+**Start:** create tmux pane → set environment → exec harness binary.
 **Stop:** send SIGTERM → wait grace period → SIGKILL → destroy pane.
-**Restart:** stop + start. Preserves the session ID and volume mounts.
-**Health:** periodic healthcheck (process alive) + readycheck (agent responsive).
-**Auto-restart:** if healthcheck fails and restart policy allows, restart the session.
+**Restart:** mark failed, delete the session, let the reconciler respawn it
+on a later tick. Names are `<team>-<role>-g<generation>-<index>` and the
+index is max(existing)+1 with no gap filling, so a single-replica role gets
+its key back while a crashed middle replica of a multi-replica role returns
+under a new index.
+**Health:** periodic healthcheck, `heartbeat` staleness or `process-alive`.
+**Auto-restart:** if healthcheck fails and restart policy allows, restart.
 
 Restart policies: `always`, `on-failure`, `never`.
 
-## Agent Communication Protocol
+Recovery behavior, all shipped:
 
-Sessions communicate via a message protocol. Three transports, same messages:
+- **Crash-loop backoff.** Repeated restarts move the session to
+  `crashloop-backoff` with the pane left alive, so the state is visible
+  while the reconciler holds off. Per-role tracking lives in
+  `team.RoleHealth`, written through to the bolt `role_health` bucket and
+  rehydrated at daemon start.
+- **`Role.MaxRestarts`** caps restarts per replica slot; on saturation the
+  session is left `failed` rather than respawned. Zero means unlimited.
+- **`crashed`** is the transition state `ReapDead` sets when a pane is
+  gone, distinguishing a dead process from a drained one.
+- **Adopt-on-restart.** A restarted daemon rehydrates the store and runs
+  `AdoptOrKill` against the live panes; agents survive the daemon.
+- **SIGTERM is detach, not teardown.** `marvel stop` leaves agents
+  running; `marvel stop --teardown` is the destructive form.
+- **Shift timeout with rollback.** A shift that cannot finish inside the
+  timeout (default 10m) is aborted and rolled back rather than left
+  half-drained.
 
-| Transport | Use Case | Latency | Reliability |
-|-----------|----------|---------|-------------|
-| Named pipes (FIFO) | Local sessions, same host | Low | High |
-| tmux send-keys | Fallback, any tmux pane | Medium | Medium |
-| Switchboard relay | Remote sessions, cross-host | Higher | High |
+## Agent Communication
 
-Message types:
-- **task** — work assignment from coordinator to session
-- **result** — work product from session to coordinator
-- **heartbeat** — periodic liveness signal
-- **signal** — control messages (pause, resume, shutdown, reconfigure)
+**UNBUILT.** There is no agent message protocol in this repo. Earlier
+prose here described three transports (named pipes, tmux send-keys,
+switchboard relay) carrying task/result/heartbeat/signal messages. None of
+that shipped: `internal/runtime/fifo.go` is a one-way sink for a harness's
+structured stdout, tmux send-keys exists only as operator keystrokes via
+`marvel inject`, and switchboard appears nowhere in the code.
 
-Director provides higher-level supervisor patterns on top of this protocol.
+What exists today:
+
+- **The events ring** (`internal/events`, 12 `agent.*` kinds plus
+  control-plane kinds). The stream-capable harnesses (headless claude,
+  codex, opencode) have parsers that emit the unprefixed vocabulary in
+  `internal/runtime/events`; `internal/session/bridge.go` lifts each kind
+  into its `agent.*` ring kind. Read it with `marvel events`.
+- **The heartbeat RPC** (`handleHeartbeat` → `UpdateSessionHeartbeat`), a
+  daemon method carrying `session_key` and `context_percent`. Cooperative,
+  and one of the CTX% column's two producers (the other is
+  `internal/usage`, fed by adapter streams).
+- **`marvel inject`**, operator keystrokes into a pane.
+
+The adopted shape (roadmap M2): an **external NATS bus, supervised by
+marvel as a declared workload**. Marvel stays thin and nats-server becomes
+a runtime dependency; embedded NATS was declined. Marvel owns the events,
+director owns the envelope. Ruling: orc `docs/roadmap.md` M2 and
+`docs/marvel-remap-2026-08.md` sections 2 and 4. Envelope draft v1: orc
+`docs/design/director-envelope-and-adapter-events.md`. Open question:
+`_kos/nodes/frontier/question-agent-communication-broker.yaml`.
 
 ## Observability
 
-Sessions export OTEL telemetry. Marvel collects and routes it.
+What exists:
 
-**Session-level signals:**
-- Traces: tool executions, API calls, agent reasoning spans
-- Metrics: token usage, tool counts, session duration, error rates
-- Logs: agent output, structured events
+- **`internal/events`**: bounded ring, severity-tagged, filterable by
+  workspace/team/role/session/kind. `marvel events`.
+- **`internal/usage`**: the context-window and token accountant, the
+  stream-fed CTX% producer. Occupancy is a per-request level, never a
+  sum; an unresolved window renders `?` and emits
+  `context.limit-unresolved` rather than guessing a denominator. The
+  discipline and its measured basis: `internal/usage/doc.go`.
+- **`internal/logbuf`**: the daemon's in-memory log ring. `marvel daemon
+  logs`, over `mrvl://` too.
+- **`internal/rlog`**: structured request/run logging.
+- **`internal/procstat`**: per-session CPU and RSS over a pid subtree.
+- **`internal/otel`** (34 lines): a stdout meter provider plus one gauge,
+  `marvel.agent.context_window_percent`, that nothing in the daemon
+  populates. Its only importer is `cmd/simulator`. Treat it as a stub.
 
-**Cluster-level signals (marvel itself):**
-- Sessions running/pending/failed per workspace
-- Restart counts, health check failures
-- Pack resolution times, volume mount times
-- Scheduling decisions and queue depth
+There is no collector, no trace export, and no ingest path. The OTEL
+funnel is explicitly HELD (orc `docs/marvel-remap-2026-08.md` section 2).
+Design question:
+`_kos/nodes/frontier/question-marvel-otel-architecture.yaml`.
 
-Export targets: self-hosted OTEL collector, stdout (dev mode), or disabled.
-Telemetry is always available, never mandatory (per SOUL.md §6).
+Telemetry stays available, never mandatory (SOUL.md §6).
 
-## Content Pack Management
+## Content Packs
 
-(Unchanged from previous design — see pack/ in architecture above.)
+Marvel has no pack subsystem: no `marvel pack` command, no `internal/pack`,
+no Pack type. Prior prose here documented six commands that were never
+built.
 
-A pack is a git repo with a `pack.yaml` manifest. Marvel resolves packs
-via the 4-scope chain and routes artifacts to the right locations for
-the target runtime.
+Pack management is phased across sideshow and marvel per orc
+`decisions/adr-008-pack-management-phased-sideshow-marvel.md` (accepted
+2026-08-01, supersedes ADR-002). **Now:** sideshow installs packs; marvel
+consumes what is on the host filesystem as-is. **Next:** marvel manifests
+declare which packs a workspace needs, and marvel or a marvel agent
+prepares the workspace. **Later:** self-contained workspaces over a
+subPath-like virtual filesystem, with sideshow gaining a marvel-aware
+install target; gated on a workspace-VFS study.
 
-Pack operations:
-- `marvel pack install <source> [--scope repo|shared|user|system]`
-- `marvel pack list [--scope ...]`
-- `marvel pack update [--all | <name>]`
-- `marvel pack remove <name>`
-- `marvel pack link <path> --scope shared --project <path>`
-- `marvel pack resolve` — show resolved config for current scope chain
+Open question: `_kos/nodes/frontier/question-pack-integration.yaml`.
 
 ## CLI
 
 ```sh
 marvel work <manifest.toml>                          # load manifest, reconcile desired state
-marvel get sessions                                  # list sessions (add -w for watch mode)
-marvel get teams                                     # list teams and roles
-marvel get workspaces                                # list workspaces
+marvel get <sessions|teams|workspaces|endpoints|policies>   # list resources (-w watches sessions)
 marvel describe session <id>                         # detailed session info
+marvel delete <session|team|workspace> <name>        # delete a resource (endpoints and policies are not deletable)
 marvel scale <workspace/team> --role <r> --replicas N  # scale a role within a team
 marvel shift <workspace/team> [--role <r>]             # rolling shift (replace sessions with fresh ones)
 marvel run <command> [args...] --role <r>             # run a one-off agent session
@@ -295,6 +300,8 @@ marvel kill <session-key>                            # kill a session
 marvel stop                                          # stop daemon, agents keep running (restart adopts them)
 marvel stop --teardown                               # stop daemon, delete sessions, kill panes
 marvel daemon                                        # start the daemon (foreground)
+marvel daemon logs [-n N]                            # daemon log ring (works over mrvl://)
+marvel daemon reexec                                 # adopt a freshly installed binary, agents keep running
 marvel events                                        # structured event ring (control-plane + agent.*)
 marvel capture <session-key>                         # capture a session's pane content
 marvel inject <session-key> <keys>                   # send keystrokes to a pane
@@ -303,19 +310,15 @@ marvel keys <generate|show|list|trust|authorize|authorized|revoke|doctor>  # SSH
 marvel version                                       # print version and channel
 marvel upgrade                                        # self-upgrade
 
-# future: logs, attach, exec, drain, top, pack management
+# future: attach, exec, drain, top, per-session logs (`daemon logs` is the
+# daemon's own ring, not a session's output)
 ```
-
-The `logs` verb is not yet implemented; `marvel events` covers the agent
-observability surface today (see charter B8 for the runtime adapter
-framework that feeds it).
 
 ## Conventions
 
 - **Language:** Go. Entire codebase.
-- **Config format:** TOML for manifests, plans, and pack config. Go flags/env for runtime.
-- **Pack manifest:** `pack.yaml` at pack root (YAML for ecosystem compatibility).
-- **Auth:** Delegates to BYOA console → Claude Code. Marvel never stores credentials.
+- **Config format:** TOML or YAML for manifests. Go flags/env for runtime.
+- **Auth:** Delegates to the harness → Claude Code. Marvel never stores credentials.
   Auth boundary: one user running their own agents under their own credentials
   (Max, API key, Bedrock, Vertex) is permitted. Orchestrating agents that route
   other people's consumer credentials is not — multi-user distribution requires
@@ -328,14 +331,14 @@ framework that feeds it).
 
 Marvel enhances every other component but requires none of them.
 
-**Marvel requires only:** Go, tmux, and a BYOA console binary (any CLI that
+**Marvel requires only:** Go, tmux, and a harness binary (any CLI that
 accepts a prompt on stdin). Everything else is optional integration.
 
 **Integration tiers:**
 
 | Component | Without It | With It |
 |-----------|-----------|---------|
-| forestage | Marvel uses bare `claude` or any CLI. Process management only. | Deep integration: personas, OTEL, packs, hooks, full metrics. |
+| forestage (RETIRED, reference only) | Marvel drives claude, codex, or opencode. | Identity flags, permission mode, script, socket. The adapter is frozen as the reference implementation of the deep-integration contract; forestage is not a live target (operator directive 2026-07-31). |
 | switchboard | Local-only scheduling. All sessions on one host. | Remote hosts. Distributed fleet. Cross-machine attach. |
 | director | No inter-agent comms. Fan-out/collect only. | Supervisor patterns, agent-to-agent routing, role-based endpoints. |
 | spectacle | No spec commands in packs. User loads manually. | IEEE-based spec templates available as a pack. |
@@ -347,22 +350,28 @@ accepts a prompt on stdin). Everything else is optional integration.
 - spectacle installs with `just install <target>`, no marvel needed
 - kos operates its own probe/finding cycle independently
 
-**Graceful degradation, not hard dependencies.** Marvel detects what's
-available at startup and adjusts its capabilities. No switchboard binary?
-Local-only mode. No director? No inter-agent routing. No packs installed?
-Sessions launch with console defaults.
+**Graceful degradation, not hard dependencies.** In the table above only
+the runtime-adapter row is shipped: the switchboard, director, spectacle,
+and kos columns describe intended integrations, and none of them appears in
+the code today. What marvel actually probes at startup is tmux, without
+which the driver refuses to run, plus the manifest validator's `LookPath`
+on each role's runtime command. Everything else is absent rather than
+detected, so a session launches with harness defaults.
 
 ## Design Principles
 
-1. **Declarative desired state** — you declare what you want running; marvel reconciles
-2. **Agents are processes** — each agent is a tmux pane running a BYOA console
-3. **Manifests are data** — TOML files, not code. Diffable, reviewable, versionable.
-4. **Configuration is resolved, not assumed** — full scope chain before launch
-5. **Packs are git repos** — versioned, diffable, shareable. No proprietary format.
-6. **Fail observable** — every session's output is visible; marvel logs all state transitions
-7. **Gradual elaboration** — start with `marvel apply` for a single session, grow to fleet management
-8. **Console-agnostic** — works with forestage, zclaude, dclaude, or any CLI that accepts a prompt
-9. **No conscription** — marvel orchestrates, it does not require. Every integration is optional.
+1. **Declarative desired state.** You declare what you want running; marvel reconciles.
+2. **Agents are processes.** Each agent is a tmux pane running a harness.
+3. **Manifests are data.** TOML or YAML, not code. Diffable, reviewable, versionable.
+4. **Configuration is resolved, not assumed.** Manifest and adapter resolve
+   at launch. Policy projection resolves at launch and re-resolves on
+   re-apply: `session.Manager.Reproject` rewrites the projected settings
+   file for every live session, so an edited policy reaches running agents
+   without a restart.
+5. **Fail observable.** Every session's output is visible; marvel logs all state transitions.
+6. **Gradual elaboration.** Start with one session in a manifest, grow to fleet management.
+7. **Harness-agnostic.** Six adapters, and the generic fallback manages any CLI.
+8. **No conscription.** Marvel orchestrates, it does not require. Every integration is optional.
 
 ## How to Work Here (kos Process)
 

--- a/_kos/nodes/bedrock/elem-runtime-adapter-framework.yaml
+++ b/_kos/nodes/bedrock/elem-runtime-adapter-framework.yaml
@@ -1,41 +1,108 @@
 id: elem-runtime-adapter-framework
 type: element
 confidence: bedrock
-title: "runtime adapter framework — three adapters with graded integration depth"
+title: "runtime adapter framework: six adapters behind one event vocabulary"
 content: |
-  Three adapters in `internal/runtime/`, each implementing a different
-  integration depth against the BYOA console:
+  Six adapters in `internal/runtime/`, all registered in
+  `NewRegistry` (adapter.go), each carrying a different integration
+  depth against the harness it launches:
 
-  - **forestage** (deep) — identity flags (`--persona`, `--identity`,
-    `--role`), permission mode, script, socket. Full marvel-aware
-    integration. Matches `aae-orc::elem-byoa-platform` + forestage's
-    `elem-marvel-adapter-contract`.
-  - **claude** (medium) — permission mode, system prompt with identity
-    via `--append-system-prompt`.
-  - **generic** (minimal) — env vars only. Works with any CLI that
-    accepts stdin. Capture-pane is the only observability.
+  | Adapter | Depth | Stream | Projection |
+  |---|---|---|---|
+  | **claude** | live target. `--settings` for the projected policy, `--permission-mode` from the role, `--append-system-prompt` with the session identity unless the manifest supplies one; headless adds `--print --output-format stream-json --verbose`. | headless only | yes |
+  | **codex** | live target. Env-var identity only; headless is `codex exec --json --skip-git-repo-check <prompt>` with stdin closed. | headless only | no |
+  | **opencode** | live target. Env-var identity only; headless is `opencode run --format json <message>` with stdin closed. | headless only | no |
+  | **forestage** | deepest surface, frozen as reference: `--persona`, `--identity`, `--role`, `--name`, `--workspace`, `--team`, `--socket`, `--permission-mode`, `--dangerously-skip-permissions`, `--script`, then `--settings` and `--append-system-prompt` after the `--` claude passthrough. Retired as a live target by operator directive 2026-07-31; the adapter stays as the reference implementation of the deep-integration contract. | no | yes |
+  | **simulator** | load-test target. Injects the identity flags the simulator's heartbeat path requires; without them a simulator launched through the generic fallback never heartbeats and restart-loops under `restart_policy = always`. | no | no |
+  | **generic** | minimal, and the registry fallback. Env vars only. Pane content is read on demand via `marvel capture`; `GenericScraper` (capture-pane history scrape with a per-session high-water mark) is written and unit-tested but not yet constructed anywhere in production code. | no | no |
 
-  Session manager resolves adapter from `Runtime.Name` via registry,
-  falls back to `generic`. Role gains `Permissions` field for
-  environment-as-permission (see `question-permission-model`).
+  Stream capability is `SupportsStream`, true only when
+  `Runtime.Mode` is headless: an interactive harness renders a TUI to
+  the pane and has no structured output to redirect. Projection is
+  `ProjectionFor(ctx, dir).Supported`.
+
+  The shared contract behind all six is a **twelve-kind event
+  vocabulary** (session started/ended, turn started/completed, message
+  delta/completed, tool call/result, permission requested, auth
+  required, health heartbeat, error). It lives in two packages under
+  two names, and the distinction matters when reading the code:
+
+  - `internal/runtime/events` (events.go:33-59) declares the twelve
+    unprefixed kinds (`session.started`, `tool.call`, ...) that the
+    per-harness parsers emit. `SchemaVersion` is 1 and the v1
+    vocabulary is closed: an unmapped vendor event becomes
+    `KindError` with `data.kind = "unmapped"` rather than being
+    dropped.
+  - `internal/events` (events.go:59-70) declares the same twelve
+    concepts prefixed as `agent.*` (`agent.session.started`,
+    `agent.tool.call`, ...), which is the form carried in the
+    daemon's event ring next to the control-plane kinds.
+    `internal/session/bridge.go` (`ringKind`) is the lift, one ring
+    kind per adapter kind.
+
+  So each adapter's parser maps its harness's own stream into the
+  unprefixed runtime vocabulary, the bridge lifts that into the ring,
+  and the daemon and the CLI see one vocabulary regardless of
+  harness. `runtime` names the HARNESS, never the agent
+  (`elem-runtime-names-harness`).
+
+  Session manager resolves the adapter from `Runtime.Name` via the
+  registry and falls back to `generic`. The `Adapter` interface has
+  three methods: `Name`, `Prepare`, and `ProjectionFor(ctx, dir)`
+  returning `ProjectionTarget{Supported, Path}`. Role carries
+  `Permissions` (harness permission mode, injected by the claude and
+  forestage adapters), `DangerousPermissions` (orthogonal, appends
+  `--dangerously-skip-permissions`, honored by the forestage adapter
+  only, so it is inert on a claude session today), and `Policy` (the
+  projected settings fragment) alongside the original
+  environment-as-permission work.
 
   Resolved former F9 (Runtime Adapter Framework). The session-017
-  probe shipped the framework end-to-end; 9 tests, 606 lines.
+  probe shipped the framework end-to-end.
 
-  Scope exclusions (deliberately NOT addressed by this bedrock): the
-  framework leaves `question-permission-model` (F10) and
-  `question-stream-attachment` (F11) open — adapter env-construction
-  ships without a permission model, and stream observation remains
-  capture-pane. Recorded here as prose because kos schema v0.3 has no
+  Scope exclusions, as of 2026-08-01: partly discharged, not closed.
+  `question-stream-attachment` (F11) is no longer capture-pane only:
+  headless claude, codex, and opencode redirect structured output to a
+  named pipe that marvel parses (`claudecode/`, `codex/`, `opencode/`
+  parsers; finding-005). Capture-pane survives as the generic
+  fallback's only path, and today only on demand through
+  `marvel capture`: no poll loop constructs `GenericScraper`.
+  `question-permission-model` (F10) gained Policy projection (orc
+  finding-024): a named settings fragment written per session, live
+  re-projected on re-apply, emitting `policy.projected`. What remains
+  open in F10 is the internal-capability layer (role-based RPC
+  authorization) and real containment, which belongs to curtain.
+  Recorded here as prose because kos schema v0.3 has no
   scope-exclusion edge type; the original `leaves-open` edges were
   removed in the schema-conformance fix (marvel 57d058f). If kos
   gains a negative-space edge type (aae-orc-dboj), restore these as
   edges.
 
-  Evidence: session-017. Closes original F9 charter question.
+  Evidence: session-017 for the framework. Test surface now spans
+  `internal/runtime/{adapter,codex_opencode,generic_scraper,projection,
+  simulator,instance_tmux}_test.go` plus the per-parser suites under
+  `claudecode/`, `codex/`, and `opencode/`.
+
+  **2026-08-01 update (append-only; the three-adapter roster above is
+  superseded, not corrected in place).** This node previously read
+  "three adapters with graded integration depth" and enumerated
+  forestage, claude, and generic. Six are registered. The roster is
+  load-bearing for `elem-runtime-names-harness`, which `derives` from
+  this node, and orc `docs/marvel-remap-2026-08.md` section 1 lists
+  "six runtime adapters (claude, codex, opencode, forestage,
+  simulator, generic) behind one 12-kind event vocabulary" as shipped
+  since roadmap rev-2. The evidence line also read "9 tests, 606
+  lines", which the current test surface exceeds by a wide margin.
+  Both were documentation drift, not a change of decision.
 edges:
   - target: elem-console-agnostic
     type: implements
+  - target: question-stream-attachment
+    type: partially_resolves
+    note: "2026-08-01: headless claude/codex/opencode parse a FIFO stream (finding-005); capture-pane remains the generic fallback"
+  - target: question-permission-model
+    type: partially_resolves
+    note: "2026-08-01: Policy projection ships the file-based layer (orc finding-024); the internal-capability layer stays open"
 provenance:
   created_by: human
   session: session-017
@@ -43,3 +110,5 @@ provenance:
   extracted_session: session-049
   extracted_at: "2026-05-13"
   extracted_from: charter.md B8 prose (resolves F9 in same charter)
+  updated_at: "2026-08-01"
+  updated_from: "de-drift against code at main 2be837a (aae-orc-ah75); roster and scope-exclusion refresh"

--- a/charter.md
+++ b/charter.md
@@ -1,5 +1,18 @@
 # marvel Charter
 
+> **2026-08-01 pointer.** Read the bedrock nodes before this prose. Four
+> nodes ratified 2026-08-01 (`elem-agentic-resource-matrix`,
+> `elem-runtime-names-harness`, `elem-staged-activation-upgrades`,
+> `elem-handoff-schema-ownership`) plus the refreshed
+> `elem-runtime-adapter-framework` are authoritative; the rulings behind
+> them are recorded in orc `docs/marvel-remap-2026-08.md` and orc
+> `docs/roadmap.md`. Two sections below lag those nodes: **B1** still
+> presents the k8s mapping as the governing frame (the agentic resource
+> matrix is the frame; k8s is a mechanics footnote per the demotion record
+> in `elem-k8s-resource-model`), and **B8** still says three runtime
+> adapters (six are registered). Both are pending a charter re-render, not
+> open decisions.
+
 Agent orchestration control plane — kubernetes-like resource model for
 AI agent workloads. Written in Go.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,13 @@ shifting, and scaling them according to declarative manifests.
 
 ## Design principles
 
-1. **Agents are processes.** Each agent is a tmux pane running a BYOA console
-   (forestage, bare claude CLI, or any command that accepts input on stdin).
+1. **Agents are processes.** Each agent is a tmux pane running a harness
+   (claude, codex, or opencode are the live targets; forestage is retired to
+   reference; the generic fallback takes any command that accepts input on
+   stdin). The manifest field `runtime` names the harness, never the agent.
 2. **Declarative desired state.** You write a manifest declaring what you want
    running. Marvel reconciles actual state to match.
-3. **Console-agnostic.** Marvel orchestrates any BYOA console. The runtime
+3. **Harness-agnostic.** Marvel orchestrates any agent CLI. The runtime
    adapter framework handles the differences.
 4. **Infrastructure, not workflow.** Marvel manages processes and the substrate
    around them. It does not understand what agents are working on, decompose
@@ -21,7 +23,8 @@ shifting, and scaling them according to declarative manifests.
 
 ```
 ┌──────────────────────────────────────┐
-│ agents (forestage, claude, any CLI)  │
+│ agents (claude, codex, opencode,     │
+│   any CLI via the generic adapter)   │
 │   personas, work, decisions, prompts │
 └─────────────────┬────────────────────┘
                   │
@@ -51,10 +54,11 @@ Marvel's resource model maps kubernetes concepts to agent orchestration.
 |-------------|-----------------|------------|
 | Namespace | **Workspace** | Isolation boundary. A project or environment. |
 | Pod | **Session** | Atomic unit. A tmux pane running one agent process. |
-| Container image | **Runtime** | The BYOA console binary + args. |
+| Container image | **Runtime** | The harness binary + args. Names the harness, never the agent. |
 | Deployment | **Team** | A group of agents with heterogeneous roles. |
 | (none) | **Role** | One kind of agent within a team (supervisor, worker). |
 | Service | **Endpoint** | Stable name for a session capability. |
+| ConfigMap | **Policy** | Named Claude Code settings fragment marvel projects into a per-session file the harness reads. Scoped to a workspace, referenced by `Role.Policy`. |
 | Node | **Host** | A machine running marvel (local by default). |
 
 Resources are declared in YAML or TOML manifests and applied with `marvel work`.
@@ -65,25 +69,77 @@ When marvel launches a session, it resolves a runtime adapter based on the
 `image` field in the manifest. Each adapter knows how to construct the
 execution environment for its runtime type.
 
-| Adapter | Triggered by | What it does |
-|---------|-------------|--------------|
-| **forestage** | `image: forestage` | Injects identity flags (--name, --workspace, --team, --role, --socket), permission mode, script path. Deep integration. |
-| **claude** | `image: claude` | Injects --permission-mode and --append-system-prompt with identity. Medium integration. |
-| **generic** | Any other image | Passes command + args through unchanged. Env vars only (MARVEL_SESSION, MARVEL_ROLE, etc.). |
+Six adapters are registered. `claude`, `codex`, and `opencode` are the live
+harness targets; `generic` is the fallback; `simulator` serves load tests;
+`forestage` is frozen as the deep-integration reference.
 
-The adapter also implements permission-through-environment: it injects
-`--permission-mode` from the role's `permissions` field in the manifest.
-The agent reads permissions from files that marvel wrote.
+| Adapter | Triggered by | What it does | Stream | Projection |
+|---------|-------------|--------------|--------|------------|
+| **claude** | `image: claude` | Injects --settings for the projected policy, --permission-mode from the role, and --append-system-prompt with the session identity unless the manifest already supplies one. Headless adds --print --output-format stream-json --verbose and the prompt as the positional argument. | headless only | yes |
+| **codex** | `image: codex` | Env-var identity only. Headless becomes `codex exec --json --skip-git-repo-check <prompt>` with stdin from /dev/null, since codex appends piped stdin to its prompt and would otherwise hang on the pane tty. | headless only | no |
+| **opencode** | `image: opencode` | Env-var identity only. Headless becomes `opencode run --format json <message>`, stdin likewise closed. | headless only | no |
+| **forestage** | `image: forestage` | The deepest surface: --persona, --identity, --role, --name, --workspace, --team, --socket, --permission-mode, --dangerously-skip-permissions, --script, then --settings and --append-system-prompt after the `--` claude passthrough. Retired to reference; the adapter stays as the deep-integration contract's reference implementation. | no | yes |
+| **simulator** | `image: simulator` | Injects the identity flags the simulator's heartbeat path needs (--name, --workspace, --team, --role, --socket, --script). Without them a simulator launched through the generic fallback never heartbeats and restart-loops under `restart_policy = always`. | no | no |
+| **generic** | Any other image | Passes command + args through unchanged. Env vars only (MARVEL_SESSION, MARVEL_ROLE, and the rest). Pane content is read on demand with `marvel capture`; `GenericScraper` (a capture-pane history scrape with a per-session high-water mark) is written and unit-tested but has no production call site yet. | no | no |
+
+Stream capability is `SupportsStream`, which returns true only when
+`Runtime.Mode` is headless: an interactive harness renders a TUI to the pane
+and has no structured output to redirect. A stream-capable session's output
+is redirected into a named pipe that the daemon parses (finding-005).
+Projection is `ProjectionFor(ctx, dir).Supported`.
+
+### Three permission mechanisms, not one
+
+1. **`Role.Permissions`** maps to the harness's `--permission-mode` and
+   selects how it prompts within its cooperative permission model. The
+   claude and forestage adapters inject it; codex, opencode, simulator,
+   and generic ignore it.
+2. **`Role.DangerousPermissions`** appends
+   `--dangerously-skip-permissions`, removing that model. Orthogonal to
+   the first: an operator picks one, the other, or both. Only the
+   forestage adapter honors it today, so on a claude session the field is
+   currently inert.
+3. **Policy projection** is the file-based mechanism.
+   `Adapter.ProjectionFor` reports where the file goes,
+   `internal/session/projection.go` writes the settings JSON, and
+   `LaunchContext.PolicyProjectionPath` is what the adapter points the
+   harness at via `--settings`. Re-projection happens live on re-apply,
+   emitting a `policy.projected` event, so a running agent's contract can
+   change without a restart. Harnesses that support no projection (codex,
+   opencode, simulator, generic) have the referenced policy logged as
+   advisory rather than silently dropped.
+
+Enforcement is spawn-time environment construction. Real containment
+belongs to curtain.
 
 ## Reconciliation loop
 
 The team controller runs a reconciliation loop every 2 seconds:
 
-1. **Reap dead sessions** — remove sessions whose tmux panes no longer exist
-2. **Evaluate health** — check heartbeat staleness, apply restart policies
-3. **Reconcile each team** — for each role, compare desired replicas vs actual,
-   create or delete sessions to match
-4. **Process shifts** — if a shift is in progress, manage the rolling replacement
+1. **Reap dead sessions.** Remove sessions whose tmux panes no longer exist.
+   `ReapDead` marks the transition state `crashed` first, so a dead process
+   is distinguishable from a drained one.
+2. **Evaluate health.** Check heartbeat staleness, apply restart policies.
+   Repeated restarts move a session to `crashloop-backoff` with its pane
+   left alive, so the state stays visible while the reconciler holds off.
+   At `Role.MaxRestarts` the reconciler stops and leaves the session
+   `failed`.
+3. **Reconcile each team.** For each role, compare desired replicas vs
+   actual, create or delete sessions to match.
+4. **Process shifts.** If a shift is in progress, manage the rolling
+   replacement. A shift that cannot finish inside `ShiftTimeout` (default
+   10 minutes) is aborted and rolled back rather than left half-drained.
+5. **Write crash-loop state through.** Every crash the reap path or the
+   health path records goes to the bolt `role_health` bucket, the one bucket
+   with no in-memory mirror, so the restart counter and the backoff deadline
+   are durable as they change.
+
+Recovery is separate: it runs once at daemon start, not on the loop.
+`RehydrateRoleHealth` loads the persisted crash-loop state before the
+reconciler starts, so a role frozen at `MaxRestarts` stays held back across a
+restart instead of getting a free respawn. `AdoptOrKill` then reconciles the
+live tmux panes against the rehydrated store, which is what lets agents
+survive the daemon.
 
 ## Shift mechanics
 
@@ -137,18 +193,47 @@ The CLI resolves connections in priority order:
 ```
 cmd/marvel/                 CLI entry point (cobra)
 internal/
-  api/                      Resource types + manifest parsing (YAML/TOML)
+  api/                      Resource types + manifest parsing (YAML/TOML) +
+                            Store (L1 in-memory snapshot boundary) +
+                            bolt.go (L2 bbolt durable record, optional via OpenBolt)
   config/                   Client cluster configuration (~/.marvel/config.yaml)
   daemon/                   Daemon, RPC handlers, embedded SSH server
-  runtime/                  Runtime adapter framework (forestage/claude/generic)
-  session/                  Session lifecycle (create, delete, reap)
-  team/                     Team controller (reconciler, shifts, health)
+  runtime/                  Runtime adapter framework (six adapters + parsers)
+  session/                  Session lifecycle (create, delete, reap, policy projection)
+  team/                     Team controller (reconciler, shifts, health, crash-loop)
   tmux/                     tmux driver (subprocess, capture, send-keys)
   procstat/                 Per-session CPU/memory rollup over a pid subtree
-  otel/                     Observability (OTEL metrics)
+  usage/                    Context-window/token accountant (stream-fed CTX% producer)
+  events/                   Bounded event ring (control-plane + 12 agent.* kinds)
+  logbuf/                   Daemon log ring behind `marvel daemon logs`
+  rlog/                     Structured request/run logging
+  keys/                     SSH client keypair management (~/.marvel/keys)
+  knownhosts/               Host-key trust (~/.marvel/known_hosts)
+  paths/                    ~/.marvel/ path resolution
+  otel/                     34-line OTEL producer stub, imported only by cmd/simulator
   simulator/                Context pressure simulator + Lua scripting
   upgrade/                  Self-update (Homebrew detection, GitHub releases)
 ```
+
+Persistence is two levels. The in-memory `Store` is L1 and remains the read
+path; `bolt.go` is the L2 durable record behind it, a bbolt write-ahead over
+the buckets `workspaces`, `teams`, `sessions`, `endpoints`, `policies`,
+`role_health`, and `meta`. `boltSchemaVersion` is 1 and a higher on-disk
+version is refused rather than migrated blind. `OpenBolt` rehydrates the
+in-memory store; a nil bolt handle means in-memory only, which is still a
+supported mode.
+
+`internal/events` is the bounded event ring: severity-tagged records
+filterable by workspace, team, role, session, and kind, served to
+`marvel events`. It carries both control-plane kinds (including
+`policy.projected` and `context.limit-unresolved`) and the 12 `agent.*`
+kinds. Those twelve are declared
+twice under two names: the stream parsers emit the unprefixed vocabulary in
+`internal/runtime/events` (`session.started`, `tool.call`, and the rest),
+and `internal/session/bridge.go` lifts each one into its `agent.*` ring
+kind, which is what lets the daemon and the CLI see one vocabulary
+regardless of harness. The ring is bounded, so it is history for the life
+of the daemon process, not durable storage.
 
 ## Manifest formats
 


### PR DESCRIPTION
marvel/CLAUDE.md is loaded into every agent session that works this repo, and it has been teaching a retired comms model, a pack CLI that does not exist, and an overstated OTEL layer. This pass makes the always-loaded docs match the shipped binary, so orienting agents stop inheriting drift. Docs only; no behavior changes.

**What it fixes:**
- CLAUDE.md: three-transports comms model replaced with what exists (events ring, heartbeat RPC, `marvel inject`) plus the adopted M2 shape (external NATS, marvel-supervised); pack CLI removed per ADR-008 (sideshow installs, marvel consumes the host filesystem as-is); OTEL right-sized to the 34-line stub; all six adapters listed; `internal/usage` added to the tree and Observability sections.
- docs/architecture.md: six adapters, Policy resource, bolt L2 persistence, events ring, `internal/usage`.
- adapter bedrock node: names both event-vocabulary packages (unprefixed `internal/runtime/events` from parsers; `agent.*` in `internal/events` after the bridge lift) instead of conflating them.
- charter.md: a dated pointer block only, directing readers to the 2026-08-01 ratified nodes and the orc remap doc (B1 frame and B8 adapter count lag them).

**How it was checked:** every corrected claim was verified against code at 31f1ea5, twice. The first adversarial review caught the de-drift draft itself introducing new drift (an implemented heading vouching for endpoint-to-session resolution that does not exist, a never-mid-flight claim contradicted by live policy re-projection, a Store interface that is a struct). A second pass after #99 merged caught the claims that change staled (single-producer CTX%, a line count, a shifted line range) and added the rehydrate note (stream-derived SessionContext zeroes on adopt, so CTX% renders `-` for adopted sessions).

Refs: aae-orc-ah75