### PR TITLE
fix: leave unrecorded tmux state running instead of destroying it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,11 @@ Recovery behavior, all shipped:
 - **`crashed`** is the transition state `ReapDead` sets when a pane is
   gone, distinguishing a dead process from a drained one.
 - **Adopt-on-restart.** A restarted daemon rehydrates the store and runs
-  `AdoptOrKill` against the live panes; agents survive the daemon.
+  `AdoptOrLeave` against the live panes; agents survive the daemon. Panes
+  it has no record of are left running and reported (`reconcile.left`),
+  not destroyed. Reclaiming is deliberate: `marvel daemon --reclaim`, or
+  `marvel reap --confirm`. Ratified 2026-08-07, err on accumulation
+  rather than destruction; see `docs/design/daemon-isolation.md`.
 - **SIGTERM is detach, not teardown.** `marvel stop` leaves agents
   running; `marvel stop --teardown` is the destructive form.
 - **Shift timeout with rollback.** A shift that cannot finish inside the
@@ -299,6 +303,8 @@ marvel scale <workspace/team> --role <r> --replicas N  # scale a role within a t
 marvel shift <workspace/team> [--role <r>]             # rolling shift (replace sessions with fresh ones)
 marvel run <command> [args...] --role <r>             # run a one-off agent session
 marvel kill <session-key>                            # kill a session
+marvel reap                                          # list marvel tmux state the daemon does not own
+marvel reap --confirm                                # destroy it
 marvel stop                                          # stop daemon, agents keep running (restart adopts them)
 marvel stop --teardown                               # stop daemon, delete sessions, kill panes
 marvel daemon                                        # start the daemon (foreground)

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -132,6 +132,7 @@ func main() {
 	root.AddCommand(configCmd())
 	root.AddCommand(stopCmd())
 	root.AddCommand(eventsCmd())
+	root.AddCommand(reapCmd())
 	root.AddCommand(newCtxForwardCmd())
 
 	if err := root.Execute(); err != nil {
@@ -171,6 +172,7 @@ func daemonCmd() *cobra.Command {
 	var logMaxTotalMiB int
 	var stateBoltPath string
 	var shiftTimeout time.Duration
+	var reclaim bool
 
 	layout, _ := paths.Default()
 	defaultLog := ""
@@ -236,6 +238,7 @@ Examples:
 				PidFile:      pidFilePath,
 				StateBolt:    stateBoltPath,
 				ShiftTimeout: shiftTO,
+				Reclaim:      reclaim,
 			})
 			if err != nil {
 				return err
@@ -306,6 +309,8 @@ Examples:
 	f.NoOptDefVal = ":" + config.DefaultMRVLPort
 	cmd.Flags().StringVar(&listenSocket, "socket", "",
 		"Unix socket path (default "+config.DefaultSocket()+", or $"+config.SocketEnv+")")
+	cmd.Flags().BoolVar(&reclaim, "reclaim", false,
+		"destroy marvel tmux state this daemon does not own, instead of leaving it running")
 	cmd.Flags().StringVar(&logFilePath, "log-file", defaultLog,
 		"tee daemon stderr to this file (empty string disables)")
 	cmd.Flags().StringVar(&pidFilePath, "pidfile", defaultPid,
@@ -602,6 +607,62 @@ func openRotatingLog(path string, maxSizeMiB, maxFiles, maxTotalMiB int) (io.Clo
 		return nil, fmt.Errorf("open rotating log %s: %w", path, err)
 	}
 	return w, nil
+}
+
+// reapCmd is the deliberate counterpart to the default leave-alone
+// posture. It prints what it would destroy and stops; --confirm is what
+// actually destroys it.
+//
+// Showing first is not politeness, it is the ruling. Leaving unrecorded
+// state alone was chosen precisely because destruction should be an act
+// an operator takes with their eyes open, so a reap that killed on sight
+// would put the original failure back behind a new name.
+func reapCmd() *cobra.Command {
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   "reap",
+		Short: "List (and with --confirm, destroy) marvel tmux state the daemon does not own",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, _ := json.Marshal(map[string]bool{"confirm": confirm})
+			resp, err := send(daemon.Request{Method: "reap", Params: params})
+			if err != nil {
+				return err
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+
+			var result struct {
+				Reaped     bool     `json:"reaped"`
+				Killed     int      `json:"killed"`
+				Candidates []string `json:"candidates"`
+			}
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				return fmt.Errorf("parse reap result: %w", err)
+			}
+
+			if len(result.Candidates) == 0 {
+				fmt.Println("Nothing to reap: every marvel tmux session is in the daemon's records.")
+				return nil
+			}
+
+			for _, c := range result.Candidates {
+				fmt.Println("  " + c)
+			}
+			if result.Reaped {
+				fmt.Printf("\nReaped %d.\n", result.Killed)
+				return nil
+			}
+			fmt.Printf("\n%d unrecorded item(s), left running. Re-run with --confirm to destroy them.\n",
+				len(result.Candidates))
+			fmt.Println("These may belong to another running daemon. Check before confirming.")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false,
+		"actually destroy the listed state (without this, reap only lists)")
+	return cmd
 }
 
 func workCmd() *cobra.Command {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,9 +137,23 @@ The team controller runs a reconciliation loop every 2 seconds:
 Recovery is separate: it runs once at daemon start, not on the loop.
 `RehydrateRoleHealth` loads the persisted crash-loop state before the
 reconciler starts, so a role frozen at `MaxRestarts` stays held back across a
-restart instead of getting a free respawn. `AdoptOrKill` then reconciles the
+restart instead of getting a free respawn. `AdoptOrLeave` then reconciles the
 live tmux panes against the rehydrated store, which is what lets agents
 survive the daemon.
+
+Panes matching the rehydrated intent are adopted. Anything else under the
+`marvel-*` prefix is **left running and reported** as a `reconcile.left`
+warning naming the acting daemon. Killing it is a deliberate act:
+`marvel daemon --reclaim` at startup, or `marvel reap --confirm` against a
+running daemon. `marvel reap` on its own lists the candidates and destroys
+nothing.
+
+Kill used to be the default, so an ordinary `marvel daemon` destroyed the
+entire running fleet of any other daemon sharing the tmux server. Reversed
+2026-08-07: err on silent accumulation, not silent destruction. Orphaned
+panes cost memory and can be reclaimed whenever an operator notices;
+destroyed work cannot be recovered. See
+`docs/design/daemon-isolation.md` decision 5.
 
 ## Shift mechanics
 

--- a/docs/design/daemon-isolation.md
+++ b/docs/design/daemon-isolation.md
@@ -350,6 +350,11 @@ rejecting a mismatch, which is authorization-shaped and belongs with
 
 ## Build sequence
 
+Status, 2026-08-07: steps 1 to 4 shipped in `ArcavenAE/marvel#122`, step
+7 in `#123`. Steps 5 and 6 are open. Step 6 was sequenced after 7 in the
+end, because 7 is what stops the destruction and 6 only lowers its
+frequency.
+
 1. Decision 2. Socket resolves through `Layout`, both hardcode sites
    removed, `RuntimeSocket()` reconciled or deleted, path-length
    assertion as a test.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -109,6 +109,11 @@ type Daemon struct {
 	// exclusion.
 	socketLock *socketLock
 
+	// reclaim makes the startup reconcile destroy marvel-* tmux state
+	// this daemon does not own, instead of leaving it running. Off by
+	// default; `marvel daemon --reclaim` is the deliberate act.
+	reclaim bool
+
 	// In-memory ring of the most recent log lines. Always non-nil.
 	logs *logbuf.Buffer
 
@@ -161,6 +166,12 @@ type Options struct {
 	// timeout without a 10-minute wait) via the daemon's --shift-timeout
 	// flag or MARVEL_SHIFT_TIMEOUT. See aae-orc-sape / ArcavenAE/marvel#88.
 	ShiftTimeout time.Duration
+	// Reclaim makes the startup reconcile pass destroy marvel-* tmux
+	// state this daemon does not own, rather than leaving it running and
+	// reporting it. The zero value is the ratified default (leave alone).
+	// Exposed as `marvel daemon --reclaim` for the operator who knows the
+	// host is theirs and wants it clean. See aae-orc-kvcs.
+	Reclaim bool
 	// ContextLimits, when non-nil, replaces the shipped model-to-window
 	// table the usage accountant resolves denominators against. Tests set
 	// it so a fixture's model does not have to be a real shipped entry.
@@ -226,6 +237,7 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 		teamCtrl: teamCtrl,
 		driver:   driver,
 		pidFile:  opts.PidFile,
+		reclaim:  opts.Reclaim,
 		logs:     buf,
 		events:   evRing,
 		usage:    acct,
@@ -293,14 +305,22 @@ func (d *Daemon) Start(socketPath string) error {
 		}
 	}
 
-	// Reconcile marvel-* tmux state against recorded intent. With L2
-	// (bbolt) in use, panes that match the rehydrated intent are
-	// adopted (kept alive). Without L2 the store is empty and this
-	// degenerates to kill-all — the pre-Session-2 behavior of
-	// ArcavenAE/marvel#13's CleanupOrphanTmux fix. See orc finding-050
-	// (Session 2 of aae-orc-k4e4) for the architectural pivot.
-	if _, _, err := d.sessMgr.AdoptOrKill(); err != nil {
-		log.Printf("AdoptOrKill on startup: %v", err)
+	// Reconcile marvel-* tmux state against recorded intent. Panes that
+	// match the rehydrated intent are adopted; anything else is LEFT
+	// RUNNING and reported, unless the operator asked to reclaim.
+	//
+	// Kill used to be the default here, and without L2 the store is
+	// empty, so it degenerated to kill-all (ArcavenAE/marvel#13's
+	// CleanupOrphanTmux fix, orc finding-050). That is what let an
+	// ordinary `marvel daemon` destroy another daemon's entire running
+	// fleet. Reversed 2026-08-07 per docs/design/daemon-isolation.md
+	// decision 5: err on accumulation, not destruction.
+	reconcile, what := d.sessMgr.AdoptOrLeave, "AdoptOrLeave"
+	if d.reclaim {
+		reconcile, what = d.sessMgr.AdoptOrKill, "AdoptOrKill"
+	}
+	if _, _, err := reconcile(); err != nil {
+		log.Printf("%s on startup: %v", what, err)
 	}
 
 	// Announced from Start, not from the constructor. cmd/marvel installs
@@ -575,6 +595,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleDelete(req.Params)
 	case "scale":
 		return d.handleScale(req.Params)
+	case "reap":
+		return d.handleReap(req.Params)
 	case "heartbeat":
 		return d.handleHeartbeat(req.Params)
 	case "run":
@@ -1213,6 +1235,50 @@ func stopMode(params json.RawMessage) (teardown bool, mode string, err error) {
 		return true, "teardown", nil
 	}
 	return false, "detach", nil
+}
+
+// handleReap lists marvel-* tmux state this daemon does not own and,
+// only when the caller confirms, destroys it.
+//
+// It is the other half of the 2026-08-07 ruling. Leaving unrecorded
+// state alone is the safe default, and it accumulates; this is how an
+// operator clears it deliberately, having seen what they are about to
+// lose. Confirmation is the caller's explicit flag, never inferred, so
+// the destructive branch cannot be reached by a command that merely
+// looks like a query.
+func (d *Daemon) handleReap(params json.RawMessage) Response {
+	var p struct {
+		Confirm bool `json:"confirm"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return Response{Error: fmt.Sprintf("bad params: %v", err)}
+		}
+	}
+
+	found, err := d.sessMgr.UnrecordedTmuxState()
+	if err != nil {
+		return Response{Error: err.Error()}
+	}
+
+	if !p.Confirm {
+		result, _ := json.Marshal(map[string]any{
+			"reaped":     false,
+			"candidates": found,
+		})
+		return Response{Result: result}
+	}
+
+	_, killed, err := d.sessMgr.AdoptOrKill()
+	if err != nil {
+		return Response{Error: err.Error()}
+	}
+	result, _ := json.Marshal(map[string]any{
+		"reaped":     true,
+		"killed":     killed,
+		"candidates": found,
+	})
+	return Response{Result: result}
 }
 
 func (d *Daemon) handleStop(params json.RawMessage) Response {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -72,6 +72,16 @@ const (
 	// killed entity may belong to a second daemon that records nothing
 	// itself.
 	KindReconcileKilled Kind = "reconcile.killed"
+	// KindReconcileLeft records that a daemon found marvel-* tmux state
+	// it does not own and left it running, which is the default posture
+	// ratified 2026-08-07.
+	//
+	// Warning severity on purpose. The ruling accepted accumulating
+	// orphans as the better of two failures, and an accepted failure that
+	// nobody can see is just the other one wearing a different hat. This
+	// is the event that keeps "leave it alone" from being as silent as
+	// the kill it replaced.
+	KindReconcileLeft Kind = "reconcile.left"
 )
 
 // Agent-stream kinds. These are the runtime adapter vocabulary

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -118,13 +118,53 @@ func tmuxSessionName(workspace string) string {
 // See orc finding-050 (this session) and aae-orc-72u (the empirical
 // orphan-pane bug that motivated the original kill-all behavior).
 func (m *Manager) AdoptOrKill() (adopted, killed int, err error) {
-	return m.adoptOrKillPrefix(marvelSessionPrefix)
+	return m.reconcilePrefix(marvelSessionPrefix, KillUnrecorded)
 }
 
-// adoptOrKillPrefix is the prefix-parameterized core of AdoptOrKill.
-// Tests use a unique prefix so they don't collide with other tmux-using
-// tests running in parallel packages.
+// AdoptOrLeave adopts panes matching recorded intent and LEAVES
+// everything else running, reporting it rather than destroying it.
+//
+// This is the default posture, ratified 2026-08-07: err on silent
+// accumulation, not silent destruction. An orphaned pane costs memory
+// and clutter and can be reclaimed whenever an operator notices.
+// Destroyed work cannot be recovered at all.
+//
+// The behavior this replaced killed any marvel-* session not in the
+// starting daemon's records, which destroyed a second daemon's entire
+// running fleet on an ordinary action with no confirmation. Measured
+// 2026-08-06, independent of the socket and independent of the starting
+// daemon's own state. See aae-orc-kvcs and
+// docs/design/daemon-isolation.md decision 5.
+//
+// Reclaiming is still available, deliberately: `marvel daemon --reclaim`
+// and the reaper verb.
+func (m *Manager) AdoptOrLeave() (adopted, left int, err error) {
+	return m.reconcilePrefix(marvelSessionPrefix, LeaveUnrecorded)
+}
+
+// UnrecordedPolicy is what a reconcile pass does with marvel-* tmux
+// state that is not in this daemon's records.
+type UnrecordedPolicy int
+
+const (
+	// LeaveUnrecorded reports unrecorded state and leaves it running.
+	// The default.
+	LeaveUnrecorded UnrecordedPolicy = iota
+	// KillUnrecorded destroys it. Reachable only through an explicit
+	// operator act: `marvel daemon --reclaim` or the reaper.
+	KillUnrecorded
+)
+
+// adoptOrKillPrefix preserves the kill-policy entry point for tests that
+// assert the reclaim behavior against a unique prefix.
 func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err error) {
+	return m.reconcilePrefix(prefix, KillUnrecorded)
+}
+
+// reconcilePrefix is the prefix-parameterized core. Tests use a unique
+// prefix so they don't collide with other tmux-using tests running in
+// parallel packages.
+func (m *Manager) reconcilePrefix(prefix string, policy UnrecordedPolicy) (adopted, acted int, err error) {
 	names, err := m.driver.ListSessions()
 	if err != nil {
 		return 0, 0, fmt.Errorf("list tmux sessions: %w", err)
@@ -142,21 +182,45 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 
 	actor := m.actorID()
 
+	// The log lines name the policy, because the two passes differ only
+	// in what they do to state they do not recognise, and a reader
+	// diagnosing a missing fleet needs to know which one ran.
+	verb, pastTense := "AdoptOrLeave", "left running"
+	if policy == KillUnrecorded {
+		verb, pastTense = "AdoptOrKill", "killed"
+	}
+
 	for _, name := range names {
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
 		workspace := strings.TrimPrefix(name, prefix)
 
-		// Workspace not recorded → kill the whole tmux session.
-		// Matches pre-L2 behavior for sessions marvel doesn't claim.
+		// Workspace not recorded. Under the default policy this is
+		// somebody else's, or our own leftovers, and either way it keeps
+		// running and gets reported.
 		if _, gerr := m.store.GetWorkspace(workspace); gerr != nil {
-			if kerr := m.driver.KillSession(name); kerr != nil {
-				log.Printf("AdoptOrKill[%s]: kill unrecorded session %s: %v", actor, name, kerr)
+			if policy == LeaveUnrecorded {
+				acted++
+				log.Printf("%s[%s]: left tmux session %s running: workspace not in this daemon's records",
+					verb, actor, name)
+				events.Emit(m.Events, events.Event{
+					Kind:      events.KindReconcileLeft,
+					Severity:  events.SeverityWarning,
+					Workspace: workspace,
+					Actor:     actor,
+					Message: fmt.Sprintf(
+						"left tmux session %s running: workspace not in this daemon's records. "+
+							"Reclaim with `marvel reap` if it is stale", name),
+				})
 				continue
 			}
-			killed++
-			log.Printf("AdoptOrKill[%s]: killed unrecorded workspace tmux session %s", actor, name)
+			if kerr := m.driver.KillSession(name); kerr != nil {
+				log.Printf("%s[%s]: kill unrecorded session %s: %v", verb, actor, name, kerr)
+				continue
+			}
+			acted++
+			log.Printf("%s[%s]: killed unrecorded workspace tmux session %s", verb, actor, name)
 			events.Emit(m.Events, events.Event{
 				Kind:      events.KindReconcileKilled,
 				Severity:  events.SeverityWarning,
@@ -178,7 +242,7 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 			if sessKey, ok := recordedByPane[p.ID]; ok {
 				adopted++
 				m.recordPanePID(sessKey, p.PID)
-				log.Printf("AdoptOrKill[%s]: adopted pane %s (session %s)", actor, p.ID, sessKey)
+				log.Printf("%s[%s]: adopted pane %s (session %s)", verb, actor, p.ID, sessKey)
 				events.Emit(m.Events, events.Event{
 					Kind:      events.KindReconcileAdopted,
 					Workspace: workspace,
@@ -186,29 +250,88 @@ func (m *Manager) adoptOrKillPrefix(prefix string) (adopted, killed int, err err
 					Actor:     actor,
 					Message:   fmt.Sprintf("adopted pane %s", p.ID),
 				})
-			} else {
-				if kerr := m.driver.KillPane(p.ID); kerr != nil {
-					log.Printf("AdoptOrKill[%s]: kill unrecorded pane %s: %v", actor, p.ID, kerr)
-					continue
-				}
-				killed++
-				log.Printf("AdoptOrKill[%s]: killed unrecorded pane %s in workspace %s", actor, p.ID, workspace)
+				continue
+			}
+			if policy == LeaveUnrecorded {
+				acted++
+				log.Printf("%s[%s]: left pane %s running in workspace %s: not in this daemon's records",
+					verb, actor, p.ID, workspace)
 				events.Emit(m.Events, events.Event{
-					Kind:      events.KindReconcileKilled,
+					Kind:      events.KindReconcileLeft,
 					Severity:  events.SeverityWarning,
 					Workspace: workspace,
 					Actor:     actor,
 					Message: fmt.Sprintf(
-						"killed pane %s: not in this daemon's records", p.ID),
+						"left pane %s running: not in this daemon's records. "+
+							"Reclaim with `marvel reap` if it is stale", p.ID),
 				})
+				continue
 			}
+			if kerr := m.driver.KillPane(p.ID); kerr != nil {
+				log.Printf("%s[%s]: kill unrecorded pane %s: %v", verb, actor, p.ID, kerr)
+				continue
+			}
+			acted++
+			log.Printf("%s[%s]: killed unrecorded pane %s in workspace %s", verb, actor, p.ID, workspace)
+			events.Emit(m.Events, events.Event{
+				Kind:      events.KindReconcileKilled,
+				Severity:  events.SeverityWarning,
+				Workspace: workspace,
+				Actor:     actor,
+				Message: fmt.Sprintf(
+					"killed pane %s: not in this daemon's records", p.ID),
+			})
 		}
 	}
 
-	if adopted > 0 || killed > 0 {
-		log.Printf("AdoptOrKill[%s]: %d adopted, %d killed", actor, adopted, killed)
+	if adopted > 0 || acted > 0 {
+		log.Printf("%s[%s]: %d adopted, %d %s", verb, actor, adopted, acted, pastTense)
 	}
-	return adopted, killed, nil
+	return adopted, acted, nil
+}
+
+// UnrecordedTmuxState returns the marvel-* tmux entities this daemon
+// does not have records for: the ones AdoptOrLeave leaves running and
+// AdoptOrKill would destroy.
+//
+// It exists so `marvel reap` can show an operator what they are about to
+// lose before they lose it. Read-only, and deliberately computed the
+// same way the reconcile pass computes it, so the preview and the action
+// cannot disagree.
+func (m *Manager) UnrecordedTmuxState() ([]string, error) {
+	names, err := m.driver.ListSessions()
+	if err != nil {
+		return nil, fmt.Errorf("list tmux sessions: %w", err)
+	}
+
+	recordedByPane := make(map[string]string)
+	for _, sess := range m.store.ListSessions() {
+		if sess.PaneID != "" {
+			recordedByPane[sess.PaneID] = sess.Key()
+		}
+	}
+
+	var found []string
+	for _, name := range names {
+		if !strings.HasPrefix(name, marvelSessionPrefix) {
+			continue
+		}
+		workspace := strings.TrimPrefix(name, marvelSessionPrefix)
+		if _, gerr := m.store.GetWorkspace(workspace); gerr != nil {
+			found = append(found, fmt.Sprintf("tmux session %s (whole workspace)", name))
+			continue
+		}
+		panes, lerr := m.driver.ListPanes(name)
+		if lerr != nil {
+			continue
+		}
+		for _, p := range panes {
+			if _, ok := recordedByPane[p.ID]; !ok {
+				found = append(found, fmt.Sprintf("pane %s in workspace %s", p.ID, workspace))
+			}
+		}
+	}
+	return found, nil
 }
 
 // actorID identifies this daemon process in the log lines and events

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -286,6 +286,136 @@ func TestActorIDOmitsUnsetSocket(t *testing.T) {
 	}
 }
 
+// The ratified default: err on silent accumulation, not silent
+// destruction (2026-08-07). Before this, a plain `marvel daemon` killed
+// every marvel-* session it did not have records for, which destroyed a
+// second daemon's entire running fleet on an ordinary action.
+func TestAdoptOrLeaveLeavesUnrecordedStateRunning(t *testing.T) {
+	skipIfNoTmux(t)
+
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	prefix := "marvel-leavetest-"
+	other := prefix + "someone-elses-fleet"
+	if err := driver.NewSession(other); err != nil {
+		t.Fatalf("new session %s: %v", other, err)
+	}
+	t.Cleanup(func() { _ = driver.KillSession(other) })
+
+	ring := events.NewRing(10)
+	mgr := NewManager(api.NewStore(), driver)
+	mgr.Events = ring
+
+	_, left, err := mgr.reconcilePrefix(prefix, LeaveUnrecorded)
+	if err != nil {
+		t.Fatalf("reconcilePrefix: %v", err)
+	}
+	if left != 1 {
+		t.Fatalf("left = %d, want 1", left)
+	}
+	if !driver.HasSession(other) {
+		t.Fatal("unrecorded session was destroyed; the default must leave it running")
+	}
+
+	// Left alone must not mean unreported, or the ruling trades one
+	// silent failure for another.
+	got := ring.Snapshot(events.Filter{Kind: events.KindReconcileLeft}, 0)
+	if len(got) != 1 {
+		t.Fatalf("reconcile.left events = %d, want 1", len(got))
+	}
+	if got[0].Severity != events.SeverityWarning {
+		t.Errorf("severity = %q, want %q", got[0].Severity, events.SeverityWarning)
+	}
+	if got[0].Actor == "" {
+		t.Error("left event has no actor")
+	}
+	if killed := ring.Snapshot(events.Filter{Kind: events.KindReconcileKilled}, 0); len(killed) != 0 {
+		t.Errorf("emitted %d kill events under the leave policy", len(killed))
+	}
+}
+
+// Leaving other daemons' state alone must not cost adoption of our own,
+// which is what makes restart-without-agent-loss work.
+func TestAdoptOrLeaveStillAdoptsRecordedPanes(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-adopt-or-leave"
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &api.Session{
+		Name:      "t-r-g1-0",
+		Workspace: ws,
+		Team:      "t",
+		Role:      "r",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	adopted, _, err := mgr.AdoptOrLeave()
+	if err != nil {
+		t.Fatalf("AdoptOrLeave: %v", err)
+	}
+	if adopted < 1 {
+		t.Fatalf("adopted = %d, want at least 1", adopted)
+	}
+	if !driver.HasSession("marvel-" + ws) {
+		t.Fatal("our own workspace session went away")
+	}
+}
+
+// The reap preview and the reap action are computed the same way, so
+// what an operator is shown is what they lose. A preview that could
+// disagree with the action would put the surprise back.
+func TestUnrecordedTmuxStateMatchesWhatKillWouldDestroy(t *testing.T) {
+	skipIfNoTmux(t)
+
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+
+	orphan := "marvel-reappreview"
+	if err := driver.NewSession(orphan); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	t.Cleanup(func() { _ = driver.KillSession(orphan) })
+
+	mgr := NewManager(api.NewStore(), driver)
+
+	found, err := mgr.UnrecordedTmuxState()
+	if err != nil {
+		t.Fatalf("UnrecordedTmuxState: %v", err)
+	}
+	var named bool
+	for _, f := range found {
+		if strings.Contains(f, orphan) {
+			named = true
+		}
+	}
+	if !named {
+		t.Fatalf("preview does not name the orphan %q: %v", orphan, found)
+	}
+
+	// The preview is read-only. Calling it must not change anything.
+	if !driver.HasSession(orphan) {
+		t.Fatal("UnrecordedTmuxState destroyed something; it must only look")
+	}
+}
+
 func TestReapDead(t *testing.T) {
 	skipIfNoTmux(t)
 


### PR DESCRIPTION
An ordinary `marvel daemon`, no flags, destroyed the entire running fleet of any other daemon sharing the tmux server. No confirmation before, and until #118 no operator-visible record after. This reverses the default: unrecognised `marvel-*` state is left running and reported, and destroying it becomes something an operator does on purpose.

Build sequence step 7 of `docs/design/daemon-isolation.md`, implementing the ruling recorded there on 2026-08-07: **err on silent accumulation, not silent destruction.**

## The reasoning, since it was a genuine tradeoff

Kill-all was not arbitrary. It exists because orphan panes accumulated and consumed resources, and a fresh daemon reclaiming its prefix is the fix that shipped (#13, `aae-orc-72u`). Reversing the default reopens that bug.

It was reopened deliberately. An orphaned pane costs memory and clutter and can be reclaimed whenever an operator notices. Destroyed work cannot be recovered at all. A failure we can clean up beats a failure we can only regret.

Worth being precise about what was killed, because the original report understated it: the rule was never "a daemon with empty state kills everything". A foreign daemon carrying a populated store and its own workspace still killed the first daemon's sessions. The rule was "anything not in my records dies", and the `resource_version=0` detail was incidental.

## Changes

- **`internal/session`** — `AdoptOrLeave` is the new default and reports what it leaves. `AdoptOrKill` keeps kill semantics for the deliberate paths. Both are one core parameterized by an `UnrecordedPolicy`, so the preview, the leave and the kill cannot drift apart. Log lines name which policy ran, because a reader diagnosing a missing fleet needs to know.
- **`internal/events`** — `reconcile.left`, at **warning** severity. The ruling accepted accumulating orphans as the better failure, and an accepted failure nobody can see is just the other one wearing a different hat. This is what keeps "leave it alone" from being as silent as the kill it replaced.
- **`internal/daemon`** — `--reclaim` opts back into the old behavior at startup. New `reap` RPC that lists by default and destroys only on explicit confirmation.
- **`cmd/marvel`** — `marvel reap` prints the candidates and stops. `marvel reap --confirm` destroys them. The listing says plainly that the candidates may belong to another live daemon.

Showing before destroying is not politeness here, it is the ruling. A reap that killed on sight would put the original failure back behind a new name.

`UnrecordedTmuxState` computes the preview exactly the way the reconcile pass computes the action, so what an operator is shown is what they lose.

## Cost of merge

The behavior change is the point, and it is one-directional: nothing that used to survive now dies. What changes is that stale panes an operator previously never saw now persist until reaped, and surface as warnings in `marvel events`. `--reclaim` restores the previous startup behavior exactly.

Adoption of a daemon's own sessions is untouched, so restart-without-agent-loss works as before. There is a test asserting that specifically.

## Tests

Full suite green, `0 issues` from golangci-lint at CI's pinned v2.10.1. Three added:

- `TestAdoptOrLeaveLeavesUnrecordedStateRunning` asserts the session survives, that a warning-severity `reconcile.left` names the actor, and that no kill event is emitted under the leave policy.
- `TestAdoptOrLeaveStillAdoptsRecordedPanes` guards the case the old default was protecting.
- `TestUnrecordedTmuxStateMatchesWhatKillWouldDestroy` asserts the preview names the orphan and that looking does not destroy.

The existing kill-path tests still cover `AdoptOrKill`, which is now the `--reclaim` and reap route.

## What this does not do

It does not make concurrent daemons safe. The `marvel-*` prefix is still machine-global, so two daemons still share one tmux server by default; deriving the tmux socket name from the layout is step 6 and is still open. It also does nothing for the consequence chain once something *has* been destroyed, which is `aae-orc-4bz2`.

Docs updated: `architecture.md` recovery section, `CLAUDE.md` recovery list and CLI table, and the design doc's build-sequence status.

Refs: aae-orc-kvcs, aae-orc-mh6g