### PR TITLE
fix: name the acting daemon and emit an event when AdoptOrKill kills

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -472,8 +472,20 @@ Examples:
 					if sessRef == "" && ev.Team != "" {
 						sessRef = ev.Workspace + "/" + ev.Team
 					}
+					if sessRef == "" {
+						sessRef = ev.Workspace
+					}
+					// Actor rides in the message rather than its own
+					// column: it is set on a small minority of events,
+					// and a column sized to a "pid=N socket=PATH" string
+					// would push MESSAGE off the right of every row that
+					// does not carry one.
+					msg := ev.Message
+					if ev.Actor != "" {
+						msg = fmt.Sprintf("%s [by %s]", msg, ev.Actor)
+					}
 					_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-						ev.Timestamp.Format("15:04:05"), sev, ev.Kind, sessRef, ev.Message)
+						ev.Timestamp.Format("15:04:05"), sev, ev.Kind, sessRef, msg)
 				}
 				_ = tw.Flush()
 			}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -60,6 +60,18 @@ const (
 	// admits — audibly, here — and budget.on_unmeasured = "refuse" is how
 	// they ratify the fail-closed posture instead.
 	KindAdmissionUnmeasured Kind = "admission.unmeasured"
+	// KindReconcileAdopted records that a daemon claimed a live tmux pane
+	// it found matching its own recorded intent at startup.
+	KindReconcileAdopted Kind = "reconcile.adopted"
+	// KindReconcileKilled records that a daemon destroyed a marvel-* tmux
+	// entity it did not find in its own records. This is the most
+	// destructive act marvel performs and until aae-orc-kvcs it was the
+	// only state transition in session.Manager with no event: the log
+	// carried it, the ring did not, so `marvel events` was blank for a
+	// fleet kill. Warning severity, and Actor is always set, because the
+	// killed entity may belong to a second daemon that records nothing
+	// itself.
+	KindReconcileKilled Kind = "reconcile.killed"
 )
 
 // Agent-stream kinds. These are the runtime adapter vocabulary
@@ -110,6 +122,16 @@ type Event struct {
 	Team      string    `json:"team,omitempty"`
 	Role      string    `json:"role,omitempty"`
 	Session   string    `json:"session,omitempty"`
+	// Actor names the daemon process that took the action, as
+	// "pid=N socket=PATH". Empty on events whose actor is unambiguous.
+	//
+	// It exists because two daemons on one host append to the same
+	// ~/.marvel/log/daemon.log by default, so their lines interleave with
+	// nothing to tell them apart, and because the daemon whose work is
+	// destroyed records nothing at all. Set it on any event describing an
+	// action one daemon takes against state another daemon may own. See
+	// aae-orc-kvcs.
+	Actor string `json:"actor,omitempty"`
 	// Message is a short human-readable description. Keep it one
 	// line — operators scan dozens of these at a time.
 	Message string `json:"message"`

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -140,6 +140,8 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 		}
 	}
 
+	actor := m.actorID()
+
 	for _, name := range names {
 		if !strings.HasPrefix(name, prefix) {
 			continue
@@ -150,11 +152,19 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 		// Matches pre-L2 behavior for sessions marvel doesn't claim.
 		if _, gerr := m.store.GetWorkspace(workspace); gerr != nil {
 			if kerr := m.driver.KillSession(name); kerr != nil {
-				log.Printf("AdoptOrKill: kill unrecorded session %s: %v", name, kerr)
+				log.Printf("AdoptOrKill[%s]: kill unrecorded session %s: %v", actor, name, kerr)
 				continue
 			}
 			killed++
-			log.Printf("AdoptOrKill: killed unrecorded workspace tmux session %s", name)
+			log.Printf("AdoptOrKill[%s]: killed unrecorded workspace tmux session %s", actor, name)
+			events.Emit(m.Events, events.Event{
+				Kind:      events.KindReconcileKilled,
+				Severity:  events.SeverityWarning,
+				Workspace: workspace,
+				Actor:     actor,
+				Message: fmt.Sprintf(
+					"killed tmux session %s: workspace not in this daemon's records", name),
+			})
 			continue
 		}
 
@@ -168,22 +178,54 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 			if sessKey, ok := recordedByPane[p.ID]; ok {
 				adopted++
 				m.recordPanePID(sessKey, p.PID)
-				log.Printf("AdoptOrKill: adopted pane %s (session %s)", p.ID, sessKey)
+				log.Printf("AdoptOrKill[%s]: adopted pane %s (session %s)", actor, p.ID, sessKey)
+				events.Emit(m.Events, events.Event{
+					Kind:      events.KindReconcileAdopted,
+					Workspace: workspace,
+					Session:   sessKey,
+					Actor:     actor,
+					Message:   fmt.Sprintf("adopted pane %s", p.ID),
+				})
 			} else {
 				if kerr := m.driver.KillPane(p.ID); kerr != nil {
-					log.Printf("AdoptOrKill: kill unrecorded pane %s: %v", p.ID, kerr)
+					log.Printf("AdoptOrKill[%s]: kill unrecorded pane %s: %v", actor, p.ID, kerr)
 					continue
 				}
 				killed++
-				log.Printf("AdoptOrKill: killed unrecorded pane %s in workspace %s", p.ID, workspace)
+				log.Printf("AdoptOrKill[%s]: killed unrecorded pane %s in workspace %s", actor, p.ID, workspace)
+				events.Emit(m.Events, events.Event{
+					Kind:      events.KindReconcileKilled,
+					Severity:  events.SeverityWarning,
+					Workspace: workspace,
+					Actor:     actor,
+					Message: fmt.Sprintf(
+						"killed pane %s: not in this daemon's records", p.ID),
+				})
 			}
 		}
 	}
 
 	if adopted > 0 || killed > 0 {
-		log.Printf("AdoptOrKill: %d adopted, %d killed", adopted, killed)
+		log.Printf("AdoptOrKill[%s]: %d adopted, %d killed", actor, adopted, killed)
 	}
 	return adopted, killed, nil
+}
+
+// actorID identifies this daemon process in the log lines and events
+// AdoptOrKill produces. Two daemons on one host append to the same
+// ~/.marvel/log/daemon.log by default, so an unattributed line cannot be
+// traced to the process that wrote it, and the daemon whose panes are
+// killed records nothing itself. pid distinguishes processes; the socket
+// path distinguishes the instances an operator addresses.
+//
+// SocketPath is set by daemon.Start before AdoptOrKill runs. It is empty
+// in tests that drive the Manager directly, which is why the socket half
+// is omitted rather than rendered blank.
+func (m *Manager) actorID() string {
+	if m.SocketPath == "" {
+		return fmt.Sprintf("pid=%d", os.Getpid())
+	}
+	return fmt.Sprintf("pid=%d socket=%s", os.Getpid(), m.SocketPath)
 }
 
 // recordPanePID commits an adopted pane's pid to the recorded session.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,11 +1,15 @@
 package session
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
 	"github.com/arcavenae/marvel/internal/tmux"
 )
 
@@ -159,6 +163,126 @@ func TestAdoptOrKill_PrefixOnly(t *testing.T) {
 	}
 	if !driver.HasSession(outsider) {
 		t.Fatalf("non-prefix session %s must not be touched", outsider)
+	}
+}
+
+// A fleet kill has to reach the event ring, not only the log. Before
+// aae-orc-kvcs it reached neither in the collected artifact set: the
+// killing daemon's log carried the line, `marvel events` was blank, and
+// an independent reader given the victim's artifacts misattributed a
+// marvel-caused kill to the environment.
+func TestAdoptOrKillEmitsKilledEventNamingTheActor(t *testing.T) {
+	skipIfNoTmux(t)
+
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	prefix := "marvel-killevent-"
+	victim := prefix + "alpha"
+	if err := driver.NewSession(victim); err != nil {
+		t.Fatalf("new session %s: %v", victim, err)
+	}
+	t.Cleanup(func() { _ = driver.KillSession(victim) })
+
+	ring := events.NewRing(10)
+	mgr := NewManager(api.NewStore(), driver)
+	mgr.Events = ring
+	mgr.SocketPath = "/tmp/marvel-killevent.sock"
+
+	if _, killed, err := mgr.adoptOrKillPrefix(prefix); err != nil {
+		t.Fatalf("adoptOrKillPrefix: %v", err)
+	} else if killed != 1 {
+		t.Fatalf("killed = %d, want 1", killed)
+	}
+
+	got := ring.Snapshot(events.Filter{Kind: events.KindReconcileKilled}, 0)
+	if len(got) != 1 {
+		t.Fatalf("reconcile.killed events = %d, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.Severity != events.SeverityWarning {
+		t.Errorf("severity = %q, want %q", ev.Severity, events.SeverityWarning)
+	}
+	if ev.Workspace != "alpha" {
+		t.Errorf("workspace = %q, want %q", ev.Workspace, "alpha")
+	}
+	// The actor is the whole point: with two daemons appending to one
+	// log file, an event that does not name the process that acted
+	// cannot be traced back to it.
+	wantActor := fmt.Sprintf("pid=%d socket=/tmp/marvel-killevent.sock", os.Getpid())
+	if ev.Actor != wantActor {
+		t.Errorf("actor = %q, want %q", ev.Actor, wantActor)
+	}
+	if !strings.Contains(ev.Message, victim) {
+		t.Errorf("message %q does not name the killed session %q", ev.Message, victim)
+	}
+}
+
+// An adopted pane emits too, so the ring shows both halves of a
+// reconcile pass and an operator can tell "adopted mine" from "killed
+// something else's" without reading the log.
+func TestAdoptOrKillEmitsAdoptedEvent(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-adopt-event"
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &api.Session{
+		Name:      "t-r-g1-0",
+		Workspace: ws,
+		Team:      "t",
+		Role:      "r",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	ring := events.NewRing(10)
+	mgr.Events = ring
+
+	if adopted, _, err := mgr.AdoptOrKill(); err != nil {
+		t.Fatalf("AdoptOrKill: %v", err)
+	} else if adopted < 1 {
+		t.Fatalf("adopted = %d, want at least 1", adopted)
+	}
+
+	got := ring.Snapshot(events.Filter{Kind: events.KindReconcileAdopted}, 0)
+	if len(got) < 1 {
+		t.Fatalf("reconcile.adopted events = %d, want at least 1", len(got))
+	}
+	if got[0].Actor == "" {
+		t.Error("adopted event has no actor")
+	}
+	if got[0].Session != sess.Key() {
+		t.Errorf("session = %q, want %q", got[0].Session, sess.Key())
+	}
+}
+
+// actorID omits the socket half rather than rendering it blank, so a
+// Manager driven directly by a test still produces a usable identity.
+func TestActorIDOmitsUnsetSocket(t *testing.T) {
+	mgr := NewManager(api.NewStore(), nil)
+
+	if got, want := mgr.actorID(), fmt.Sprintf("pid=%d", os.Getpid()); got != want {
+		t.Errorf("actorID with no socket = %q, want %q", got, want)
+	}
+
+	mgr.SocketPath = "/run/user/501/marvel/marvel.sock"
+	want := fmt.Sprintf("pid=%d socket=/run/user/501/marvel/marvel.sock", os.Getpid())
+	if got := mgr.actorID(); got != want {
+		t.Errorf("actorID with socket = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
When a second marvel daemon starts, it reconciles the machine-global `marvel-*` tmux namespace against its own records and kills every session it does not recognise, destroying the first daemon's running fleet. That behavior is tracked separately (`aae-orc-kvcs`) and is not fixed here. What this PR fixes is that the kill was close to unattributable.

The kill was recorded only as a bare `log.Printf` line. `marvel events` was blank for the most destructive act marvel performs, while every neighbouring transition (session created, deleted, crashed) emits. The line named the victim and never the actor, and two daemons append to the same `~/.marvel/log/daemon.log` by default, so their lines interleave with nothing to tell them apart. The daemon whose panes die records nothing at all.

The cost of that showed up in a measurement on 2026-08-06. An independent analyst, given a victim daemon's artifact set plus the marvel source and no knowledge of the investigation, correctly judged that something external had interfered, then concluded it was an external kill or a sandbox teardown and explicitly ruled marvel out. A second daemon never entered their model, because nothing in the artifacts indicates one can exist. The operator-facing failure is not a fleet that dies mysteriously; it is a fleet that dies and points confidently at the wrong culprit.

## Changes

- `internal/events`: two kinds, `reconcile.adopted` (info) and `reconcile.killed` (warning), plus an additive `Actor` field carrying `pid=N socket=PATH`. `omitempty`, so the JSON surface is unchanged for every existing event.
- `internal/session`: `adoptOrKillPrefix` emits both kinds and prefixes its log lines with the actor. `actorID` omits the socket half when `SocketPath` is unset rather than rendering it blank, which is the case for a `Manager` driven directly by a test.
- `cmd/marvel`: `marvel events` renders the actor as a message suffix rather than its own column, because it is set on a minority of events and a column sized to a socket path would push `MESSAGE` off the right of every row without one. Also falls back to the workspace when an event names no session, which a whole-tmux-session kill does not.

`Actor` is set on any event describing an action one daemon takes against state another daemon may own.

## Cost of merge

Additive only. No existing event changes shape, no existing behavior changes, and the kill path is untouched apart from what it records.

## What this does not do

This does not make concurrent daemons safe. It makes one of them attributable. The `marvel-*` tmux prefix is still machine-global, the default posture toward unrecognised state is still kill, and the victim still records nothing. Those are `aae-orc-kvcs` decisions 1 to 3 and are being decided in a design document alongside the runtime socket (`aae-orc-mh6g` item 0).

## Tests

Three added, all passing, `0 issues` from golangci-lint at CI's pinned v2.10.1:

- `TestAdoptOrKillEmitsKilledEventNamingTheActor` asserts kind, warning severity, workspace, the exact actor string, and that the message names the killed session.
- `TestAdoptOrKillEmitsAdoptedEvent` covers the adopt half against a real spawned session.
- `TestActorIDOmitsUnsetSocket` covers both actor shapes.

Refs: aae-orc-kvcs