### PR TITLE
fix: show the resolved default in config list instead of a blank address

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -1099,9 +1099,17 @@ func configCmd() *cobra.Command {
 				if cl.Name == cfg.CurrentCluster {
 					marker = "* "
 				}
+				// A cluster with neither field set resolves to the
+				// layout default at use time. Show what it resolves to,
+				// marked, rather than an empty cell: the address column
+				// is where an operator checks which daemon they are
+				// pointed at, and blank reads as broken.
 				addr := cl.Socket
 				if cl.Server != "" {
 					addr = cl.Server
+				}
+				if addr == "" {
+					addr = config.ResolveSocket() + "  (default)"
 				}
 				identity := cl.Identity
 				if identity == "" {


### PR DESCRIPTION
Follow-up to #122. Making the socket resolve at use time left `marvel config list` printing an empty ADDRESS cell for a cluster that sets neither `socket:` nor `server:`, which is now the correct shape for the `local` cluster once an operator migrates off the pinned legacy path.

That column is where you check which daemon you are pointed at, so a blank reads as broken rather than as default.

Before:
```
     NAME       ADDRESS                IDENTITY
*    local                             -
```

After:
```
     NAME       ADDRESS                                              IDENTITY
*    local      /Users/…/.marvel/run/marvel.sock  (default)          -
```

The `(default)` marker keeps it honest: the value is resolved, not pinned in the file, so nobody reads the listing and concludes their config contains a path it does not.

Additive to the display only; no resolution behavior changes.

Refs: aae-orc-mh6g