### PR TITLE
probe(marvel): the daemon isolation fixes hold under two live daemons

### DIFF
--- a/_kos/findings/finding-012-daemon-isolation-rig-verification.md
+++ b/_kos/findings/finding-012-daemon-isolation-rig-verification.md
@@ -1,0 +1,132 @@
+# finding-012: the daemon isolation fixes hold under two live daemons
+
+Date: 2026-08-07
+Probe: `aae-orc-3st1`
+Verifies: marvel #118, #122, #123
+Bears on: `aae-orc-t6da`, `aae-orc-kvcs`, `aae-orc-mh6g`,
+`question-daemon-isolation-boundary`
+Rig: `scripts/rig-daemon-isolation.sh`
+
+## Why this exists
+
+Everything shipped on 2026-08-07 had unit-test evidence and one no-daemon
+CLI check. None of it had been exercised with two daemons running at
+once, which is the only condition under which the original bugs appear.
+The bugs were found in a rig; the fixes had not been confirmed in one.
+
+That is the shape orc finding-002 named: development-scoped validation
+produces false confidence. Three tickets were reading as effectively
+closed on the strength of tests that cannot, by construction, reproduce
+the failure.
+
+## Result
+
+Eight scenarios, all pass. The load-bearing one first.
+
+**A second daemon no longer destroys the first's fleet.** Daemon A
+running a two-replica simulator team on a shared tmux server, 3 panes and
+2 live simulator processes. Daemon B started with a different HOME, its
+own socket, and the SAME tmux server: the exact configuration that killed
+everything in about five seconds on 2026-08-06.
+
+```
+before: 3 pane(s), 2 simulator process(es)
+after:  3 pane(s), 2 simulator process(es)
+```
+
+B logged and evented what it declined to touch, naming itself:
+
+```
+AdoptOrLeave[pid=26518 socket=/tmp/mrig-b/.marvel/run/marvel.sock]:
+  left tmux session marvel-alpha running: workspace not in this daemon's records
+
+warning  reconcile.left  alpha  left tmux session marvel-alpha running:
+  workspace not in this daemon's records. Reclaim with `marvel reap` if it
+  is stale [by pid=26518 socket=/tmp/mrig-b/.marvel/run/marvel.sock]
+```
+
+**The socket lock refuses rather than stranding.** Two daemons, same
+explicit `--socket`. B refuses with the holder named; A stays reachable
+and its socket file survives B's exit, which is the stranding case that
+previously left a live daemon unreachable with nothing in its log.
+
+```
+Error: another marvel daemon is already using socket /tmp/mrig-shared.sock
+(lock held on /tmp/mrig-shared.sock.lock). Stop it, or start this one with
+a different --socket
+```
+
+**Sockets follow HOME.** Two daemons, no `--socket` on either, each got
+its own layout-derived socket. A saw its 2 sessions; B saw none of them.
+No cross-talk.
+
+**The path assertion fires on a real path, not a synthetic one.** A
+layout socket under this session's scratchpad measured 138 bytes and was
+refused with the number named. This is not hypothetical: the session
+scratchpad prefix alone is 109 bytes against a 104-byte ceiling, so the
+rig itself had to live in `/tmp`. The assertion caught its own author.
+
+**The deliberate destructive paths still destroy.** `--reclaim` took the
+fleet from 2 simulators to 0 and logged the kill with its own identity.
+`marvel reap` listed one candidate and destroyed nothing; `reap --confirm`
+destroyed it. The listing warns that candidates may belong to another
+running daemon.
+
+**Restart-without-agent-loss survived the policy change.** This was the
+regression most likely to have been caused by flipping the default, since
+kill-on-start was the behavior adoption was built around. Agents survived
+the daemon stop (2 alive), the restarted daemon adopted 2 panes, and no
+agent was lost. The restart used the leave policy.
+
+## The methodology error, recorded because it nearly banked two results
+
+The first run used `pgrep -fc` to count simulator processes. `-c` is not
+a valid `pgrep` flag on macOS, so every count returned garbage. Two
+consequences, in opposite directions:
+
+- Scenario 3's process comparison became `0 == 0`, vacuously true. It
+  reported PASS on the single most important claim in this probe while
+  measuring nothing. The pane count beside it was real, which is the only
+  reason the result was recoverable rather than merely wrong.
+- Scenario 5 reported FAIL for "agents survived daemon stop" against a
+  broken counter, which would have read as a genuine regression in M3.
+
+Both were caught by reading the raw output rather than the PASS/FAIL
+tally, and re-run with `pgrep -f ... | wc -l`. The checked-in rig carries
+the corrected helper and a comment naming the trap.
+
+This is the second methodology flaw in this ticket family caught after
+the fact, the first being the incomplete artifact set in the 2026-08-06
+blind read. Both times the flaw made a result look stronger or weaker
+than it was, and both times only re-reading the primary evidence found
+it. A green tally is not a result.
+
+## What this does NOT establish
+
+- Nothing about the tmux namespace being scoped. It is still
+  machine-global; two daemons still share one tmux server by default.
+  Survivability was verified, isolation was not. That is `aae-orc-by6j`.
+- Nothing about the victim daemon's own records. Under the leave policy
+  there is no victim to test, and the `--reclaim` and reap paths still
+  leave the owner of the destroyed state with no record
+  (`aae-orc-tt5e`).
+- Nothing about real harnesses. The simulator runtime was used
+  throughout, so no model tokens were spent and no claude/codex process
+  behavior was exercised.
+- Nothing about peer authentication. Every daemon here ran at the same
+  uid, which is the condition `aae-orc-sqh0` is about.
+
+## Rig recipe, for the next ticket
+
+- Separate `HOME` per daemon, in a SHORT path. `sun_path` is 104 bytes
+  and the session scratchpad prefix is 109, so `/tmp/mrig-a` and
+  `/tmp/mrig-b` rather than the scratchpad. This is a technical
+  constraint, not a preference.
+- `MARVEL_TMUX_SOCKET` is a tmux socket NAME, consumed as `tmux -L`, not
+  a path. Short names (`mxA`, `mxB`). A 109-byte value was refused by
+  tmux with `File name too long` and left sessions pending rather than
+  failing the run.
+- Simulator runtime, so no model tokens are spent.
+- Never against the real `~/.marvel`: its bolt still holds the
+  2026-08-06 demo's desired state, and a daemon started there rehydrates
+  it into live agent processes.

--- a/scripts/rig-daemon-isolation.sh
+++ b/scripts/rig-daemon-isolation.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Rig verification for aae-orc-3st1.
+#
+# Verifies the behavior shipped in marvel #122 (socket through the layout,
+# advisory lock) and #123 (adopt-or-leave default, --reclaim, reap) with
+# two daemons actually running at once, which is the only condition the
+# original bugs appear under.
+#
+# SAFETY: every daemon runs under a throwaway HOME in /tmp and a dedicated
+# tmux socket NAME. Nothing touches the real ~/.marvel, whose bolt still
+# holds the 2026-08-06 demo's desired state.
+#
+# WHY /tmp AND NOT THE SCRATCHPAD: sun_path is 104 bytes. The session
+# scratchpad prefix alone measures 109, so a layout-derived socket under it
+# is rejected before it is created. Scenario 0 demonstrates exactly that.
+set -uo pipefail
+
+MARVEL=/tmp/mrig-marvel
+SIM=/tmp/mrig-sim
+HOME_A=/tmp/mrig-a
+HOME_B=/tmp/mrig-b
+TMUX_A=mxA
+TMUX_B=mxB
+TMUX_S=mxS          # deliberately shared, for the fleet-kill scenario
+SHARED_SOCK=/tmp/mrig-shared.sock
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $*"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+hdr()  { echo; echo "=== $* ==="; }
+# NOT `pgrep -fc`: -c is not a pgrep flag on macOS, and the first run of
+# this rig used it, so every process count was garbage and two scenarios
+# measured nothing. Count lines instead.
+sims() { pgrep -f "$SIM" 2>/dev/null | wc -l | tr -d ' '; }
+
+cleanup() {
+  hdr "cleanup"
+  for s in "$TMUX_A" "$TMUX_B" "$TMUX_S"; do
+    tmux -L "$s" kill-server 2>/dev/null
+  done
+  pkill -f 'mrig-marvel daemon' 2>/dev/null
+  pkill -f mrig-sim 2>/dev/null
+  sleep 1
+  rm -rf "$HOME_A" "$HOME_B" "$SHARED_SOCK" "$SHARED_SOCK.lock"
+  echo "  torn down"
+}
+trap cleanup EXIT
+
+mkdir -p "$HOME_A" "$HOME_B"
+
+cat > /tmp/mrig-fleet.toml <<EOF
+[workspace]
+name = "alpha"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 2
+
+    [team.role.runtime]
+    image = "simulator"
+    command = "$SIM"
+    args = ["--tick", "3000"]
+EOF
+
+# ---------------------------------------------------------------- scenario 0
+hdr "0. path-length assertion (paths.CheckSocketPath, #122 item 5)"
+LONGHOME=/private/tmp/claude-501/-Users-michael-pursifull-work-aae-orc/8f433f41-bdba-4aba-9454-abdd716cb2ca/scratchpad/rigL
+mkdir -p "$LONGHOME"
+out=$(HOME="$LONGHOME" "$MARVEL" daemon --state-bolt= --pidfile= --log-file= 2>&1 | head -3)
+if grep -qi "unix socket" <<<"$out" && grep -q "104" <<<"$out"; then
+  ok "over-long layout socket refused, error names the limit: $(head -1 <<<"$out")"
+else
+  bad "expected a 104-byte refusal, got: $out"
+fi
+rm -rf "$LONGHOME"
+
+# ---------------------------------------------------------------- scenario 1
+hdr "1. socket lock: two daemons, SAME explicit socket (#122 item 2)"
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_A" "$MARVEL" daemon \
+  --socket "$SHARED_SOCK" --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
+A_PID=$!
+sleep 3
+
+if HOME="$HOME_A" "$MARVEL" --socket "$SHARED_SOCK" get sessions >/dev/null 2>&1; then
+  ok "daemon A is up and reachable on the shared path"
+else
+  bad "daemon A did not come up"
+fi
+
+berr=$(HOME="$HOME_B" MARVEL_TMUX_SOCKET="$TMUX_B" "$MARVEL" daemon \
+  --socket "$SHARED_SOCK" --log-file="$HOME_B/d.log" 2>&1 | head -3)
+if grep -qi "another marvel daemon" <<<"$berr"; then
+  ok "daemon B refused: $(head -1 <<<"$berr")"
+else
+  bad "daemon B did NOT refuse. Output: $berr"
+fi
+
+# The stranding case: pre-fix, B's exit unlinked A's socket.
+if HOME="$HOME_A" "$MARVEL" --socket "$SHARED_SOCK" get sessions >/dev/null 2>&1; then
+  ok "daemon A still reachable after B's attempt and exit (not stranded)"
+else
+  bad "daemon A was stranded by B"
+fi
+if [[ -S "$SHARED_SOCK" ]]; then
+  ok "A's socket file still exists"
+else
+  bad "A's socket file was unlinked"
+fi
+
+HOME="$HOME_A" "$MARVEL" --socket "$SHARED_SOCK" stop >/dev/null 2>&1
+wait $A_PID 2>/dev/null
+sleep 1
+
+# ---------------------------------------------------------------- scenario 2
+hdr "2. socket isolation by HOME, no --socket anywhere (#122 item 1)"
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_A" "$MARVEL" daemon \
+  --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
+sleep 2
+HOME="$HOME_B" MARVEL_TMUX_SOCKET="$TMUX_B" "$MARVEL" daemon \
+  --log-file="$HOME_B/d.log" >"$HOME_B/out.log" 2>&1 &
+sleep 3
+
+if [[ -S "$HOME_A/.marvel/run/marvel.sock" && -S "$HOME_B/.marvel/run/marvel.sock" ]]; then
+  ok "each HOME got its own socket, both live"
+else
+  bad "expected two layout-derived sockets; A=$(ls "$HOME_A/.marvel/run/" 2>&1) B=$(ls "$HOME_B/.marvel/run/" 2>&1)"
+fi
+
+# Both daemons must be independently reachable, and each must see only itself.
+HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
+sleep 6
+a_sess=$(HOME="$HOME_A" "$MARVEL" get sessions 2>/dev/null | grep -c alpha)
+b_sess=$(HOME="$HOME_B" "$MARVEL" get sessions 2>/dev/null | grep -c alpha)
+if (( a_sess > 0 && b_sess == 0 )); then
+  ok "A sees its $a_sess session(s); B sees none of them (no cross-talk)"
+else
+  bad "cross-talk or missing fleet: A=$a_sess B=$b_sess"
+fi
+
+# ---------------------------------------------------------------- scenario 3
+hdr "3. adopt-or-leave: B joins A's tmux server (#123, the fleet-kill case)"
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+rm -rf "$HOME_A" "$HOME_B"; mkdir -p "$HOME_A" "$HOME_B"
+
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon \
+  --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
+sleep 2
+HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
+sleep 7
+
+before=$(tmux -L "$TMUX_S" list-panes -a 2>/dev/null | wc -l | tr -d ' ')
+sim_before=$(sims)
+echo "  before: $before pane(s) on the shared tmux server, $sim_before simulator process(es)"
+
+# B: different HOME, its own socket, but the SAME tmux server. This is the
+# exact configuration that destroyed A's fleet on 2026-08-06.
+HOME="$HOME_B" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon \
+  --log-file="$HOME_B/d.log" >"$HOME_B/out.log" 2>&1 &
+sleep 6
+
+after=$(tmux -L "$TMUX_S" list-panes -a 2>/dev/null | wc -l | tr -d ' ')
+sim_after=$(sims)
+echo "  after:  $after pane(s), $sim_after simulator process(es)"
+
+if [[ "$after" == "$before" && "$sim_after" == "$sim_before" ]]; then
+  ok "A's fleet SURVIVED daemon B starting on the same tmux server"
+else
+  bad "fleet changed: panes $before -> $after, sims $sim_before -> $sim_after"
+fi
+
+a_state=$(HOME="$HOME_A" "$MARVEL" get sessions 2>/dev/null | grep -c -i running)
+if (( a_state > 0 )); then
+  ok "A still reports $a_state running session(s)"
+else
+  bad "A reports no running sessions"
+fi
+
+if grep -q "left .* running" "$HOME_B/d.log" 2>/dev/null; then
+  ok "B logged what it left: $(grep -m1 'left .* running' "$HOME_B/d.log" | sed 's/^.*AdoptOrLeave/AdoptOrLeave/')"
+else
+  bad "B did not log a left-running line. Log: $(tail -5 "$HOME_B/d.log" 2>&1)"
+fi
+
+if HOME="$HOME_B" "$MARVEL" events 2>/dev/null | grep -q "reconcile.left"; then
+  ok "reconcile.left present in B's event ring"
+  HOME="$HOME_B" "$MARVEL" events 2>/dev/null | grep "reconcile.left" | head -2 | sed 's/^/      /'
+else
+  bad "no reconcile.left event. Events: $(HOME="$HOME_B" "$MARVEL" events 2>&1 | tail -3)"
+fi
+
+# ---------------------------------------------------------------- scenario 4
+hdr "4. reap: lists without destroying, destroys only on --confirm (#123)"
+reap_out=$(HOME="$HOME_B" "$MARVEL" reap 2>&1)
+echo "$reap_out" | sed 's/^/      /'
+mid=$(tmux -L "$TMUX_S" list-panes -a 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$mid" == "$after" ]]; then
+  ok "bare reap destroyed nothing ($mid pane(s) still up)"
+else
+  bad "bare reap changed the fleet: $after -> $mid"
+fi
+if grep -qi "another running daemon" <<<"$reap_out"; then
+  ok "reap warns the candidates may belong to another daemon"
+else
+  bad "reap did not warn about live owners"
+fi
+
+HOME="$HOME_B" "$MARVEL" reap --confirm >/dev/null 2>&1
+sleep 3
+post=$(tmux -L "$TMUX_S" list-panes -a 2>/dev/null | wc -l | tr -d ' ')
+if (( post < after )); then
+  ok "reap --confirm destroyed the unrecorded state ($after -> $post pane(s))"
+else
+  bad "reap --confirm did not destroy: $after -> $post"
+fi
+
+# ---------------------------------------------------------------- scenario 4b
+hdr "4b. --reclaim still destroys, deliberately"
+HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
+sleep 8
+pre_reclaim=$(sims)
+HOME="$HOME_B" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon --reclaim \
+  --log-file="$HOME_B/d2.log" >"$HOME_B/out2.log" 2>&1 &
+sleep 7
+post_reclaim=$(sims)
+if (( pre_reclaim > 0 && post_reclaim < pre_reclaim )); then
+  ok "--reclaim destroyed the fleet on purpose: $pre_reclaim -> $post_reclaim simulators"
+else
+  bad "--reclaim did not destroy: $pre_reclaim -> $post_reclaim"
+fi
+if grep -q "killed" "$HOME_B/d2.log" 2>/dev/null; then
+  ok "reclaim logged the kill with its own identity"
+else
+  bad "reclaim did not log a kill"
+fi
+
+# ---------------------------------------------------------------- scenario 5
+hdr "5. adopt-on-restart: same HOME re-adopts its own fleet (#123 regression guard)"
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+tmux -L "$TMUX_S" kill-server 2>/dev/null
+rm -rf "$HOME_A"; mkdir -p "$HOME_A"
+
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_A" "$MARVEL" daemon \
+  --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
+sleep 2
+HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
+sleep 7
+pre_restart=$(sims)
+
+# Detach (agents keep running), then start again against the same HOME.
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+survived=$(sims)
+if (( survived == pre_restart && survived > 0 )); then
+  ok "agents survived daemon stop ($survived alive)"
+else
+  bad "agents did not survive stop: $pre_restart -> $survived"
+fi
+
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_A" "$MARVEL" daemon \
+  --log-file="$HOME_A/d2.log" >"$HOME_A/out2.log" 2>&1 &
+sleep 6
+if grep -q "adopted pane" "$HOME_A/d2.log" 2>/dev/null; then
+  ok "restarted daemon adopted its own panes: $(grep -c 'adopted pane' "$HOME_A/d2.log") adoption(s)"
+else
+  bad "no adoption on restart. Log: $(tail -5 "$HOME_A/d2.log" 2>&1)"
+fi
+readopted=$(sims)
+if (( readopted == survived )); then
+  ok "no agent lost across the restart ($readopted alive)"
+else
+  bad "agents lost across restart: $survived -> $readopted"
+fi
+
+hdr "result"
+echo "  $PASS passed, $FAIL failed"
+exit $(( FAIL > 0 ? 1 : 0 ))


### PR DESCRIPTION
Everything merged into marvel today (#118, #122, #123) had unit-test evidence and one no-daemon CLI check. None of it had been run with two daemons live at once, which is the only condition the bugs it fixes actually appear under. The bugs were found in a rig; the fixes had not been confirmed in one. This closes that gap and checks the rig in so the next two tickets do not rebuild it.

`aae-orc-3st1`. Eight scenarios, all pass.

## The one that matters

Daemon A running a two-replica simulator team on a shared tmux server, 3 panes and 2 live simulator processes. Daemon B started with a different HOME, its own socket, and the same tmux server: the exact configuration that killed everything in about five seconds on 2026-08-06.

```
before: 3 pane(s), 2 simulator process(es)
after:  3 pane(s), 2 simulator process(es)
```

B logged and evented what it declined to touch, naming itself:

```
warning  reconcile.left  alpha  left tmux session marvel-alpha running:
  workspace not in this daemon's records. Reclaim with `marvel reap` if it is
  stale [by pid=26518 socket=/tmp/mrig-b/.marvel/run/marvel.sock]
```

## Also confirmed

- **Socket lock refuses rather than strands.** Two daemons on the same `--socket`: B refuses naming the holder, A stays reachable, A's socket survives B's exit. That last part is the stranding case that used to leave a live daemon unreachable with nothing in its log.
- **Sockets follow HOME.** No `--socket` on either daemon, each got its own layout-derived path, A saw its 2 sessions and B saw none of them.
- **The path assertion fires on a real path.** A layout socket under this session's scratchpad measured 138 bytes and was refused with the number named. The scratchpad prefix alone is 109 bytes against a 104-byte ceiling, so the rig had to live in `/tmp`. The assertion caught its own author.
- **The deliberate paths still destroy.** `--reclaim` took the fleet from 2 simulators to 0 and logged it. `marvel reap` listed and destroyed nothing; `--confirm` destroyed.
- **Restart-without-agent-loss survived the policy flip.** This was the likeliest regression, since adoption was built around kill-on-start. Agents survived the stop, the restart adopted 2 panes, none lost.

## A methodology error, recorded rather than quietly fixed

The first run counted processes with `pgrep -fc`. `-c` is not a valid `pgrep` flag on macOS, so every count was garbage, in both directions: scenario 3 became `0 == 0` and reported PASS on the most important claim in the probe while measuring nothing, and scenario 5 reported FAIL against the broken counter, which would have read as a genuine M3 regression.

Caught by reading raw output instead of the PASS/FAIL tally, then re-run with a correct counter. The checked-in rig carries the fixed helper and a comment naming the trap.

This is the second methodology flaw in this ticket family found after the fact; the first was the incomplete artifact set in the 2026-08-06 blind read. Both times the flaw made a result look other than it was, and both times only re-reading the primary evidence caught it.

## What this does not establish

The tmux namespace is still machine-global. Survivability was verified; isolation was not, and that is `aae-orc-by6j`. Nothing here covers the victim daemon's own records (`aae-orc-tt5e`), real harnesses (simulator throughout, no model tokens), or peer authentication (`aae-orc-sqh0`, every daemon at the same uid).

Docs and script only. No production code changes.

Refs: aae-orc-3st1, aae-orc-t6da, aae-orc-kvcs, aae-orc-mh6g