### PR TITLE
harvest: question-daemon-isolation-boundary — the kill was logged all along, the event was not

### DIFF
--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -41,6 +41,28 @@ content: |
   - A daemon restarting against its own records adopts correctly. The
     discrimination is by record, not by prefix.
 
+  Corrected 2026-08-07, read-only on kinu. An earlier reading of these
+  runs held that the kill was unlogged and that a careful analyst
+  therefore misattributes it. Both need qualifying:
+
+  - The kill was always logged. `adoptOrKillPrefix` logs each kill and a
+    summary, `log.SetOutput` is installed before `Start` runs it, and
+    `--log-file` defaults to `~/.marvel/log/daemon.log`. That file
+    carries 11 such lines on this machine.
+  - The rig saw silence because stderr is teed only when it is a
+    terminal, and because HOME separation split the two daemons' log
+    files. In the default case both daemons append to one file, so the
+    kill line is in the obvious place. The misattribution result is a
+    property of that artifact set.
+  - What was genuinely absent: any structured event, so `marvel events`
+    was blank for the most destructive act marvel performs while every
+    neighbouring session transition emits; and any actor identity on the
+    line, so interleaved lines in a shared file could not be traced to a
+    process. Both shipped in marvel PR #118 as `reconcile.adopted` and
+    `reconcile.killed` with an additive `Event.Actor` field.
+  - Still absent, and not fixable from the acting daemon: the daemon
+    whose panes are killed records nothing.
+
   THE QUESTION, which is not the same as the bugs it was found through:
 
   1. What is the isolation unit? Candidates: the HOME rooted layout
@@ -53,7 +75,8 @@ content: |
      working one bug. Nothing establishes that two is the count.
   3. What is the default posture toward state a daemon does not
      recognise: adopt, leave alone, or kill? Kill is the current
-     default and it is unlogged.
+     default. It is now logged and evented with the acting daemon
+     named, which makes it attributable but no less destructive.
   4. Is this a precondition for multi host (`question-multi-host`)?
      Cross host scheduling treats the host as the isolation unit,
      which assumes within host isolation exists. It does not.
@@ -63,8 +86,10 @@ content: |
   authorization boundary and must not be described as one.
 
   Probe: `aae-orc::_kos/probes/brief-marvel-runtime-socket-placement.md`
-  (run 1 results recorded 2026-08-06; still a probe, no fix built, so
-  nothing here is a finding).
+  (run 1 recorded 2026-08-06, corrected and closed 2026-08-07). The
+  probe is complete; no fix to either namespace has been built, so
+  nothing about the isolation boundary itself is a finding yet. The one
+  shipped change, PR #118, is attribution, not isolation.
   Work items: `aae-orc-t6da` and `aae-orc-mh6g` (socket namespace),
   `aae-orc-kvcs` (tmux namespace and the unlogged kill),
   `aae-orc-sqh0` (the same uid question this does not answer).


### PR DESCRIPTION
The isolation-boundary node carried two claims from the 2026-08-06 runs that do not survive a source read, and one of them is the claim the whole severity argument rests on. Correcting them now keeps the next session from building on it.

Verified read-only on kinu; no daemon was started.

**The kill was never unlogged.** `adoptOrKillPrefix` logs each kill and a summary, `log.SetOutput` is installed at `cmd/marvel/main.go:238` before `Start` runs `AdoptOrKill`, and `--log-file` defaults to `~/.marvel/log/daemon.log`. That file on this machine holds 11 `AdoptOrKill` lines, kills included, appending across restarts since April.

The rig saw silence for two reasons that are both artifacts of the rig: stderr is teed only when it is a terminal, so a backgrounded daemon writes almost nothing to redirected stderr; and HOME separation, adopted as a safety measure, also separated the two daemons' log files. In the default case both daemons append to one file, so the kill line lands in the first file an operator would open.

**That qualifies the misattribution result.** The analyst who ruled marvel out was working from an artifact set that omitted the acting daemon's log, under a split the default case does not have. It is a property of that artifact set, not of marvel, and the priority-raise argument built on it is weaker than the runs stated.

**What was genuinely absent** was the structured event, so `marvel events` was blank for a fleet kill while every neighbouring session transition emits, and any actor identity on the line, so interleaved lines in a shared file could not be traced to a process. Both shipped in #118.

**What remains absent** is any record on the daemon whose panes are killed. No change in the acting daemon can supply it, and it stays open on `aae-orc-kvcs`.

Also updates question 3's framing (kill is still the default posture, now attributable rather than silent) and the probe pointer, since `aae-orc-ppqb` closed 2026-08-07.

Node only; no code. `kos validate` passes: 32 nodes, 0 failed, 0 parse errors.

Refs: aae-orc-kvcs, aae-orc-ppqb