### PR TITLE
feat: report the daemon's layout home on every response

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -91,11 +91,26 @@ func resolveDaemonAddr() (string, daemon.DialOptions) {
 }
 
 // send runs a JSON-RPC request against the currently selected daemon,
-// threading through per-cluster dial options. All subcommands should
-// use this instead of daemon.SendRequest directly.
+// threading through per-cluster dial options, and warns when the daemon
+// that answered is not rooted at the layout home this client resolved
+// against. All subcommands should use this instead of
+// daemon.SendRequest directly.
 func send(req daemon.Request) (*daemon.Response, error) {
 	addr, opts := resolveDaemon()
-	return daemon.SendRequestWith(addr, req, opts)
+	resp, err := daemon.SendRequestWith(addr, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	// Diagnostic only, and deliberately after the fact: the daemon's
+	// self-reported home arrives on the response, so a mutating request
+	// has already been carried out by the time a mismatch is visible.
+	// Prevention would put the expectation on the request and have the
+	// daemon reject it, which is authorization-shaped (aae-orc-sqh0).
+	// See docs/design/daemon-isolation.md decision 8.
+	if w := config.DaemonHomeWarning(addr, resp.DaemonHome, config.ClientHome()); w != "" {
+		fmt.Fprintln(os.Stderr, w)
+	}
+	return resp, nil
 }
 
 func main() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,6 +212,21 @@ one constant bypassed the layout every other path honored. A config entry
 still pinning it gets a warning naming the new default. Full reasoning:
 `docs/design/daemon-isolation.md`.
 
+The path alone cannot say which daemon answered, so every response
+carries the layout home the daemon is rooted at (`daemon_home`), and the
+client warns on stderr when that differs from the home it resolved
+against. The warning names both homes and points at `--socket` and
+`$MARVEL_SOCKET`. It stays quiet for remote clusters, which are expected
+to run under a different home, and for daemons that predate the field,
+which simply omit it.
+
+This is diagnostic, not preventive. The field arrives on the response, so
+a read gets a warning before the operator trusts the answer, but a
+mutating call has already been carried out by the time the mismatch is
+visible. Preventing it would put the expectation on the request and have
+the daemon reject a mismatch, which is an authorization question tracked
+separately (`aae-orc-sqh0`).
+
 This is not an authorization boundary. A 0700 socket is private to the
 user and remains reachable by every agent marvel spawns, because those
 run at the same uid.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -92,6 +93,74 @@ func LegacySocketWarning(addr string) string {
 			"and a client that reaches the wrong one gets an empty answer with "+
 			"exit code 0. Update config.yaml, or set %s to silence this.",
 		LegacySocket, DefaultSocket(), SocketEnv)
+}
+
+// ClientHome returns the layout home this client resolves against,
+// ~/.marvel, or the empty string when the home directory cannot be
+// determined. It is the expectation a daemon's self-reported home is
+// compared with.
+func ClientHome() string {
+	layout, err := paths.Default()
+	if err != nil {
+		return ""
+	}
+	return layout.Home
+}
+
+// DaemonHomeWarning returns a warning to show the operator when the
+// daemon that answered is rooted at a different layout home than the
+// client resolved against, or the empty string when there is nothing to
+// warn about.
+//
+// This is what makes a wrong-daemon hit visible at all. Measured
+// 2026-08-06: a client that reaches the wrong daemon gets a well-formed,
+// successful, EMPTY answer with exit code 0, and a mutating call reports
+// success against the wrong daemon. Neither the path nor the exit code
+// distinguishes that from a correct call, so the daemon says which
+// layout it is rooted at and the client checks.
+//
+// It warns. It does not fail the command, and it cannot prevent
+// anything: the field arrives on the response, so a mutating call has
+// already been carried out by the time this runs. See
+// docs/design/daemon-isolation.md decision 8 and aae-orc-sqh0.
+//
+// Silent by design in three cases:
+//
+//   - Remote addresses (mrvl://, ssh://, tcp://, host:port). A remote
+//     daemon runs under its own home and is EXPECTED to differ; warning
+//     there would be noise on every single remote call.
+//   - An empty reported home, which is a daemon predating this field.
+//   - An empty client home, which leaves nothing to compare against.
+func DaemonHomeWarning(addr, daemonHome, clientHome string) string {
+	if daemonHome == "" || clientHome == "" {
+		return ""
+	}
+	if !isLocalSocket(addr) {
+		return ""
+	}
+	if daemonHome == clientHome {
+		return ""
+	}
+	return fmt.Sprintf(
+		"warning: the daemon at %s is rooted at %s, but this client resolved against %s. "+
+			"The answer above came from a different marvel. "+
+			"Pass --socket, or set %s, to reach the one you meant.",
+		addr, daemonHome, clientHome, SocketEnv)
+}
+
+// isLocalSocket reports whether addr names a Unix socket on this
+// machine. Mirrors the daemon's own address routing: a scheme means
+// remote, and a colon means host:port. A Unix socket path with a colon
+// in it would be misread here, and equally by the dialer, so the two
+// agree.
+func isLocalSocket(addr string) bool {
+	if isMRVL(addr) || isSSH(addr) {
+		return false
+	}
+	if strings.HasPrefix(addr, "tcp://") {
+		return false
+	}
+	return !strings.Contains(addr, ":")
 }
 
 // Config is the top-level marvel client configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,18 +149,18 @@ func DaemonHomeWarning(addr, daemonHome, clientHome string) string {
 }
 
 // isLocalSocket reports whether addr names a Unix socket on this
-// machine. Mirrors the daemon's own address routing: a scheme means
-// remote, and a colon means host:port. A Unix socket path with a colon
-// in it would be misread here, and equally by the dialer, so the two
-// agree.
+// machine. A scheme means remote; otherwise the host:port rule decides,
+// and that rule is paths.IsTCPAddr so the client cannot drift from what
+// the daemon and the dialer do.
+//
+// The scheme tests are kept explicit rather than left to the colon in
+// "://", so that adding a fourth scheme is a change here and not a
+// coincidence of punctuation.
 func isLocalSocket(addr string) bool {
-	if isMRVL(addr) || isSSH(addr) {
+	if isMRVL(addr) || isSSH(addr) || strings.HasPrefix(addr, "tcp://") {
 		return false
 	}
-	if strings.HasPrefix(addr, "tcp://") {
-		return false
-	}
-	return !strings.Contains(addr, ":")
+	return !paths.IsTCPAddr(addr)
 }
 
 // Config is the top-level marvel client configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDaemonHomeWarning(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mine   = "/Users/op/.marvel"
+		theirs = "/Users/other/.marvel"
+		sock   = "/Users/op/.marvel/run/marvel.sock"
+	)
+
+	tests := []struct {
+		name       string
+		addr       string
+		daemonHome string
+		clientHome string
+		wantWarn   bool
+	}{
+		{
+			name:       "mismatch on a local socket warns",
+			addr:       sock,
+			daemonHome: theirs,
+			clientHome: mine,
+			wantWarn:   true,
+		},
+		{
+			name:       "matching homes stay quiet",
+			addr:       sock,
+			daemonHome: mine,
+			clientHome: mine,
+		},
+		{
+			name:       "remote mrvl cluster is expected to differ",
+			addr:       "mrvl://other-host",
+			daemonHome: theirs,
+			clientHome: mine,
+		},
+		{
+			name:       "remote ssh cluster is expected to differ",
+			addr:       "ssh://op@other-host/home/op/.marvel/run/marvel.sock",
+			daemonHome: theirs,
+			clientHome: mine,
+		},
+		{
+			name:       "explicit tcp is expected to differ",
+			addr:       "tcp://127.0.0.1:9090",
+			daemonHome: theirs,
+			clientHome: mine,
+		},
+		{
+			name:       "bare host:port is expected to differ",
+			addr:       "127.0.0.1:9090",
+			daemonHome: theirs,
+			clientHome: mine,
+		},
+		{
+			name:       "daemon predating the field says nothing",
+			addr:       sock,
+			daemonHome: "",
+			clientHome: mine,
+		},
+		{
+			name:       "no client home leaves nothing to compare",
+			addr:       sock,
+			daemonHome: theirs,
+			clientHome: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DaemonHomeWarning(tt.addr, tt.daemonHome, tt.clientHome)
+			if tt.wantWarn && got == "" {
+				t.Fatalf("expected a warning for addr %q, daemon %q, client %q",
+					tt.addr, tt.daemonHome, tt.clientHome)
+			}
+			if !tt.wantWarn && got != "" {
+				t.Fatalf("expected no warning, got %q", got)
+			}
+		})
+	}
+}
+
+// The warning has to be actionable on its own: an operator reading one
+// line of stderr needs both homes and the way out.
+func TestDaemonHomeWarningNamesBothHomesAndTheOverride(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mine   = "/Users/op/.marvel"
+		theirs = "/Users/other/.marvel"
+		sock   = "/Users/op/.marvel/run/marvel.sock"
+	)
+
+	w := DaemonHomeWarning(sock, theirs, mine)
+	if w == "" {
+		t.Fatal("expected a warning")
+	}
+	for _, want := range []string{theirs, mine, sock, "--socket", SocketEnv} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning does not mention %q: %s", want, w)
+		}
+	}
+}
+
+func TestIsLocalSocket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"/Users/op/.marvel/run/marvel.sock", true},
+		{"/tmp/marvel.sock", true},
+		{"mrvl://host", false},
+		{"mrvl://op@host:6785", false},
+		{"ssh://op@host/run/marvel.sock", false},
+		{"tcp://host:9090", false},
+		{"host:9090", false},
+		{":9090", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			t.Parallel()
+			if got := isLocalSocket(tt.addr); got != tt.want {
+				t.Errorf("isLocalSocket(%q) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -54,9 +54,11 @@ const (
 )
 
 // listenNetwork returns "tcp" if the address looks like host:port,
-// otherwise "unix". Used by the daemon listener side only.
+// otherwise "unix". The host:port rule itself is paths.IsTCPAddr, which
+// is the single definition shared with the client and with the socket
+// length check.
 func listenNetwork(addr string) string {
-	if strings.Contains(addr, ":") {
+	if paths.IsTCPAddr(addr) {
 		return "tcp"
 	}
 	return "unix"

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -82,6 +82,22 @@ type Request struct {
 type Response struct {
 	Result json.RawMessage `json:"result,omitempty"`
 	Error  string          `json:"error,omitempty"`
+
+	// DaemonHome is the layout home this daemon is rooted at
+	// (~/.marvel), stamped on every response so a client can tell
+	// whether the daemon it reached is the one it meant. Empty from a
+	// daemon that predates the field, and omitempty keeps the envelope
+	// readable by a client that predates it, so no protocol version bump
+	// or handshake is involved.
+	//
+	// Diagnostic, not preventive. A field on the RESPONSE is read after
+	// the request has already been sent: for read methods that is fine,
+	// but for mutating methods the client learns it hit the wrong daemon
+	// after it has already changed it. Prevention would put the
+	// expectation on the REQUEST and have the daemon reject a mismatch,
+	// which is authorization-shaped and belongs with aae-orc-sqh0. See
+	// docs/design/daemon-isolation.md decision 8.
+	DaemonHome string `json:"daemon_home,omitempty"`
 }
 
 // DefaultLogBufferLines is the default ring-buffer depth for the
@@ -113,6 +129,13 @@ type Daemon struct {
 	// this daemon does not own, instead of leaving it running. Off by
 	// default; `marvel daemon --reclaim` is the deliberate act.
 	reclaim bool
+
+	// home is the layout home this daemon is rooted at (~/.marvel),
+	// stamped onto every response. Empty when the home directory cannot
+	// be resolved, which is the same condition under which nothing else
+	// in the layout works either; the field is then simply absent from
+	// the wire and the client has nothing to compare.
+	home string
 
 	// In-memory ring of the most recent log lines. Always non-nil.
 	logs *logbuf.Buffer
@@ -231,6 +254,15 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	acct := usage.New(store, usage.NewResolver(limits), usage.WithEvents(evRing))
 	sessMgr.Usage = acct
 
+	// Resolved once at construction rather than per response: the home
+	// cannot change under a running daemon, and a failure here is not
+	// worth refusing to start over. An empty home means the field is
+	// absent on the wire.
+	var home string
+	if layout, lerr := paths.Default(); lerr == nil {
+		home = layout.Home
+	}
+
 	d := &Daemon{
 		store:    store,
 		sessMgr:  sessMgr,
@@ -238,6 +270,7 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 		driver:   driver,
 		pidFile:  opts.PidFile,
 		reclaim:  opts.Reclaim,
+		home:     home,
 		logs:     buf,
 		events:   evRing,
 		usage:    acct,
@@ -575,12 +608,21 @@ func (d *Daemon) handleRWC(rwc io.ReadWriteCloser) {
 	var req Request
 	if err := json.NewDecoder(rwc).Decode(&req); err != nil {
 		resp := Response{Error: fmt.Sprintf("decode request: %v", err)}
-		_ = json.NewEncoder(rwc).Encode(resp)
+		_ = json.NewEncoder(rwc).Encode(d.stamp(resp))
 		return
 	}
 
 	resp := d.dispatch(req)
-	_ = json.NewEncoder(rwc).Encode(resp)
+	_ = json.NewEncoder(rwc).Encode(d.stamp(resp))
+}
+
+// stamp records which daemon answered. It sits on the write path rather
+// than in the 14 handlers so no method can be added without it, and it
+// covers the decode-error reply too: a malformed request answered by the
+// wrong daemon is worth attributing as much as a successful one.
+func (d *Daemon) stamp(resp Response) Response {
+	resp.DaemonHome = d.home
+	return resp
 }
 
 func (d *Daemon) dispatch(req Request) Response {

--- a/internal/daemon/selfreport_test.go
+++ b/internal/daemon/selfreport_test.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+// pipeRWC feeds handleRWC a fixed request and captures what it writes.
+type pipeRWC struct {
+	in  *bytes.Reader
+	out bytes.Buffer
+}
+
+func newPipeRWC(request string) *pipeRWC {
+	return &pipeRWC{in: bytes.NewReader([]byte(request))}
+}
+
+func (p *pipeRWC) Read(b []byte) (int, error)  { return p.in.Read(b) }
+func (p *pipeRWC) Write(b []byte) (int, error) { return p.out.Write(b) }
+func (p *pipeRWC) Close() error                { return nil }
+
+var _ io.ReadWriteCloser = (*pipeRWC)(nil)
+
+// serve runs one request through the daemon's write path and decodes the
+// reply the way a client would. A bare &Daemon is enough: the methods
+// exercised here answer before touching the store or the tmux driver, so
+// the test does not need a real daemon or a tmux binary.
+func serve(t *testing.T, home, request string) Response {
+	t.Helper()
+	rwc := newPipeRWC(request)
+	d := &Daemon{home: home}
+	d.handleRWC(rwc)
+
+	var resp Response
+	if err := json.Unmarshal(rwc.out.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %q: %v", rwc.out.String(), err)
+	}
+	return resp
+}
+
+// The field has to reach the client on the wire, not merely exist on the
+// struct: it is stamped on the write path, so any method gets it.
+func TestResponseCarriesDaemonHome(t *testing.T) {
+	t.Parallel()
+
+	const home = "/Users/op/.marvel"
+
+	tests := []struct {
+		name    string
+		request string
+	}{
+		{
+			name:    "dispatched method",
+			request: `{"method":"nosuchmethod"}`,
+		},
+		{
+			// The decode-error reply is written before dispatch, and it
+			// is worth attributing too: a malformed request answered by
+			// the wrong daemon is the same diagnostic problem.
+			name:    "undecodable request",
+			request: `{not json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp := serve(t, home, tt.request)
+			if resp.Error == "" {
+				t.Fatal("expected an error reply from this fixture")
+			}
+			if resp.DaemonHome != home {
+				t.Errorf("daemon_home: want %q, got %q", home, resp.DaemonHome)
+			}
+		})
+	}
+}
+
+// A daemon that cannot resolve its home omits the field rather than
+// reporting an empty string, which is what keeps an old client's parse
+// identical and gives a new client something unambiguous to skip.
+func TestUnresolvedHomeOmitsField(t *testing.T) {
+	t.Parallel()
+
+	rwc := newPipeRWC(`{"method":"nosuchmethod"}`)
+	d := &Daemon{}
+	d.handleRWC(rwc)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rwc.out.Bytes(), &raw); err != nil {
+		t.Fatalf("decode response %q: %v", rwc.out.String(), err)
+	}
+	if _, ok := raw["daemon_home"]; ok {
+		t.Errorf("expected daemon_home to be omitted, got %s", rwc.out.String())
+	}
+}
+
+// Wire compatibility, both directions. No version field and no handshake
+// ship with this change, so the envelope has to stay readable by clients
+// and daemons that predate the field.
+func TestEnvelopeWireCompatibility(t *testing.T) {
+	t.Parallel()
+
+	t.Run("old client ignores the new field", func(t *testing.T) {
+		t.Parallel()
+		// The envelope as it was before this change.
+		type oldResponse struct {
+			Result json.RawMessage `json:"result,omitempty"`
+			Error  string          `json:"error,omitempty"`
+		}
+		wire, err := json.Marshal(Response{
+			Result:     json.RawMessage(`{"status":"ok"}`),
+			DaemonHome: "/Users/op/.marvel",
+		})
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+		var old oldResponse
+		if err := json.Unmarshal(wire, &old); err != nil {
+			t.Fatalf("old client failed to parse %s: %v", wire, err)
+		}
+		if string(old.Result) != `{"status":"ok"}` {
+			t.Errorf("result: got %s", old.Result)
+		}
+	})
+
+	t.Run("new client tolerates a daemon without the field", func(t *testing.T) {
+		t.Parallel()
+		var resp Response
+		if err := json.Unmarshal([]byte(`{"result":{"status":"ok"}}`), &resp); err != nil {
+			t.Fatalf("parse old daemon reply: %v", err)
+		}
+		if resp.DaemonHome != "" {
+			t.Errorf("daemon_home: want empty, got %q", resp.DaemonHome)
+		}
+	})
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -139,10 +139,29 @@ func (l Layout) RuntimeSocket() string {
 // while probing this, and the tmux one failed silently.
 const MaxUnixSocketPath = 104
 
+// IsTCPAddr reports whether an address is host:port rather than a Unix
+// socket path. A colon is the whole rule.
+//
+// This is the single definition of that rule, and it lives here because
+// paths owns the socket and because both internal/config and
+// internal/daemon already import this package, so sharing it adds no
+// dependency edge. It was three inline copies before: the daemon's
+// listen and dial routing, this package's length check, and the client's
+// self-report comparison. Marvel #122 exists partly to delete a socket
+// default that survived a fix because it was declared twice, so a rule
+// with three encodings is the same defect one layer up.
+//
+// A Unix socket path containing a colon would be misread as TCP. That is
+// the behavior every copy already had, and keeping it in one place is
+// what makes it changeable.
+func IsTCPAddr(addr string) bool {
+	return strings.Contains(addr, ":")
+}
+
 // CheckSocketPath rejects a Unix socket path the kernel would truncate.
-// Addresses containing ":" are TCP and are not checked.
+// TCP addresses are not checked.
 func CheckSocketPath(path string) error {
-	if strings.Contains(path, ":") {
+	if IsTCPAddr(path) {
 		return nil
 	}
 	if len(path) > MaxUnixSocketPath {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -158,6 +158,34 @@ func TestCheckSocketPath(t *testing.T) {
 	}
 }
 
+// IsTCPAddr is the one definition of the host:port rule, shared by the
+// daemon's listen and dial routing, the socket length check, and the
+// client's self-report comparison. These cases are the vocabulary all
+// three see.
+func TestIsTCPAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"/Users/someone/.marvel/run/marvel.sock", false},
+		{"/tmp/marvel.sock", false},
+		{"marvel.sock", false},
+		{"0.0.0.0:9090", true},
+		{":9090", true},
+		{"tcp://host:9090", true},
+		{"mrvl://host", true},
+		{"ssh://op@host/run/marvel.sock", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			if got := IsTCPAddr(tc.addr); got != tc.want {
+				t.Errorf("IsTCPAddr(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCheckMode(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Right now a client that reaches the wrong marvel daemon cannot tell. Measured 2026-08-06: the wrong daemon answers a read with a well-formed, successful, EMPTY table and exit code 0, and answers `marvel work` with `workspace/alpha ready` while changing state the operator never meant to touch. No script and no agent can distinguish either from a correct call.

The socket move in #122 made this checkable for the first time. Before it, the client's only notion of which daemon it meant was a path, and in every collision mode both daemons sat at the same path, so there was nothing to compare. Now the client's own layout home is the expectation.

## What changed

The daemon states the layout home it is rooted at (`~/.marvel`) on every response, and the client warns on stderr when that differs from the home it resolved against.

- One additive field on the shared `{Result, Error}` envelope, `daemon_home`, with `omitempty`. No protocol version bump, no handshake, no new message type. Old clients ignore the extra key; a daemon that predates the field simply omits it and the client says nothing.
- Stamped on the write path (`handleRWC`), not in each handler, so all 15 methods get it and a 16th cannot be added without it. It covers the decode-error reply too, since a malformed request answered by the wrong daemon is the same diagnostic problem.
- The warning names both homes and points at `--socket` and `$MARVEL_SOCKET`. It never fails the command.
- Quiet where it would be noise: a remote `mrvl://`, `ssh://`, or TCP cluster is expected to run under a different home, so only local Unix-socket connections are compared.

Cost of merge: additive only. No existing behavior changes, and every existing wire exchange still parses in both directions.

## What this does not do

It is diagnostic, not preventive, and the difference matters for mutating calls. A field on the RESPONSE is read after the request has already been sent: a read gets its warning before the operator trusts the answer, but `marvel work`, `scale`, and `delete` have already run against the wrong daemon by the time the mismatch is visible. Prevention would put the expectation on the REQUEST and have the daemon reject a mismatch, which is authorization-shaped and belongs with `aae-orc-sqh0`. The limit is stated in the code, in `docs/architecture.md`, and in the design document.

It also does not touch the socket resolution chain, the tmux namespace, or `AdoptOrLeave`.

## One correction to the design document

`docs/design/daemon-isolation.md` decision 8 says the envelope is shared by 14 methods. It is 15 now: `reap` landed in #123, after the count was taken in #121. The conclusion is unaffected, and stamping on the write path is what makes the count stop mattering.

## Tests

`internal/daemon/selfreport_test.go` and `internal/config/config_test.go`, stdlib `testing`, table-driven: the field round-trips through the envelope on both the dispatch and the decode-error reply, an unresolvable home omits the key rather than sending an empty string, an old client parses a response carrying the field, a new client parses a response without it, a mismatch warns, matching homes do not, and remote clusters do not.

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` (v2.10.1, matching CI) are all clean.

Refs: aae-orc-drx4, `docs/design/daemon-isolation.md` decision 8, step 5 of the build sequence

## Review follow-up

Address classification had three inline copies of one rule: `daemon.listenNetwork` (listen and dial routing), `paths.CheckSocketPath` (skip the length check for TCP), and `config.isLocalSocket` (added by this branch). Nothing made them change together, and #122 exists partly to delete a socket default that survived a fix because it was declared twice.

`paths.IsTCPAddr` is the single definition now, with the reason recorded in its comment. `CheckSocketPath`, `listenNetwork`, and `isLocalSocket` all call it; `internal/config` and `internal/daemon` already import `internal/paths`, so this adds no dependency edge. `isLocalSocket` keeps its scheme tests on top, deliberately explicit rather than relying on the colon in `://`, so a fourth scheme is a change in that function and not a coincidence of punctuation. Behavior is unchanged, which the untouched tests confirm.

One correction on the review's premise, since it changes what should be done rather than only who wrote it: `isMRVL` and `isSSH` in `internal/config` are not copies added here. They date from 9abee5b (the original mrvl:// work) and are called by `AddCluster`. `isLocalSocket` reuses them. Deleting them in favor of inline literals would touch pre-existing callers for no gain, so they stand.
