### PR TITLE
fix: capture -S without -E spans through bottom of visible, not -E 0

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -876,15 +876,26 @@ func injectCmd() *cobra.Command {
 
 func captureCmd() *cobra.Command {
 	var start, end int
-	var hasRange bool
 	cmd := &cobra.Command{
 		Use:   "capture <session-key>",
 		Short: "Capture a session's pane content",
-		Args:  cobra.ExactArgs(1),
+		Long: `Capture a session's pane content.
+
+Without flags, captures the visible area. -S with a negative value reaches
+into scrollback; an omitted -E defaults to the bottom of the visible area.
+
+Full-screen TUI harnesses (interactive claude and friends) run on the tmux
+alternate screen, which has no scrollback — captures of those sessions cap
+at the visible screen regardless of -S.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p := map[string]any{"session_key": args[0]}
-			if hasRange {
+			// Send only the bounds actually given: a defaulted end of 0
+			// would pin the span to the TOP visible line (marvel#114).
+			if cmd.Flags().Changed("start") {
 				p["start"] = start
+			}
+			if cmd.Flags().Changed("end") {
 				p["end"] = end
 			}
 			params, _ := json.Marshal(p)
@@ -907,11 +918,8 @@ func captureCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().IntVarP(&start, "start", "S", 0, "start line (negative for scrollback)")
-	cmd.Flags().IntVarP(&end, "end", "E", 0, "end line")
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		hasRange = cmd.Flags().Changed("start") || cmd.Flags().Changed("end")
-	}
+	cmd.Flags().IntVarP(&start, "start", "S", 0, "start line (negative for scrollback; default top of visible)")
+	cmd.Flags().IntVarP(&end, "end", "E", 0, "end line (default bottom of visible)")
 	return cmd
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1107,6 +1107,31 @@ type captureParams struct {
 	End        *int   `json:"end,omitempty"`
 }
 
+// captureVisibleEnd stands in for an omitted end bound. tmux clamps an
+// over-large -E to the last visible row, which is also tmux's own default
+// end — so a start-only request spans scrollback through the bottom of
+// the screen instead of stopping at -E 0, the TOP visible line (a
+// one-line span on alternate-screen panes; marvel#114).
+const captureVisibleEnd = 100000
+
+// captureBounds resolves the optional start/end params to concrete tmux
+// bounds. Either bound alone triggers a range capture; the missing bound
+// defaults to tmux's own default for that side (-S 0 = top of visible,
+// -E clamped to bottom of visible).
+func captureBounds(p captureParams) (start, end int, ranged bool) {
+	if p.Start == nil && p.End == nil {
+		return 0, 0, false
+	}
+	start, end = 0, captureVisibleEnd
+	if p.Start != nil {
+		start = *p.Start
+	}
+	if p.End != nil {
+		end = *p.End
+	}
+	return start, end, true
+}
+
 func (d *Daemon) handleCapture(params json.RawMessage) Response {
 	var p captureParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -1123,8 +1148,8 @@ func (d *Daemon) handleCapture(params json.RawMessage) Response {
 	}
 
 	var content string
-	if p.Start != nil && p.End != nil {
-		content, err = d.driver.CapturePaneRange(sess.PaneID, *p.Start, *p.End)
+	if start, end, ranged := captureBounds(p); ranged {
+		content, err = d.driver.CapturePaneRange(sess.PaneID, start, end)
 	} else {
 		content, err = d.driver.CapturePane(sess.PaneID)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1121,3 +1121,33 @@ func TestCleanExecPath(t *testing.T) {
 		})
 	}
 }
+
+func TestCaptureBounds(t *testing.T) {
+	iptr := func(v int) *int { return &v }
+	tests := []struct {
+		name       string
+		params     captureParams
+		wantStart  int
+		wantEnd    int
+		wantRanged bool
+	}{
+		{"neither bound: visible capture", captureParams{}, 0, 0, false},
+		{"start only: end defaults to bottom of visible, not -E 0", captureParams{Start: iptr(-200)}, -200, captureVisibleEnd, true},
+		{"end only: start defaults to top of visible", captureParams{End: iptr(5)}, 0, 5, true},
+		{"both bounds pass through", captureParams{Start: iptr(-100), End: iptr(10)}, -100, 10, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, ranged := captureBounds(tt.params)
+			if ranged != tt.wantRanged {
+				t.Fatalf("ranged = %v, want %v", ranged, tt.wantRanged)
+			}
+			if !ranged {
+				return
+			}
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Fatalf("bounds = (%d, %d), want (%d, %d)", start, end, tt.wantStart, tt.wantEnd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #114.

An operator reaching for scrollback with `marvel capture <key> -S -200` got a single line back on alternate-screen panes, making the capture verb look broken exactly when it matters. Root cause: the CLI sent both bounds when either flag changed, so a start-only request carried `end: 0`, and tmux's `-E 0` is the TOP visible line.

Fix, per the issue's fix shape:
- CLI sends only the bounds actually passed (no more PreRun/hasRange coupling).
- Daemon fills a missing bound with tmux's own default for that side: `-S 0` = top of visible; a missing end becomes a large `-E` that tmux clamps to the bottom visible row (the same clamp GenericScraper already relies on).
- `capture --help` now carries the honest-rendering note: alternate-screen TUI harnesses have no scrollback, so captures cap at the visible screen regardless of `-S`.

Verified live: a generic pane with 80 lines of scrollback returns all 80 with `-S -200` (was 1), 23 with no flags (visible area), and explicit `-S/-E` ranges pass through unchanged. New table test `TestCaptureBounds` covers start-only, end-only, both, and neither. Full suite + lint clean.

Additive only; the no-flag and both-flag paths behave exactly as before.