### PR TITLE
probe: interactive CTX% remainder sweep brief + question-node refresh

### DIFF
--- a/_kos/nodes/frontier/question-interactive-context-pressure.yaml
+++ b/_kos/nodes/frontier/question-interactive-context-pressure.yaml
@@ -52,10 +52,33 @@ content: |
   value (w5su); interactive sessions get a best-effort scraped figure
   clearly labelled as approximate and harness-normalized.
 
-  Tracked: bd aae-orc-dc1j. Related: aae-orc-w5su (headless CTX%; scope
-  it headless-only so nobody assumes TUI coverage), aae-orc-gtpz
-  (shim), finding-005 (capture-pane tier), finding-007 (the headless
-  probe that left this untouched).
+  STATE 2026-08-06 (supersedes the framing above for claude):
+
+  - Interactive claude is SOLVED, and by neither (a) nor (b): the
+    statusline side channel (finding-011) exports raw occupancy WITH
+    the window denominator; shipped as `runtime.context_feed =
+    "statusline"` plus `marvel ctx-forward` into the heartbeat RPC.
+    The scrape-vs-headless-only dichotomy was false for claude; a
+    third, cooperative channel existed.
+  - codex and gemini have a named candidate (native OTEL, finding-008;
+    capable but not live-verified, occupancy derivation open).
+  - opencode and Crush have no verified channel; opencode's HTTP API
+    and plugin surface are unchecked candidates.
+  - Capture-pane scraping (option (a)) is ruled out as a default path:
+    fragile, per-harness, normalized figure, and now beaten on every
+    axis by the statusline precedent. Reopen only by deliberate
+    operator decision.
+  - Remaining work is structured as a two-phase sweep (secondary desk
+    catalog across all four runtimes, then primary live verification
+    for surviving candidates only, with a kill rule to headless-only):
+    probe-interactive-ctx-remainder-sweep.md.
+
+  Tracked: bd aae-orc-dc1j. Related: aae-orc-7hzb (statusline probe;
+  its "other harnesses" remainder is absorbed by the sweep brief),
+  aae-orc-w5su (headless CTX%; scope it headless-only so nobody
+  assumes TUI coverage), aae-orc-gtpz (shim), finding-005
+  (capture-pane tier), finding-007 (the headless probe that left this
+  untouched), finding-008 (OTEL), finding-011 (statusline).
 edges:
   - target: question-stream-attachment
     type: derives

--- a/_kos/probes/probe-interactive-ctx-remainder-sweep.md
+++ b/_kos/probes/probe-interactive-ctx-remainder-sweep.md
@@ -1,0 +1,89 @@
+# Probe brief: interactive CTX% remainder sweep (codex, gemini, opencode, Crush)
+
+**Status:** OPEN (brief only; not started).
+**Question:** `question-interactive-context-pressure` (the non-claude remainder)
+**Probe medium:** desk research first, then code (live rig per surviving candidate)
+**Timebox:** phase 1 one sitting; phase 2 one session per surviving runtime, run only as fleet priority demands
+**Prior work it extends:** finding-011 (statusline side channel, solved
+interactive claude), finding-008 (native OTEL, capable-but-unverified for
+codex and gemini), finding-007 (headless accountant), aae-orc-dc1j (the
+decision ticket), aae-orc-7hzb (whose "other harnesses statusline
+equivalents" remainder this brief absorbs).
+
+## Why this probe exists
+
+Interactive claude CTX% shipped 2026-08-05 via the statusline side channel:
+one day, one brief, because the work ran secondary-first (catalog candidate
+channels from docs/source, then one empirical rig on the best candidate).
+This brief applies the same shape to the four remaining runtimes instead of
+pre-committing to per-runtime probe pairs. The remainder matrix at time of
+writing:
+
+| Runtime | Known channel | Actually unknown |
+|---|---|---|
+| codex | OTEL (capable per finding-008, not live-verified) | occupancy derivation; whether a statusline-like hook exists |
+| gemini | OTEL (capable, not live-verified; no marvel adapter yet) | same, plus whether the fleet runs it at all |
+| opencode | none verified | its client/server HTTP API and plugin surface are unchecked candidates |
+| Crush | none | config and event hooks unchecked |
+
+## Hypothesis
+
+For each runtime, at least one cooperative channel (OTEL, statusline-like
+hook, HTTP API, plugin) exports enough to compute raw occupancy with a
+denominator, without owning the PTY and without capture-pane scraping. Where
+no such channel exists, the honest answer is documented headless-only, not a
+scraper.
+
+## Phase 1 — secondary sweep (one pass, all four runtimes)
+
+Desk research only: docs, source, changelogs, issue trackers. No daemons.
+Catalog every candidate side channel per runtime:
+
+- codex: OTEL metric/log semantics (does anything carry cumulative context
+  tokens plus the window size, or only per-turn usage?); any statusline or
+  notify-hook analog; `conversation_starts` as denominator source
+  (finding-008 note).
+- gemini: OTEL semantics, same questions; also record whether adding a
+  marvel adapter is even scheduled, because a channel for a runtime marvel
+  cannot launch is shelf inventory.
+- opencode: the client/server HTTP API (what does the server expose about a
+  session's token state?); the plugin API (can a plugin observe usage and
+  call out?); any TUI statusline configurability.
+- Crush: config surface, event hooks, anything resembling a status command
+  or emit-on-tick facility.
+
+Output: a channel-candidate table with one verdict per runtime, one of:
+`candidate: <channel>` (carries occupancy + denominator, or enough to derive
+them) or `no channel` (nothing exports the pair).
+
+## Phase 2 — primary verification (surviving candidates only)
+
+The finding-011 rig shape, per surviving runtime: launch the runtime
+interactively under marvel, attach the candidate channel, drive turns, and
+verify the exported figure against ground truth (the harness's own rendered
+indicator, or a token-counted transcript). Run in fleet-priority order:
+codex and opencode before gemini and Crush unless operations say otherwise.
+
+Success signal per runtime: a live `marvel get sessions` row showing CTX%
+for an interactive session of that runtime, fed by the candidate channel
+through the existing heartbeat RPC (or a documented reason the channel
+needs a new ingest path).
+
+## Kill rule
+
+A runtime whose phase-1 verdict is `no channel` gets recorded in the
+question node as "interactive CTX% not meterable for <runtime>; documented
+headless-only" (dc1j option (b)) and phase 2 is not run for it. The
+capture-pane scraper path (dc1j option (a)) stays ruled out unless an
+operator deliberately reopens it; fragility plus a normalized figure lost to
+the statusline precedent.
+
+## Non-goals
+
+- Per-subagent context surfaces (that is the aae-orc-7hzb daemon-surface
+  remainder, separate data plane).
+- OTEL collector architecture (held per question-marvel-otel-architecture;
+  if phase 2 verifies a codex/gemini OTEL channel, ingest design goes to
+  that question, not this probe).
+- Settings-precedence documentation for projected statuslines (7hzb
+  remainder, docs work, not research).


### PR DESCRIPTION
Files the research structure for the aae-orc-dc1j remainder so the next session runs one sweep instead of inventing per-runtime probe pairs: a two-phase brief (secondary desk catalog across codex/gemini/opencode/Crush, then primary live verification only for candidates that survive, finding-011 rig shape) with a kill rule to documented headless-only where no channel exports occupancy plus a denominator.

Also refreshes question-interactive-context-pressure, which still framed the decision as scrape-vs-headless-only from before the statusline solve; the node now records that interactive claude resolved via a third cooperative channel, names the per-runtime state, and rules out capture-pane scraping as a default path.

Docs and graph only; no code changes.