### PR TITLE
finding: finding-012 — correct the reap scenario, it measured tmux's base pane

### DIFF
--- a/_kos/findings/finding-012-daemon-isolation-rig-verification.md
+++ b/_kos/findings/finding-012-daemon-isolation-rig-verification.md
@@ -101,6 +101,52 @@ blind read. Both times the flaw made a result look stronger or weaker
 than it was, and both times only re-reading the primary evidence found
 it. A green tally is not a result.
 
+## Correction, 2026-08-07: the reap scenario measured the wrong object
+
+The claim above that "`marvel reap` listed one candidate and destroyed
+nothing; `reap --confirm` destroyed it" is true as written and does not
+mean what it was recorded to mean. Found while building finding-013.
+
+That one candidate was not an orphan. It was the tmux base pane (`%0`,
+running a shell) that tmux creates with every session before marvel
+splits replicas into it. `UnrecordedTmuxState` builds its recorded set
+from `sess.PaneID` over store sessions, and the base pane is never a
+marvel session, so it is never recorded and is always reported. A single
+healthy daemon on its own fleet reports "1 unrecorded item(s)", and
+`reap --confirm` on a healthy fleet destroys a pane inside a live
+session.
+
+So the scenario demonstrated that reap's plumbing works, not that reap
+correctly identifies orphans. The destructive half is worse than
+unproven: it is wrong, and this finding's green result helped it look
+right. Filed as ArcavenAE/marvel#129; it predates finding-013's change
+and was reproduced against the unmodified `358d882` binary.
+
+**Scenario 4b no longer reproduces**, also verified against unmodified
+`358d882`, so it is not a regression from later work. Two causes
+compounded: 4b inherited the fleet scenario 4's `reap --confirm` had
+already destroyed, and the `sims()` helper counts machine-wide while
+`marvel stop` is detach rather than teardown, so both readings were
+earlier scenarios' surviving simulators on a tmux server `--reclaim`
+never touched. Measured directly, `--reclaim` does take 2 simulators to
+0 and logs the kill. The rig has been fixed to start 4b from a clean
+slate with a loud precondition assertion, and to kill the prior
+scenario's tmux server so counts stop carrying earlier processes.
+
+**This is the third methodology error in this ticket family, and the
+first two are in this document.** All three share one shape: a check
+passed while measuring something other than what it claimed. The
+`pgrep -fc` error made a comparison vacuously true; the exit-code error
+in the sibling rustfmt work read `head`'s status instead of cargo's;
+this one counted a live shell pane as an orphan. Orc finding-114
+generalizes the lesson from a different tool: a green check does not
+mean the thing you declared was the thing that got checked. It applies
+to this rig as much as to rustfmt, which is why the correction is
+appended here rather than filed only downstream.
+
+The original text above is left unaltered. Findings record what was
+believed when written; corrections append.
+
 ## What this does NOT establish
 
 - Nothing about the tmux namespace being scoped. It is still

--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -92,8 +92,17 @@ content: |
 
   ANSWERED 2026-08-07, by build rather than by argument. The design is
   `docs/design/daemon-isolation.md`; the verification is
-  `_kos/findings/finding-012-daemon-isolation-rig-verification.md` and
+  `_kos/findings/finding-012-daemon-isolation-rig-verification.md`,
+  `_kos/findings/finding-013-tmux-server-isolation-by-home.md`, and
   scenario 6 of `scripts/rig-daemon-isolation.sh`.
+
+  Read finding-012 WITH its 2026-08-07 correction, not without it. Two
+  of its recorded results did not mean what they were recorded to mean,
+  and one of them concerns a destructive path: the single candidate its
+  reap scenario destroyed was tmux's base shell pane, not an orphan, so
+  reap's orphan identification is unverified and in fact wrong
+  (ArcavenAE/marvel#129). Isolation is verified; reap's correctness is
+  not, and the two were reported together.
 
   1. The isolation unit is the HOME-rooted `paths.Layout` (decision 1).
   2. Yes. Both namespaces now derive from it: the control socket at


### PR DESCRIPTION
finding-012 is the document anyone will read to decide whether today's daemon-isolation work is trustworthy, and one of its recorded results concerns a destructive path that turns out to be wrong. Correcting it matters more than the code fix would, because the finding is what makes the code look verified.

The finding recorded that `marvel reap` listed one candidate and `reap --confirm` destroyed it, and read that as orphan identification working. That candidate was tmux's base shell pane, created with every session before marvel splits replicas into it. `UnrecordedTmuxState` builds its recorded set from store sessions' `PaneID`, and the base pane is never a marvel session, so a healthy single daemon always reports one unrecorded item and `reap --confirm` on a healthy fleet destroys a pane inside a live session. Filed separately as #129 and reproduced against the unmodified `358d882` binary, so it predates #128.

Scenario 4b also no longer reproduces, likewise checked against `358d882` rather than assumed to be a regression from later work.

The original text is left unaltered and the correction appends, since findings record what was believed when written. The frontier node now cites finding-013 alongside finding-012 and states plainly that isolation is verified while reap's correctness is not. The two were reported together, so a reader would otherwise inherit the confidence of the first for the second.

This is the third methodology error in this ticket family, and the first two are in the same document. All three share one shape: a check passed while measuring something other than what it claimed. Orc finding-114 names the general form from a different tool.

Cost of merge: two files, one finding and one node. No code, no behavior change.