### PR TITLE
harvest: daemon isolation boundary opened from the runtime-socket probe

### DIFF
--- a/_kos/nodes/bedrock/elem-data-directory-permissions.yaml
+++ b/_kos/nodes/bedrock/elem-data-directory-permissions.yaml
@@ -31,6 +31,22 @@ content: |
   - Both default to the canonical paths above; empty string disables
 
   Evidence: session-025. `aae-orc-ax8`, `aae-orc-9d6` closed.
+
+  **Known incomplete (measured 2026-08-06).** The table above is the
+  on-disk layout, not the daemon's whole namespace. Two runtime
+  namespaces escape it and both are machine global: the control socket
+  (`/tmp/marvel.sock`, hardcoded at `config.go:19` and `daemon.go:39`,
+  never resolved through `internal/paths`) and the tmux session prefix
+  (`marvel-*` on the shared tmux server). Neither appears above.
+
+  This has a direct consequence for the `--pidfile` guard described in
+  this node. Its refuse-if-live semantics are real and on by default,
+  but the pid file is HOME scoped while the socket is machine global,
+  so the guard cannot protect the socket. Two daemons under different
+  HOMEs collide with no warning. Moving the socket into this layout is
+  what would make the guard load-bearing for it.
+
+  Open at `question-daemon-isolation-boundary`.
 edges:
   - target: elem-mrvl-protocol-ssh
     type: supports

--- a/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
+++ b/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
@@ -38,6 +38,24 @@ content: |
   Evidence: MVP functional with tmux driver across sessions 008-026;
   finding-004 (shim-in-pane spike), finding-005 (stream-attachment
   probe), both 2026-07-31.
+
+  **Property recorded 2026-08-06, not known when this was ratified.**
+  The substrate carries a machine-global namespace. Sessions are named
+  `marvel-*` on whichever tmux server the driver reaches, and by
+  default that is the user's shared one. A daemon starting up
+  reconciles that prefix against its own records and kills what it does
+  not recognise, so a second daemon destroys the first daemon's running
+  fleet. Measured independent of the control socket (distinct
+  `--socket` per daemon: the fleet still died) and independent of the
+  starting daemon's state. `MARVEL_TMUX_SOCKET` (consumed as
+  `tmux -L <name>` at `internal/tmux/driver.go:88`, a socket name and
+  not a path) isolates it cleanly, so the mechanism exists and the
+  default declines to use it.
+
+  This does not reopen the substrate decision. It records that
+  "tmux is the terminal and human-view layer" left the namespace
+  question unanswered. Open at `question-daemon-isolation-boundary`;
+  work item `aae-orc-kvcs`.
 edges:
   - target: aae-orc::elem-tmux-cmc
     type: derives

--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -1,0 +1,87 @@
+id: question-daemon-isolation-boundary
+type: question
+confidence: frontier
+title: "What is the isolation boundary for concurrent marvel daemons on one host?"
+tags:
+  - isolation
+  - security
+content: |
+  Marvel has no isolation unit between two daemons running on the same
+  machine. The layout in `elem-data-directory-permissions` is HOME
+  scoped and mode enforced, but at least two runtime namespaces escape
+  it, and both are machine global:
+
+  - **The control socket.** `config.DefaultSocket` is the literal
+    `/tmp/marvel.sock`, hardcoded in two places (`config.go:19` and
+    `daemon.go:39`), and never resolved through `internal/paths`.
+  - **The tmux session prefix.** `marvel-*` on whichever tmux server
+    the driver reaches, which by default is the user's shared one.
+
+  Measured 2026-08-06 in an isolated rig (HOME separated daemons,
+  simulator runtime, no model tokens):
+
+  - A second daemon takes the socket from the first. The `--pidfile`
+    guard, which does default to `$HOME/.marvel/run/daemon.pid` and
+    does carry sshd-style refuse-if-live semantics, cannot fire,
+    because the guard is HOME scoped while the socket is machine
+    global. A guard that already ships is structurally unable to
+    protect the thing it looks like it protects.
+  - A client that reaches the wrong daemon gets a well formed,
+    successful, empty answer with exit code 0. A mutating call
+    (`marvel work`) reports success against the wrong daemon.
+  - A second daemon kills the first daemon's entire running fleet
+    through the tmux prefix. Verified independent of the socket
+    (distinct `--socket` per daemon: the fleet still died) and
+    independent of the starting daemon's own state (populated store
+    carrying its own workspace: still killed). The rule is not "empty
+    state kills"; it is "any `marvel-*` session not in my records gets
+    killed."
+  - Both namespaces already have a working manual override, `--socket`
+    and `MARVEL_TMUX_SOCKET`, and the default declines to use either.
+  - A daemon restarting against its own records adopts correctly. The
+    discrimination is by record, not by prefix.
+
+  THE QUESTION, which is not the same as the bugs it was found through:
+
+  1. What is the isolation unit? Candidates: the HOME rooted layout
+     (one flag isolates everything), an explicit named instance, or a
+     declared cluster. The layout already exists and everything else
+     keys off it, which argues for it, but it puts the socket on the
+     home filesystem, where unix sockets do not work on NFS.
+  2. Should every machine global namespace be derived from that one
+     unit, so they cannot drift apart again? Two were found by
+     working one bug. Nothing establishes that two is the count.
+  3. What is the default posture toward state a daemon does not
+     recognise: adopt, leave alone, or kill? Kill is the current
+     default and it is unlogged.
+  4. Is this a precondition for multi host (`question-multi-host`)?
+     Cross host scheduling treats the host as the isolation unit,
+     which assumes within host isolation exists. It does not.
+
+  Bears on `question-permission-model`: an agent marvel spawned runs at
+  the same uid and can reach both namespaces. Scoping them is not an
+  authorization boundary and must not be described as one.
+
+  Probe: `aae-orc::_kos/probes/brief-marvel-runtime-socket-placement.md`
+  (run 1 results recorded 2026-08-06; still a probe, no fix built, so
+  nothing here is a finding).
+  Work items: `aae-orc-t6da` and `aae-orc-mh6g` (socket namespace),
+  `aae-orc-kvcs` (tmux namespace and the unlogged kill),
+  `aae-orc-sqh0` (the same uid question this does not answer).
+edges:
+  - target: elem-data-directory-permissions
+    type: derives
+    note: "the layout this question says is incomplete: the control socket appears nowhere in its table"
+  - target: elem-tmux-session-substrate
+    type: derives
+    note: "the second machine-global namespace is a property of the substrate choice, unrecorded when it was ratified"
+  - target: question-multi-host
+    type: supports
+    note: "within-host isolation is a precondition for treating the host as the scheduling unit"
+  - target: question-permission-model
+    type: supports
+    note: "scoping these namespaces is not authorization; same-uid agents reach both either way"
+provenance:
+  created_by: agent
+  session: "2026-08-06-marvel-socket-probe"
+  created_at: "2026-08-06"

--- a/_kos/nodes/frontier/question-multi-host.yaml
+++ b/_kos/nodes/frontier/question-multi-host.yaml
@@ -13,6 +13,15 @@ content: |
   marvel need its own discovery mechanism? What happens when a remote
   host becomes unreachable — drain, reschedule, or wait? How does
   volume management (worktrees, shared dirs) work across hosts?
+
+  **Precondition surfaced 2026-08-06.** This question treats the host
+  as the scheduling and isolation unit, which assumes isolation exists
+  within a host. It does not. Two daemons on one machine share the
+  control socket path and the tmux session prefix, and the second one
+  takes the socket and kills the first one's fleet. Whatever answers
+  `question-daemon-isolation-boundary` also decides what a Host
+  resource is actually a boundary around, so that question is worth
+  settling before the scheduling algorithm is designed on top of it.
 edges:
   - target: elem-mvp-complete
     type: discovered_from


### PR DESCRIPTION
Working `aae-orc-t6da` (the `/tmp/marvel.sock` collision) turned up something the ticket did not cover: marvel has no isolation unit between two daemons on the same host, and the destructive half of that is not fixed by anything in the socket work. A second daemon kills the first daemon's entire running fleet through the machine-global `marvel-*` tmux prefix. Measured with distinct sockets per daemon: the fleet still died. Three nodes currently read as though the HOME-scoped layout covers more than it does, so this corrects them and opens the question.

Nodes only. No code, no behavior change.

### New

`question-daemon-isolation-boundary` (frontier). What the isolation unit should be, whether every machine-global namespace should derive from it, what the default posture toward unrecognised state should be, and whether this is a precondition for multi-host.

### Amended

- `elem-data-directory-permissions` — the layout table is incomplete. The control socket appears nowhere in it, and the `--pidfile` guard this node documents is HOME-scoped, so it is structurally unable to protect a machine-global socket. Two daemons under different HOMEs collide with no warning.
- `elem-tmux-session-substrate` — records the machine-global prefix property, which was not known when the substrate was ratified. This does not reopen the kxce decision; it records that "tmux is the terminal and human-view layer" left the namespace question unanswered.
- `question-multi-host` — treats the host as the isolation unit, which assumes within-host isolation exists.

### Evidence

Isolated rig, 2026-08-06: HOME-separated daemons, simulator runtime, no model tokens. Socket theft with no guard firing; a client reaching the wrong daemon getting a successful empty answer with exit code 0; the fleet kill verified independent of the socket and independent of the starting daemon's own state; and `MARVEL_TMUX_SOCKET` confirmed to isolate cleanly, so both namespaces already have a working override the default declines to use.

### Not a finding

Nothing has been built or used, so nothing has been found. The probe brief and its run-1 results live in the orchestrator (`_kos/probes/brief-marvel-runtime-socket-placement.md`, separate PR). Work items: `aae-orc-t6da`, `aae-orc-mh6g`, `aae-orc-kvcs`, `aae-orc-sqh0`.

`kos validate`: 32 nodes, 0 failures, 0 parse errors. The remaining warnings are pre-existing cross-repo edge targets.