### PR TITLE
feat: derive the tmux socket name from the paths layout

### DIFF
--- a/_kos/findings/finding-013-tmux-server-isolation-by-home.md
+++ b/_kos/findings/finding-013-tmux-server-isolation-by-home.md
@@ -1,0 +1,139 @@
+# finding-013: the tmux namespace is scoped, and the rig's own 4b was vacuous
+
+Date: 2026-08-07
+Work: `aae-orc-by6j`, decision 4 and build step 6 of
+`docs/design/daemon-isolation.md`
+Follows: finding-012 (which verified survivability on a SHARED tmux
+server and said explicitly that isolation was not established)
+Rig: `scripts/rig-daemon-isolation.sh` scenario 6
+
+## Result
+
+Two daemons under different HOMEs, with `MARVEL_TMUX_SOCKET` set
+nowhere, land on different tmux servers and cannot see each other's
+sessions.
+
+```
+derived: /tmp/mrig-a -> marvel-0960b344
+derived: /tmp/mrig-b -> marvel-926b8048
+panes: marvel-0960b344=3  marvel-926b8048=3  (-1 means no such server)
+sessions on marvel-0960b344: marvel-alpha
+sessions on marvel-926b8048: marvel-beta
+```
+
+Both fleets alive at 4 simulators. Each daemon's session table shows its
+own workspace only. B's `marvel reap` lists nothing from workspace
+alpha, and B's log carries no `reconcile.left` line, which is the
+discriminator between "isolated" and "sharing a server but declining to
+kill". No marvel session reached the shared default tmux server. A
+restarted daemon A found the same derived server and re-adopted its own
+2 panes with no agent lost, which is the stability property the
+sha256-of-HOME shape exists for.
+
+The derivation is `paths.Layout.TmuxSocketName`, beside `RuntimeSocket`
+and for the same reason: both namespaces are the isolation unit, and
+`internal/paths` is the one place either is defined.
+
+## Migration: no adoption sweep, and why
+
+The one-time sweep over the shared default server was declined on a
+measurement rather than a preference. On this machine, at the time of
+the change: `tmux -L default list-sessions` reported no server, `pgrep
+-l tmux` returned nothing, and `/private/tmp/tmux-501` held 529 socket
+files, all stale. There was no population to adopt, so the sweep would
+have been code for a case that did not exist, and it would have
+reintroduced one pass of the cross-server reach the change removes.
+
+Two facts were verified rather than assumed before being documented:
+
+- `tmux list-sessions` and `tmux -L default list-sessions` both report
+  the socket `/private/tmp/tmux-501/default`. `default` is tmux's own
+  default server name, so `MARVEL_TMUX_SOCKET=default` is an exact
+  reproduction of the old shared behavior, not an approximation.
+- The derived name is 15 bytes for any home, including a 508-byte one.
+  The 109-byte name that tmux refused with `File name too long`, while
+  marvel emitted nothing and sessions stayed pending, is not reachable
+  through this path.
+
+## The flaky check, third methodology note in this family
+
+Scenario 4b (`--reclaim` still destroys) failed on the first run of the
+extended rig, twice, with `--reclaim did not destroy: 2 -> 2`. It fails
+the same way on the unmodified binary at `358d882` with the unmodified
+script, so it is not a regression from this change. finding-012
+recorded it passing at `2 -> 0`, so the scenario is nondeterministic
+rather than simply broken.
+
+`--reclaim` itself is fine. Given a fleet of its own it takes 2
+simulators to 0, takes the tmux server with them, and logs
+`AdoptOrKill[pid=2619 socket=/tmp/mrig-b/.marvel/run/marvel.sock]:
+killed unrecorded workspace tmux session marvel-alpha`. Measured
+directly against the `358d882` binary, outside the rig.
+
+What made the rig read `2 -> 2` is two properties compounding:
+
+- 4b inherited scenario 4's aftermath rather than building its own
+  fleet. Scenario 4 ends with `reap --confirm` having destroyed
+  `marvel-alpha`, so 4b's `marvel work` is asking a daemon to rebuild a
+  fleet an external actor destroyed underneath it. That is the behavior
+  `aae-orc-4bz2` is about, and it did not happen on this run. Whether
+  it happens is the difference between finding-012's numbers and these.
+- `sims()` counts `mrig-sim` processes machine-wide, and `marvel stop`
+  is detach rather than teardown, so scenario 2's fleet was still alive
+  on a different tmux server. The `2` on both sides of `2 -> 2` was
+  scenario 2's simulators, on a server `--reclaim` never touched. The
+  check was comparing a number `--reclaim` could not move.
+
+Fixed by giving 4b its own setup from a clean slate, asserting the
+precondition out loud before reclaiming, and counting panes on the
+target server rather than processes on the machine. Scenario 3 now
+kills scenario 2's tmux server first, so its numbers stop carrying a
+previous scenario's processes; with that, its counts match the 3 panes
+and 2 simulators finding-012 recorded.
+
+This is the third methodology flaw found in this ticket family, after
+the incomplete artifact set of the 2026-08-06 blind read and `pgrep
+-fc`. All three were caught by reading raw output rather than the tally,
+and all three made a result look stronger than it was. Scenario 6's
+helpers report `-1` for an absent tmux server for this reason: `tmux
+... | wc -l` reports 0 both for "live and empty" and for "no server",
+and a comparison against 0 then passes without measuring anything.
+
+## Adjacent defect, pre-existing and unrelated to isolation
+
+`marvel reap` lists one permanent candidate per live session that the
+daemon itself owns. A single healthy daemon running its own two-replica
+fleet reports:
+
+```
+  pane %0 in workspace probe
+
+1 unrecorded item(s), left running. Re-run with --confirm to destroy them.
+```
+
+`%0` is the shell pane tmux creates with the session, before marvel
+splits replicas into it:
+
+```
+%0 pid=19198 cmd=zsh
+%1 pid=19203 cmd=mrig-sim
+%2 pid=19209 cmd=mrig-sim
+```
+
+So reap can never report clean, and an operator following its own
+prompt destroys part of a healthy session. Reproduced on the binary at
+`358d882` as well, so it predates this change. Filed separately; not
+touched here.
+
+## What this does NOT establish
+
+- Nothing about two daemons under one HOME. They still share one tmux
+  server, which is why the leave-alone default (decision 5) ships
+  alongside this rather than instead of it.
+- Nothing about real harnesses. The simulator runtime throughout, so no
+  model tokens were spent.
+- Nothing about the victim side. Under leave-alone there is no victim,
+  and the `--reclaim` and reap paths still leave the owner of destroyed
+  state with no record (`aae-orc-tt5e`).
+- Nothing about peer authentication. Every daemon ran at the same uid
+  (`aae-orc-sqh0`).

--- a/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
+++ b/_kos/nodes/bedrock/elem-tmux-session-substrate.yaml
@@ -52,10 +52,22 @@ content: |
   not a path) isolates it cleanly, so the mechanism exists and the
   default declines to use it.
 
+  **Scoped 2026-08-07 (`aae-orc-by6j`, marvel #128).** The default is
+  now `marvel-<first 8 hex of sha256(~/.marvel)>`, derived in
+  `paths.Layout.TmuxSocketName` beside `RuntimeSocket`, so each HOME
+  gets its own tmux server. `MARVEL_TMUX_SOCKET` keeps its meaning as
+  the override, and `MARVEL_TMUX_SOCKET=default` reproduces the old
+  shared behavior. Verified in `scripts/rig-daemon-isolation.sh`
+  scenario 6: two daemons, two servers, neither able to see the
+  other's sessions. The namespace is scoped, not eliminated: two
+  daemons under one HOME still share one tmux server.
+
   This does not reopen the substrate decision. It records that
   "tmux is the terminal and human-view layer" left the namespace
-  question unanswered. Open at `question-daemon-isolation-boundary`;
-  work item `aae-orc-kvcs`.
+  question unanswered, and that the answer is the HOME-rooted layout.
+  See `question-daemon-isolation-boundary` and
+  `docs/design/daemon-isolation.md` decision 4; work item
+  `aae-orc-kvcs`.
 edges:
   - target: aae-orc::elem-tmux-cmc
     type: derives

--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -87,11 +87,33 @@ content: |
 
   Probe: `aae-orc::_kos/probes/brief-marvel-runtime-socket-placement.md`
   (run 1 recorded 2026-08-06, corrected and closed 2026-08-07). The
-  probe is complete; no fix to either namespace has been built, so
-  nothing about the isolation boundary itself is a finding yet. The one
-  shipped change, PR #118, is attribution, not isolation.
+  probe is complete. The one change shipped at the time of writing, PR
+  #118, was attribution rather than isolation.
+
+  ANSWERED 2026-08-07, by build rather than by argument. The design is
+  `docs/design/daemon-isolation.md`; the verification is
+  `_kos/findings/finding-012-daemon-isolation-rig-verification.md` and
+  scenario 6 of `scripts/rig-daemon-isolation.sh`.
+
+  1. The isolation unit is the HOME-rooted `paths.Layout` (decision 1).
+  2. Yes. Both namespaces now derive from it: the control socket at
+     `Layout.RuntimeSocket` (marvel #122) and the tmux server name at
+     `Layout.TmuxSocketName` (marvel #128, `aae-orc-by6j`). Whether two
+     is the count is still not established, which is why both live in
+     `internal/paths` rather than each in its own package.
+  3. Leave alone (decision 5, marvel #123). Killing is `marvel daemon
+     --reclaim` or `marvel reap --confirm`.
+  4. Still a precondition for `question-multi-host`, now satisfied for
+     the single-host case.
+
+  Left open: whether a daemon may kill what it did not create at all
+  (decision 6), which `--reclaim` and reap still have to answer; and
+  the victim side, since the daemon whose panes are destroyed still
+  records nothing (`aae-orc-tt5e`, `aae-orc-4bz2`).
+
   Work items: `aae-orc-t6da` and `aae-orc-mh6g` (socket namespace),
   `aae-orc-kvcs` (tmux namespace and the unlogged kill),
+  `aae-orc-by6j` (the layout-derived tmux server name),
   `aae-orc-sqh0` (the same uid question this does not answer).
 edges:
   - target: elem-data-directory-permissions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,10 @@ entire running fleet of any other daemon sharing the tmux server. Reversed
 2026-08-07: err on silent accumulation, not silent destruction. Orphaned
 panes cost memory and can be reclaimed whenever an operator notices;
 destroyed work cannot be recovered. See
-`docs/design/daemon-isolation.md` decision 5.
+`docs/design/daemon-isolation.md` decision 5. Since 2026-08-07 daemons
+under different homes no longer share a tmux server at all, so the
+population `AdoptOrLeave` meets is normally the daemon's own leftovers;
+see [The tmux server](#the-tmux-server).
 
 ## Shift mechanics
 
@@ -230,6 +233,44 @@ separately (`aae-orc-sqh0`).
 This is not an authorization boundary. A 0700 socket is private to the
 user and remains reachable by every agent marvel spawns, because those
 run at the same uid.
+
+### The tmux server
+
+The control socket is one of two namespaces a daemon has to have to
+itself. The other is the tmux server its panes live on, and it is the
+destructive one: session names are `marvel-<workspace>`, so two daemons
+sharing a tmux server can each reach the other's entire running fleet.
+
+The daemon always runs on a dedicated tmux server (`tmux -L <name>`).
+Resolution order:
+
+1. `$MARVEL_TMUX_SOCKET`
+2. `marvel-<first 8 hex of sha256(~/.marvel)>`
+
+The derived name is 15 bytes whatever the home is, which matters because
+tmux refuses an over-long socket name with `File name too long` and
+marvel surfaces nothing: sessions simply stay pending. It is a pure
+function of the home, so a restarted daemon finds the same server and
+adopts its own panes.
+
+Until 2026-08 the default was the user's shared tmux server, so every
+marvel on the machine shared one namespace no matter how its HOME was
+set. Two consequences of the change:
+
+- Sessions an older build left on the shared server are invisible to the
+  new default rather than adopted. They keep running, and `marvel reap`
+  will not see them either, because reap looks at the daemon's own
+  server. Clean them up with `tmux -L default kill-session -t
+  marvel-<workspace>` before upgrading, or leave them and kill them
+  later; nothing destroys them.
+- `MARVEL_TMUX_SOCKET=default` reproduces the old shared behavior
+  exactly. `default` is tmux's own default server name, so `tmux -L
+  default` and a bare `tmux` are the same server.
+
+This shrinks the blast radius of a shared namespace; it does not remove
+it. Two daemons under one HOME still share one tmux server, which is why
+the leave-alone posture above ships alongside it. Full reasoning:
+`docs/design/daemon-isolation.md` decision 4.
 
 ### Cluster configuration
 

--- a/docs/design/daemon-isolation.md
+++ b/docs/design/daemon-isolation.md
@@ -192,6 +192,35 @@ Two consequences to state plainly:
   of Decision 5's kill posture. Two daemons sharing one HOME still share
   one tmux server.
 
+### Migration (resolved 2026-08-07)
+
+Ruled: accept the invisibility, document the cleanup, name the escape
+hatch. No adoption sweep.
+
+The rejected alternative was a one-time sweep over the shared default
+server at first start under the new scheme, adopting what matches
+records. It is the kindest option and the most code, and it reintroduces
+exactly one pass of the cross-server reach this decision removes. It was
+declined on measurement rather than taste: on the machine this shipped
+from there were zero live tmux servers and 529 stale socket files under
+`/private/tmp/tmux-501`, `tmux -L default list-sessions` reported no
+server, so the sweep would have been code written for a population that
+did not exist. If a fleet worth adopting ever turns up, the sweep is
+still available and the reasoning above is what it has to answer to.
+
+What ships instead:
+
+- The layout-derived default.
+- Cleanup instructions for an operator holding a live fleet on the
+  shared server: `tmux -L default kill-session -t marvel-<workspace>`
+  before upgrading. Nothing is destroyed if they do not; the sessions
+  keep running and stop being marvel's problem.
+- `MARVEL_TMUX_SOCKET=default` as the exact reproduction of the old
+  behavior. Verified rather than assumed: both `tmux list-sessions` and
+  `tmux -L default list-sessions` report the same socket,
+  `/private/tmp/tmux-501/default`, because `default` is tmux's own
+  default server name.
+
 ## Decision 5: the default posture toward unrecognised state (RESOLVED, Reading B)
 
 This is `aae-orc-kvcs` decision 2. **Ratified 2026-08-07: err on silent
@@ -351,9 +380,15 @@ rejecting a mismatch, which is authorization-shaped and belongs with
 ## Build sequence
 
 Status, 2026-08-07: steps 1 to 4 shipped in `ArcavenAE/marvel#122`, step
-7 in `#123`. Steps 5 and 6 are open. Step 6 was sequenced after 7 in the
-end, because 7 is what stops the destruction and 6 only lowers its
-frequency.
+7 in `#123`, step 5 in `#126`, step 6 in `#128`. Nothing here is open.
+Step 6 was sequenced after 7, because 7 is what stops the destruction and
+6 only lowers its frequency.
+
+The rig (`scripts/rig-daemon-isolation.sh`) gained scenario 6 with step
+6: two daemons under different homes, `MARVEL_TMUX_SOCKET` set nowhere,
+each on its own tmux server, each blind to the other's sessions. Unit
+tests cannot see this; the 109-byte failure below produced no marvel
+output at all.
 
 1. Decision 2. Socket resolves through `Layout`, both hardcode sites
    removed, `RuntimeSocket()` reconciled or deleted, path-length

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -19,6 +19,11 @@
 // Modes follow OpenSSH conventions. Private material is 0600 or 0700;
 // public material is 0644. The root directory is 0700.
 //
+// One name is derived here without being a file here: TmuxSocketName.
+// tmux owns that socket's location; the layout owns the name, because
+// the tmux server is an isolation boundary between daemons in the same
+// way the control socket is.
+//
 // The control socket is protected by its directory, not by its own mode.
 // Nothing in the tree chmods a socket, and with the common umask of 022
 // net.Listen creates it 0755. run/ is 0700 and mode-checked, which is
@@ -26,6 +31,8 @@
 package paths
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -125,6 +132,38 @@ func (l Layout) DaemonPid() string { return filepath.Join(l.RunDir(), "daemon.pi
 // protect it. See docs/design/daemon-isolation.md and aae-orc-t6da.
 func (l Layout) RuntimeSocket() string {
 	return filepath.Join(l.RunDir(), "marvel.sock")
+}
+
+// TmuxSocketName returns the tmux server socket NAME for this layout,
+// consumed as `tmux -L <name>`. It is a name, not a path: tmux places
+// the socket file itself, under its own per-uid directory.
+//
+// It lives here, beside RuntimeSocket, because the tmux session prefix
+// is the second machine-global namespace that escaped the HOME-rooted
+// layout, and it is the destructive one: a second daemon reached the
+// first daemon's entire running fleet through the shared default tmux
+// server. Deriving the name from Layout.Home gives each HOME its own
+// tmux server, so two daemons no longer see each other's sessions at
+// all. See docs/design/daemon-isolation.md decision 4 and aae-orc-by6j.
+//
+// Three constraints the derivation has to respect, all measured:
+//
+//   - It must be short. A 109-byte name was refused by tmux with "File
+//     name too long", and marvel emitted nothing at all: sessions simply
+//     stayed pending. This one is 15 bytes regardless of how deep Home is.
+//   - It must be stable across daemon restarts under the same HOME, or
+//     adopt-on-restart breaks and every restart orphans its own fleet.
+//     sha256 of Home is a pure function of the layout.
+//   - It must differ between HOMEs, which is the whole point.
+//
+// The scheme (marvel- plus the first 8 hex of sha256(Home)) is an
+// implementation choice; the constraints are not. Four bytes of hash is
+// not a collision guarantee, and it does not have to be: a collision
+// would put two HOMEs on one tmux server, which is exactly today's
+// behavior for every HOME.
+func (l Layout) TmuxSocketName() string {
+	sum := sha256.Sum256([]byte(l.Home))
+	return "marvel-" + hex.EncodeToString(sum[:4])
 }
 
 // MaxUnixSocketPath is the ceiling on a Unix-domain socket path,

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -123,6 +123,55 @@ func TestRuntimeSocketFollowsTheLayout(t *testing.T) {
 	}
 }
 
+// The tmux server is the second isolation unit, and the destructive one:
+// two daemons sharing it means either can reach the other's whole running
+// fleet. See docs/design/daemon-isolation.md decision 4, aae-orc-by6j.
+func TestTmuxSocketNameFollowsTheLayout(t *testing.T) {
+	a := WithHome("/home/alice/.marvel")
+	b := WithHome("/home/bob/.marvel")
+
+	if a.TmuxSocketName() == b.TmuxSocketName() {
+		t.Errorf("two layouts share a tmux server (%q); they must not", a.TmuxSocketName())
+	}
+
+	// Stability across restarts under the same HOME. Without this,
+	// adopt-on-restart breaks and every restart orphans its own fleet.
+	if got, want := WithHome("/home/alice/.marvel").TmuxSocketName(), a.TmuxSocketName(); got != want {
+		t.Errorf("name is not stable for one home: %q then %q", want, got)
+	}
+
+	// Shape: marvel- plus exactly 8 lowercase hex digits.
+	name := a.TmuxSocketName()
+	rest, ok := strings.CutPrefix(name, "marvel-")
+	if !ok {
+		t.Fatalf("name %q does not start with marvel-", name)
+	}
+	if len(rest) != 8 {
+		t.Errorf("name %q has a %d-digit suffix, want 8", name, len(rest))
+	}
+	for _, r := range rest {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Errorf("name %q has non-hex digit %q", name, r)
+			break
+		}
+	}
+}
+
+// tmux refused a 109-byte socket name with "File name too long" and
+// marvel emitted nothing at all: sessions stayed pending forever. The
+// name must not grow with the depth of HOME, so measure it against a
+// home far deeper than the failing case.
+func TestTmuxSocketNameStaysShortForADeepHome(t *testing.T) {
+	deep := WithHome("/" + strings.Repeat("verylongdirectorysegment/", 20) + ".marvel")
+	if len(deep.Home) < 109 {
+		t.Fatalf("test home is only %d bytes; it is meant to exceed the 109-byte case", len(deep.Home))
+	}
+	if got := len(deep.TmuxSocketName()); got != 15 {
+		t.Errorf("name for a %d-byte home is %d bytes (%q), want 15",
+			len(deep.Home), got, deep.TmuxSocketName())
+	}
+}
+
 func TestCheckSocketPath(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/arcavenae/marvel/internal/paths"
 )
 
 // DefaultHistoryLimit is the tmux history-limit (scrollback lines) marvel
@@ -24,12 +26,14 @@ const DefaultHistoryLimit = 100000
 type Driver struct {
 	binary string
 
-	// socket is the tmux server socket name. Empty means the default
-	// tmux server. When non-empty every tmux invocation prepends
-	// -L <socket>, scoping the driver to a dedicated server.
+	// socket is the tmux server socket name. Every tmux invocation
+	// prepends -L <socket>, scoping the driver to a dedicated server.
+	// Empty means the user's shared default tmux server, which is no
+	// longer what NewDriver produces: it now derives a name from the
+	// paths layout so each HOME gets its own tmux server.
 	//
-	// Set via the MARVEL_TMUX_SOCKET env var at NewDriver time. Tests
-	// use this to get per-package isolation from the system-wide tmux.
+	// MARVEL_TMUX_SOCKET overrides the derived name. Tests use it to get
+	// per-package isolation from the system-wide tmux.
 	socket string
 
 	// paneMu serializes SendKeys per pane. The daemon runs each inject
@@ -45,18 +49,38 @@ type Driver struct {
 
 // NewDriver creates a tmux driver, verifying tmux is available.
 //
-// If MARVEL_TMUX_SOCKET is set, the driver talks to a dedicated tmux
-// server at that socket name (tmux -L <socket>). Useful for test
-// isolation and for running marvel alongside an unrelated tmux
-// workflow on the same machine.
+// The driver always talks to a dedicated tmux server (tmux -L <name>).
+// The name is MARVEL_TMUX_SOCKET when set, and otherwise is derived from
+// the paths layout, so daemons under different HOMEs land on different
+// tmux servers and cannot see each other's sessions.
+//
+// Before this, the default was the user's shared tmux server, which is
+// how a second daemon destroyed the first's entire running fleet through
+// the marvel-* session prefix. Two consequences worth stating:
+//
+//   - marvel sessions left on the shared default server by an older
+//     build become invisible rather than adopted. They keep running.
+//     Clean them up with `tmux -L default kill-session -t marvel-<name>`.
+//   - MARVEL_TMUX_SOCKET=default reproduces the old shared behavior
+//     exactly, since `default` is tmux's own default server name.
+//
+// See docs/design/daemon-isolation.md decision 4.
 func NewDriver() (*Driver, error) {
 	path, err := exec.LookPath("tmux")
 	if err != nil {
 		return nil, fmt.Errorf("tmux not found: %w", err)
 	}
+	socket := os.Getenv("MARVEL_TMUX_SOCKET")
+	if socket == "" {
+		layout, lerr := paths.Default()
+		if lerr != nil {
+			return nil, fmt.Errorf("derive tmux socket name: %w", lerr)
+		}
+		socket = layout.TmuxSocketName()
+	}
 	return &Driver{
 		binary: path,
-		socket: os.Getenv("MARVEL_TMUX_SOCKET"),
+		socket: socket,
 		paneMu: make(map[string]*sync.Mutex),
 	}, nil
 }
@@ -92,9 +116,10 @@ func (d *Driver) cmd(args ...string) *exec.Cmd {
 	return exec.Command(d.binary, args...)
 }
 
-// Socket returns the tmux socket name the driver is scoped to, or
-// empty string for the default tmux server. Used by test teardown to
-// kill the right server.
+// Socket returns the tmux socket name the driver is scoped to. Used by
+// test teardown to kill the right server. A driver built by NewDriver
+// always has one; only a hand-built Driver literal can report empty,
+// which still means the shared default server.
 func (d *Driver) Socket() string { return d.socket }
 
 // HasSession checks if a tmux session exists.

--- a/internal/tmux/driver_test.go
+++ b/internal/tmux/driver_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/arcavenae/marvel/internal/paths"
 )
 
 func skipIfNoTmux(t *testing.T) {
@@ -25,6 +27,53 @@ func TestNewDriver(t *testing.T) {
 	}
 	if d.binary == "" {
 		t.Fatal("expected binary path")
+	}
+}
+
+// With no MARVEL_TMUX_SOCKET the driver must still scope itself to a
+// dedicated server. An empty socket here is the shared default tmux
+// server, which is the namespace a second daemon used to destroy the
+// first's fleet through. See aae-orc-by6j.
+func TestNewDriverDerivesASocketWhenTheEnvIsUnset(t *testing.T) {
+	skipIfNoTmux(t)
+	// TestMain sets this for the whole package; clear it for this case.
+	t.Setenv("MARVEL_TMUX_SOCKET", "")
+	t.Setenv("HOME", t.TempDir())
+
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	if d.Socket() == "" {
+		t.Fatal("driver fell back to the shared default tmux server")
+	}
+	layout, err := paths.Default()
+	if err != nil {
+		t.Fatalf("resolve layout: %v", err)
+	}
+	derived := layout.TmuxSocketName()
+	if d.Socket() != derived {
+		t.Errorf("socket %q, want the layout-derived %q", d.Socket(), derived)
+	}
+	// The derived name has to reach the -L argument, not just the field.
+	args := d.cmd("list-sessions").Args
+	if len(args) < 3 || args[1] != "-L" || args[2] != derived {
+		t.Errorf("tmux args %v do not carry -L %s", args, derived)
+	}
+}
+
+// The override has to keep working, because it is the escape hatch for
+// the shared-server behavior and for per-package test isolation.
+func TestNewDriverPrefersTheEnvOverride(t *testing.T) {
+	skipIfNoTmux(t)
+	t.Setenv("MARVEL_TMUX_SOCKET", "mxOverride")
+
+	d, err := NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	if got := d.Socket(); got != "mxOverride" {
+		t.Errorf("socket %q, want mxOverride", got)
 	}
 }
 

--- a/scripts/rig-daemon-isolation.sh
+++ b/scripts/rig-daemon-isolation.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # Rig verification for aae-orc-3st1.
 #
+# Extended for aae-orc-by6j: scenario 6.
+#
 # Verifies the behavior shipped in marvel #122 (socket through the layout,
-# advisory lock) and #123 (adopt-or-leave default, --reclaim, reap) with
-# two daemons actually running at once, which is the only condition the
-# original bugs appear under.
+# advisory lock), #123 (adopt-or-leave default, --reclaim, reap), and the
+# layout-derived tmux socket name, with two daemons actually running at
+# once, which is the only condition the original bugs appear under.
+#
+# Scenarios 0 to 5 set MARVEL_TMUX_SOCKET explicitly, including the
+# deliberately shared server the fleet-kill case needs. Scenario 6 sets
+# it nowhere, because the DEFAULT is what it measures.
 #
 # SAFETY: every daemon runs under a throwaway HOME in /tmp and a dedicated
 # tmux socket NAME. Nothing touches the real ~/.marvel, whose bolt still
@@ -35,15 +41,38 @@ hdr()  { echo; echo "=== $* ==="; }
 # measured nothing. Count lines instead.
 sims() { pgrep -f "$SIM" 2>/dev/null | wc -l | tr -d ' '; }
 
+# Scenario 6 helpers. `tmux ... | wc -l` reports 0 both for "server is
+# live and empty" and for "there is no server", so a comparison against
+# 0 passes without measuring anything. These report -1 for the absent
+# server, which no expected count ever equals.
+panes_on() {
+  local out
+  if ! out=$(tmux -L "$1" list-panes -a 2>/dev/null); then echo -1; return; fi
+  printf '%s\n' "$out" | grep -c . | tr -d ' '
+}
+fmt_panes() { if (( $1 < 0 )); then echo "no server"; else echo "$1 pane(s)"; fi; }
+sessions_on() {
+  if ! tmux -L "$1" list-sessions -F '#S' 2>/dev/null; then return 1; fi
+}
+# The name marvel derives for a HOME: paths.Layout.TmuxSocketName().
+# Reproduced here rather than asked of the binary on purpose. If marvel's
+# derivation ever changes, the server this names stops existing and the
+# scenario fails loudly instead of measuring a server nobody uses.
+tmux_name_for_home() {
+  printf 'marvel-%s' "$(printf '%s' "$1/.marvel" | shasum -a 256 | cut -c1-8)"
+}
+
 cleanup() {
   hdr "cleanup"
-  for s in "$TMUX_A" "$TMUX_B" "$TMUX_S"; do
+  for s in "$TMUX_A" "$TMUX_B" "$TMUX_S" \
+           "$(tmux_name_for_home "$HOME_A")" "$(tmux_name_for_home "$HOME_B")"; do
     tmux -L "$s" kill-server 2>/dev/null
   done
   pkill -f 'mrig-marvel daemon' 2>/dev/null
   pkill -f mrig-sim 2>/dev/null
   sleep 1
-  rm -rf "$HOME_A" "$HOME_B" "$SHARED_SOCK" "$SHARED_SOCK.lock"
+  rm -rf "$HOME_A" "$HOME_B" "$SHARED_SOCK" "$SHARED_SOCK.lock" \
+         /tmp/mrig-fleet.toml /tmp/mrig-fleet-beta.toml
   echo "  torn down"
 }
 trap cleanup EXIT
@@ -148,6 +177,11 @@ HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
 HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
 sleep 2
 rm -rf "$HOME_A" "$HOME_B"; mkdir -p "$HOME_A" "$HOME_B"
+# Scenario 2's fleet is still running on its own server. `marvel stop` is
+# detach, not teardown, so without this the machine-global sims() count
+# carries scenario 2's simulators into every later scenario's numbers.
+tmux -L "$TMUX_A" kill-server 2>/dev/null
+sleep 1
 
 HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon \
   --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
@@ -222,19 +256,42 @@ fi
 
 # ---------------------------------------------------------------- scenario 4b
 hdr "4b. --reclaim still destroys, deliberately"
+# Builds its own fleet from a clean slate rather than inheriting scenario
+# 4's. Scenario 4 ends with `reap --confirm` having destroyed marvel-alpha,
+# and daemon A does not respawn it (aae-orc-4bz2: the victim daemon
+# records nothing), so re-applying the manifest against A's existing store
+# produced no panes. The old check then measured scenario 2's leftover
+# simulators on a different tmux server and read 2 -> 2 as a --reclaim
+# failure. Verified 2026-08-07: --reclaim takes 2 simulators to 0 and logs
+# the kill when the fleet it is aimed at actually exists.
 HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+tmux -L "$TMUX_S" kill-server 2>/dev/null
+rm -rf "$HOME_A"; mkdir -p "$HOME_A"
+HOME="$HOME_A" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon \
+  --log-file="$HOME_A/d3.log" >"$HOME_A/out3.log" 2>&1 &
 sleep 2
 HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
 sleep 8
-pre_reclaim=$(sims)
+
+# Pane counts on the target server, not the machine-global process count:
+# panes_on reports -1 for an absent server, so no expected value is
+# reachable by accident.
+pre_reclaim=$(panes_on "$TMUX_S")
+if (( pre_reclaim > 0 )); then
+  ok "precondition: A has $pre_reclaim pane(s) on the shared server to reclaim"
+else
+  bad "precondition failed, nothing to reclaim: $pre_reclaim pane(s)"
+fi
 HOME="$HOME_B" MARVEL_TMUX_SOCKET="$TMUX_S" "$MARVEL" daemon --reclaim \
   --log-file="$HOME_B/d2.log" >"$HOME_B/out2.log" 2>&1 &
 sleep 7
-post_reclaim=$(sims)
+post_reclaim=$(panes_on "$TMUX_S")
 if (( pre_reclaim > 0 && post_reclaim < pre_reclaim )); then
-  ok "--reclaim destroyed the fleet on purpose: $pre_reclaim -> $post_reclaim simulators"
+  ok "--reclaim destroyed the fleet on purpose: $pre_reclaim pane(s) -> $(fmt_panes "$post_reclaim")"
 else
-  bad "--reclaim did not destroy: $pre_reclaim -> $post_reclaim"
+  bad "--reclaim did not destroy: $pre_reclaim -> $(fmt_panes "$post_reclaim")"
 fi
 if grep -q "killed" "$HOME_B/d2.log" 2>/dev/null; then
   ok "reclaim logged the kill with its own identity"
@@ -281,6 +338,140 @@ if (( readopted == survived )); then
 else
   bad "agents lost across restart: $survived -> $readopted"
 fi
+
+# --------------------------------------------------------------- scenario 6
+# The one aae-orc-3st1 could not run: finding-012 verified survivability
+# on a SHARED tmux server, not isolation. This is the isolation claim.
+hdr "6. tmux server isolation by HOME, no MARVEL_TMUX_SOCKET anywhere (#by6j)"
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+tmux -L "$TMUX_A" kill-server 2>/dev/null
+tmux -L "$TMUX_S" kill-server 2>/dev/null
+rm -rf "$HOME_A" "$HOME_B"; mkdir -p "$HOME_A" "$HOME_B"
+
+sed 's/name = "alpha"/name = "beta"/' /tmp/mrig-fleet.toml > /tmp/mrig-fleet-beta.toml
+
+NAME_A=$(tmux_name_for_home "$HOME_A")
+NAME_B=$(tmux_name_for_home "$HOME_B")
+echo "  derived: $HOME_A -> $NAME_A"
+echo "  derived: $HOME_B -> $NAME_B"
+if [[ "$NAME_A" != "$NAME_B" && -n "$NAME_A" ]]; then
+  ok "two HOMEs derive two different tmux server names"
+else
+  bad "derivation collapsed: A=$NAME_A B=$NAME_B"
+fi
+
+# Note the absence of MARVEL_TMUX_SOCKET on both. That is the point.
+HOME="$HOME_A" "$MARVEL" daemon --log-file="$HOME_A/d.log" >"$HOME_A/out.log" 2>&1 &
+sleep 2
+HOME="$HOME_A" "$MARVEL" work /tmp/mrig-fleet.toml >/dev/null 2>&1
+sleep 7
+HOME="$HOME_B" "$MARVEL" daemon --log-file="$HOME_B/d.log" >"$HOME_B/out.log" 2>&1 &
+sleep 2
+HOME="$HOME_B" "$MARVEL" work /tmp/mrig-fleet-beta.toml >/dev/null 2>&1
+sleep 7
+
+pa=$(panes_on "$NAME_A")
+pb=$(panes_on "$NAME_B")
+echo "  panes: $NAME_A=$pa  $NAME_B=$pb  (-1 means no such server)"
+if (( pa > 0 && pb > 0 )); then
+  ok "each HOME started its own tmux server, both populated ($pa and $pb panes)"
+else
+  bad "expected two populated servers, got A=$pa B=$pb"
+fi
+
+sess_a=$(sessions_on "$NAME_A" | sort | tr '\n' ' ')
+sess_b=$(sessions_on "$NAME_B" | sort | tr '\n' ' ')
+echo "  sessions on $NAME_A: $sess_a"
+echo "  sessions on $NAME_B: $sess_b"
+if grep -q 'marvel-alpha' <<<"$sess_a" && ! grep -q 'marvel-beta' <<<"$sess_a"; then
+  ok "A's server carries marvel-alpha and not B's marvel-beta"
+else
+  bad "A's server is wrong: $sess_a"
+fi
+if grep -q 'marvel-beta' <<<"$sess_b" && ! grep -q 'marvel-alpha' <<<"$sess_b"; then
+  ok "B's server carries marvel-beta and not A's marvel-alpha"
+else
+  bad "B's server is wrong: $sess_b"
+fi
+
+both=$(sims)
+if (( both == 4 )); then
+  ok "both fleets alive: $both simulators (2 per daemon)"
+else
+  bad "expected 4 simulators across two daemons, got $both"
+fi
+
+a_view=$(HOME="$HOME_A" "$MARVEL" get sessions 2>/dev/null)
+b_view=$(HOME="$HOME_B" "$MARVEL" get sessions 2>/dev/null)
+if grep -q alpha <<<"$a_view" && ! grep -q beta <<<"$a_view"; then
+  ok "A's session table shows alpha only"
+else
+  bad "A's session table: $a_view"
+fi
+if grep -q beta <<<"$b_view" && ! grep -q alpha <<<"$b_view"; then
+  ok "B's session table shows beta only"
+else
+  bad "B's session table: $b_view"
+fi
+
+# The discriminator between "isolated" and "shared but leaving alone".
+# On a shared server B would list A's marvel-alpha as a reap candidate and
+# log reconcile.left for it. On its own server it cannot see alpha at all.
+#
+# The assertion is "no alpha", not "nothing to reap": reap legitimately
+# lists one pane per session that marvel does not record, the shell pane
+# tmux creates with the session itself before marvel splits replicas into
+# it. That is pre-existing and unrelated to isolation (a 2-replica role
+# produces 3 panes throughout this rig), so "nothing to reap" would fail
+# for a reason this scenario is not about.
+reap_b=$(HOME="$HOME_B" "$MARVEL" reap 2>&1)
+echo "$reap_b" | sed 's/^/      /'
+if ! grep -qE 'unrecorded|Nothing to reap' <<<"$reap_b"; then
+  bad "B's reap produced no listing at all, so it measured nothing: $reap_b"
+elif grep -q 'alpha' <<<"$reap_b"; then
+  bad "B can still see A's tmux state: $reap_b"
+else
+  ok "B's reap candidates contain nothing from workspace alpha: A's fleet is invisible"
+fi
+
+if [[ ! -s "$HOME_B/d.log" ]]; then
+  bad "B has no daemon log, so the left-running check would pass vacuously"
+elif grep -q "left .* running" "$HOME_B/d.log"; then
+  bad "B still met A's sessions: $(grep -m1 'left .* running' "$HOME_B/d.log")"
+else
+  ok "B logged no left-running line (nothing foreign was on its server)"
+fi
+
+if tmux -L default list-sessions 2>/dev/null | grep -q '^marvel-'; then
+  bad "a marvel session landed on the shared default tmux server"
+else
+  ok "the shared default tmux server carries no marvel sessions"
+fi
+
+# Stability. A derived name that moved between restarts would orphan the
+# fleet it just created, which is the failure the sha256-of-HOME shape
+# exists to prevent.
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
+alive=$(sims)
+HOME="$HOME_A" "$MARVEL" daemon --log-file="$HOME_A/d2.log" >"$HOME_A/out2.log" 2>&1 &
+sleep 6
+if grep -q "adopted pane" "$HOME_A/d2.log" 2>/dev/null; then
+  ok "restarted A found the same server and adopted $(grep -c 'adopted pane' "$HOME_A/d2.log") pane(s)"
+else
+  bad "restarted A adopted nothing; the derived name moved. Log: $(tail -5 "$HOME_A/d2.log" 2>&1)"
+fi
+if (( $(sims) == alive && alive > 0 )); then
+  ok "no agent lost across the restart ($alive alive)"
+else
+  bad "agents lost across restart: $alive -> $(sims)"
+fi
+
+HOME="$HOME_A" "$MARVEL" stop >/dev/null 2>&1
+HOME="$HOME_B" "$MARVEL" stop >/dev/null 2>&1
+sleep 2
 
 hdr "result"
 echo "  $PASS passed, $FAIL failed"


### PR DESCRIPTION
Two marvel daemons on one machine shared a single tmux server, so either could reach the other's entire running fleet through the `marvel-*` session prefix. That is the namespace that actually destroyed a fleet during the 2026-08-06 probe, verified independent of the control socket. This scopes it to the same HOME-rooted layout the socket moved to in #126's predecessor, #122, and closes the last open step of `docs/design/daemon-isolation.md`.

## What changes

The default tmux socket name becomes `marvel-<first 8 hex of sha256(~/.marvel)>`, derived by `paths.Layout.TmuxSocketName` beside `RuntimeSocket`. Both isolation units now have one definition in one package, which is the point: two machine-global namespaces drifted apart because nobody decided them together, and a rule with two encodings is how the third one escapes. `MARVEL_TMUX_SOCKET` keeps its current meaning and precedence as the explicit override.

The scheme is an implementation choice; the three constraints are not, and all three were measured rather than assumed:

- **Short.** 15 bytes for any home, including a 508-byte one. A 109-byte name was refused by tmux with `File name too long` while marvel emitted nothing at all, leaving sessions pending forever.
- **Stable per home.** A name that moved between restarts would orphan the fleet the daemon just created, since adopt-on-restart discriminates by record on the daemon's own server.
- **Different between homes.** The whole point.

## Migration: accept it, document it, name the escape hatch

No adoption sweep. Sessions an older build left on the shared default server become invisible rather than adopted; they keep running, and `marvel reap` will not see them either. Operators holding a live fleet clean up with `tmux -L default kill-session -t marvel-<workspace>` before upgrading, and `MARVEL_TMUX_SOCKET=default` reproduces the old shared behavior exactly (verified: `tmux list-sessions` and `tmux -L default list-sessions` report the same socket path, because `default` is tmux's own default server name).

The sweep was declined on a measurement. This machine had zero live tmux servers behind 529 stale socket files under `/private/tmp/tmux-501`, so the sweep would have been code for a population that does not exist, and it would have reintroduced exactly one pass of the cross-server reach being removed. If a fleet worth adopting ever turns up, the option is still there.

## Verification

Unit tests cannot see these failure modes; the 109-byte case produced no marvel output whatsoever. So `scripts/rig-daemon-isolation.sh` gains scenario 6: two daemons, different HOMEs, `MARVEL_TMUX_SOCKET` set nowhere.

```
derived: /tmp/mrig-a -> marvel-0960b344
derived: /tmp/mrig-b -> marvel-926b8048
panes: marvel-0960b344=3  marvel-926b8048=3  (-1 means no such server)
sessions on marvel-0960b344: marvel-alpha
sessions on marvel-926b8048: marvel-beta
```

Both fleets alive at 4 simulators, each daemon's session table showing its own workspace only, B's `reap` listing nothing from workspace alpha, B's log carrying no `reconcile.left` line (the discriminator between isolated and sharing-but-declining-to-kill), nothing on the shared default server, and a restarted daemon A finding the same server and re-adopting its own panes. 32 checks pass, 0 fail. Simulator runtime throughout, separate HOMEs in short `/tmp` paths, never against the real `~/.marvel`.

Scenario 4b (`--reclaim` still destroys) is fixed in the same change. It failed on the first run, and fails identically on the unmodified binary at `358d882`, so it is not a regression here. It inherited scenario 4's destroyed fleet and then compared a machine-wide simulator count that `--reclaim` could not move, reading `2 -> 2` against a `--reclaim` that works fine when aimed at a fleet that exists. It now builds its own fleet, asserts the precondition out loud, and counts panes on the target server; the helper reports `-1` for an absent server so no expected value is reachable by accident. Scenario 3 kills the previous scenario's tmux server first, so its numbers stop carrying earlier simulators and now match what finding-012 recorded.

## Cost of merge

The default changes, which is the intent; the override is unchanged and every existing `MARVEL_TMUX_SOCKET` caller behaves as before. All package tests set it explicitly, so test isolation is untouched. `go test ./... -race`, `go vet`, `gofumpt -l`, and `golangci-lint run` are clean.

## Notes

`marvel reap` lists one permanent candidate per live session the daemon itself owns: the shell pane tmux creates with the session, before marvel splits replicas into it. Reproduced on `358d882` too, so it predates this change and is untouched here; recorded in finding-013 and filed separately.

Refs: aae-orc-by6j. Design: `docs/design/daemon-isolation.md` decision 4. Measurement: `_kos/findings/finding-013-tmux-server-isolation-by-home.md`.
