### PR TITLE
docs: pin gofumpt to v0.7.0 in contributing prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You don't need to use AI agents to contribute -- just follow this guide and subm
 
 - **Go 1.22+** -- [install](https://go.dev/doc/install)
 - **just** -- [install](https://github.com/casey/just)
-- **gofumpt** -- `go install mvdan.cc/gofumpt@latest`
+- **gofumpt v0.7.0** -- `go install mvdan.cc/gofumpt@v0.7.0` (the version CI checks against)
 - **golangci-lint** -- [install](https://golangci-lint.run/welcome/install/)
 
 ## Getting Started


### PR DESCRIPTION
CONTRIBUTING tells contributors to install `gofumpt@latest`, but `ci.yml`
installs `mvdan.cc/gofumpt@v0.7.0` and fails the build on any file that
version would reformat. A contributor who follows the guide installs a
different formatter than the one grading them, so any formatting change
between the two shows up as CI rejecting correctly formatted code.

CI is authoritative, so the guide now names v0.7.0.

One line in one doc. No CI or tooling changes.

Refs: aae-orc-9nfg