### PR TITLE
fix: expose the tmux server name so scripts stop reaching the wrong server

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arcavenae/marvel/internal/keys"
 	"github.com/arcavenae/marvel/internal/paths"
 	"github.com/arcavenae/marvel/internal/rlog"
+	"github.com/arcavenae/marvel/internal/tmux"
 	"github.com/arcavenae/marvel/internal/upgrade"
 	"github.com/spf13/cobra"
 )
@@ -1098,6 +1099,29 @@ func configCmd() *cobra.Command {
 		Use:   "config",
 		Short: "Manage marvel cluster configuration",
 	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "tmux-server",
+		Short: "Print the tmux server name this HOME's daemon uses",
+		Long: `Print the tmux server name (` + "`tmux -L <name>`" + `) for this HOME.
+
+Since marvel #128 each HOME gets its own tmux server, so a bare
+` + "`tmux kill-session -t marvel-<workspace>`" + ` reaches the wrong server. Scripts
+and runbooks use this to get the name instead of recomputing it:
+
+  tmux -L "$(marvel config tmux-server)" kill-session -t marvel-demo
+
+MARVEL_TMUX_SOCKET overrides the derived name and is reported as-is.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, err := tmux.SocketName()
+			if err != nil {
+				return err
+			}
+			fmt.Println(name)
+			return nil
+		},
+	})
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "list",

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -43,11 +43,19 @@ The acts read better watched than replayed. Two tools:
   tail, then polls once a second and prints each new event exactly once,
   in order, using a ring-assigned sequence cursor. All the usual filters
   compose with it (`--workspace`, `--kind`, `--warnings`).
-- `just demo-watch` builds a four-pane tmux operator console (driver
-  shell, live session table, live event tail, daemon log poll). Attach
-  with `tmux attach -t marvel-watch`, drive the beats from the top-left
-  pane, and watch states flip in real time. The panes poll until a
-  daemon appears, so start it in whichever order you like.
+- `just demo-watch` builds a four-pane tmux operator console:
+
+  |  | left | right |
+  |---|---|---|
+  | **top** | live session table | live event tail |
+  | **bottom** | driver shell | daemon log poll |
+
+  Attach with `tmux attach -t marvel-watch`, drive the beats from the
+  bottom-left pane (already selected on attach), and watch states flip in
+  real time. The readouts sit on top: the session table directly above the
+  shell acting on it, the daemon log directly below the events it explains.
+  The panes poll until a daemon appears, so start it in whichever order you
+  like.
 
 ---
 
@@ -356,3 +364,22 @@ rm -f ~/.marvel/state/marvel.bolt
 `just clean` also removes `bin/` and the default socket, but it only kills the
 `marvel-demo` tmux session; `stop --teardown` is what ends every agent across
 all workspaces.
+
+Since #128 each HOME has its own tmux server, so anything reaching marvel's
+sessions with raw tmux needs `-L`. Ask the binary for the name rather than
+recomputing it:
+
+```sh
+tmux -L "$(marvel config tmux-server)" attach -t marvel-demo
+tmux -L "$(marvel config tmux-server)" list-sessions
+```
+
+A bare `tmux kill-session -t marvel-demo` now targets tmux's shared default
+server and silently reaches nothing. `just clean` was fixed to pass `-L`, and
+degrades with a message when `bin/marvel` is not built rather than pretending
+it cleaned up.
+
+The `marvel-watch` operator console from `just demo-watch` is unaffected. It is
+a plain tmux session of your own on the default server, and its panes reach the
+daemon over the control socket, so `tmux attach -t marvel-watch` is still
+correct as written above.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -434,6 +434,16 @@ marvel get sessions --socket mrvl://kinu
 marvel get sessions --socket /tmp/marvel-dev.sock
 ```
 
+`--socket` takes either an `mrvl://` address or a Unix socket path. With
+neither `--socket` nor `--cluster`, marvel uses `MARVEL_SOCKET` if set and
+otherwise `~/.marvel/run/marvel.sock`.
+
+That default follows `HOME`, which is how you run more than one daemon on one
+machine: give each its own `HOME` and each gets its own control socket and its
+own tmux server, with neither able to see the other's sessions. `marvel config
+list` shows the resolved default, and `marvel config tmux-server` prints the
+tmux server name for scripts that need `tmux -L`.
+
 ## Deleting resources
 
 ```bash
@@ -446,6 +456,32 @@ marvel delete team dev/squad
 # Delete a workspace and everything in it
 marvel delete workspace dev
 ```
+
+## Reclaiming leftover tmux state
+
+A restarted daemon adopts the panes it has records for and **leaves the rest
+running**. It does not destroy tmux state it does not recognise, because that
+state may be another daemon's live fleet. What it left is reported as a
+`reconcile.left` warning, visible in `marvel events`.
+
+Two deliberate paths reclaim it. Neither is automatic:
+
+```bash
+marvel reap             # list what this daemon does not own, destroy nothing
+marvel reap --confirm   # destroy it
+marvel daemon --reclaim # kill unrecognised state at startup instead of leaving it
+```
+
+`marvel reap` on its own is a query. The listing warns that candidates may
+belong to another running daemon, which is worth taking literally: check before
+confirming.
+
+> **Known defect (ArcavenAE/marvel#129).** `reap` currently reports one false
+> candidate per live session, the base shell pane tmux creates before marvel
+> adds replica panes. A healthy daemon therefore never reports clean, and
+> `reap --confirm` on a healthy fleet destroys that pane. Agents survive, since
+> replicas live in their own windows, but do not read a non-empty `reap` listing
+> as evidence of leftovers until this is fixed.
 
 ## Version and upgrade
 

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -70,19 +70,40 @@ func NewDriver() (*Driver, error) {
 	if err != nil {
 		return nil, fmt.Errorf("tmux not found: %w", err)
 	}
-	socket := os.Getenv("MARVEL_TMUX_SOCKET")
-	if socket == "" {
-		layout, lerr := paths.Default()
-		if lerr != nil {
-			return nil, fmt.Errorf("derive tmux socket name: %w", lerr)
-		}
-		socket = layout.TmuxSocketName()
+	socket, err := SocketName()
+	if err != nil {
+		return nil, err
 	}
 	return &Driver{
 		binary: path,
 		socket: socket,
 		paneMu: make(map[string]*sync.Mutex),
 	}, nil
+}
+
+// SocketEnv is the environment variable that overrides the derived tmux
+// server name. Named here, once, because the driver and every caller
+// that needs to report or reproduce the driver's target must agree on
+// it; a second string literal elsewhere is how the control socket's
+// default survived a fix by being declared twice (marvel #122).
+const SocketEnv = "MARVEL_TMUX_SOCKET"
+
+// SocketName resolves the tmux server name the driver will use: the
+// SocketEnv override when set, otherwise the layout-derived name.
+//
+// Exported so operators and scripts can ask marvel which tmux server to
+// reach rather than recomputing sha256(HOME) in shell. `just clean` and
+// the demo runbook both need `tmux -L <name>`, and a shell reimplementation
+// of the derivation would be a second definition of it.
+func SocketName() (string, error) {
+	if s := os.Getenv(SocketEnv); s != "" {
+		return s, nil
+	}
+	layout, err := paths.Default()
+	if err != nil {
+		return "", fmt.Errorf("derive tmux socket name: %w", err)
+	}
+	return layout.TmuxSocketName(), nil
 }
 
 // lockPane acquires the per-pane inject lock and returns its unlock

--- a/justfile
+++ b/justfile
@@ -65,7 +65,7 @@ demo: build
     ./bin/marvel get endpoints
     @echo ""
     @echo "Demo running. Use 'just stop' to tear down."
-    @echo "Attach to tmux: tmux attach -t marvel-demo"
+    @echo "Attach to tmux: tmux -L $(./bin/marvel config tmux-server) attach -t marvel-demo"
 
 # Show running state
 status: build
@@ -109,10 +109,30 @@ demo-shift: build
     @echo "Shift complete. Use 'just watch' to monitor or 'just stop' to tear down."
 
 # Clean up everything (kill all marvel tmux sessions)
+#
+# The kill-session needs -L: since #128 each HOME has its own tmux server,
+# so a bare kill-session targets tmux's shared default server and silently
+# reaches nothing. Asking the binary keeps the derivation in one place
+# rather than recomputing sha256(HOME) here. No build dependency, because
+# this recipe deletes bin/ and should still work when it is already gone;
+# it says what it skipped instead of failing or pretending.
 clean:
-    -tmux kill-session -t marvel-demo 2>/dev/null
-    -rm -f "${HOME}/.marvel/run/marvel.sock" "${HOME}/.marvel/run/marvel.sock.lock"
-    -rm -rf bin/
+    #!/usr/bin/env bash
+    set -uo pipefail
+    server=""
+    if [[ -x ./bin/marvel ]]; then
+      server=$(./bin/marvel config tmux-server 2>/dev/null || true)
+    fi
+    if [[ -n "${server}" ]]; then
+      tmux -L "${server}" kill-session -t marvel-demo 2>/dev/null || true
+      echo "cleaned tmux session marvel-demo on server ${server}"
+    else
+      echo "note: ./bin/marvel not built, so the tmux server name is unknown."
+      echo "      Skipped the tmux cleanup. Run 'just build' first, or:"
+      echo "      tmux -L \"\$(marvel config tmux-server)\" kill-session -t marvel-demo"
+    fi
+    rm -f "${HOME}/.marvel/run/marvel.sock" "${HOME}/.marvel/run/marvel.sock.lock"
+    rm -rf bin/
 
 # Three-act runnable demo. Full runbook: docs/demo.md.
 # Each recipe assumes a running daemon (`just start-bg` first).
@@ -199,11 +219,14 @@ demo-watch: build
     P1=$(tmux split-window -t "$P0" -v -P -F '#{pane_id}')
     P2=$(tmux split-window -t "$P0" -h -P -F '#{pane_id}')
     P3=$(tmux split-window -t "$P1" -h -P -F '#{pane_id}')
-    tmux send-keys -t "$P0" 'clear; echo "DRIVER — run demo beats here (runbook: docs/demo.md). Daemon: ./bin/marvel daemon &"' C-m
-    tmux send-keys -t "$P2" 'while :; do ./bin/marvel get sessions -w 1 2>/dev/null; sleep 2; clear; done' C-m
-    tmux send-keys -t "$P1" 'while :; do ./bin/marvel events --follow 2>/dev/null; sleep 2; done' C-m
+    # Layout: P0 top-left, P2 top-right, P1 bottom-left, P3 bottom-right.
+    # Readouts on top, driver shell bottom-left under the session table it
+    # acts on, logs bottom-right under the events they explain.
+    tmux send-keys -t "$P0" 'while :; do ./bin/marvel get sessions -w 1 2>/dev/null; sleep 2; clear; done' C-m
+    tmux send-keys -t "$P2" 'while :; do ./bin/marvel events --follow 2>/dev/null; sleep 2; done' C-m
+    tmux send-keys -t "$P1" 'clear; echo "DRIVER — run demo beats here (runbook: docs/demo.md). Daemon: ./bin/marvel daemon &"' C-m
     tmux send-keys -t "$P3" 'while :; do clear; ./bin/marvel daemon logs -n 14 2>/dev/null || echo "(daemon not up yet)"; sleep 2; done' C-m
-    tmux select-pane -t "$P0"
+    tmux select-pane -t "$P1"
     echo "Operator console ready: tmux attach -t marvel-watch"
-    echo "  top-left  DRIVER          top-right  sessions (live)"
-    echo "  bot-left  events --follow bot-right  daemon logs"
+    echo "  top-left  sessions (live) top-right  events --follow"
+    echo "  bot-left  DRIVER          bot-right  daemon logs"


### PR DESCRIPTION
Since #128 gave each HOME its own tmux server, two justfile lines still reach tmux's shared default one. `just demo` prints an attach command that fails, and `just clean` silently cleans nothing: its `kill-session` carries a leading `-` and `2>/dev/null`, so the miss is invisible. Anyone running the demo today gets a broken instruction and a cleanup that quietly does not.

Fixing them needs the derived name, and the tempting fix is to recompute `sha256(HOME)` in shell. That would be a second definition of the derivation, which is what #122 exists to undo. So `tmux.SocketName()` now owns the resolution `NewDriver` inlined, `MARVEL_TMUX_SOCKET` is named once as `tmux.SocketEnv`, and `marvel config tmux-server` prints the answer:

```sh
tmux -L "$(marvel config tmux-server)" attach -t marvel-demo
```

That also closes the cheapest half of `aae-orc-412j` for the local case. The remote case still wants the daemon asked rather than the local layout derived.

`just clean` no longer depends on `build`, since it deletes `bin/`, and it says what it skipped rather than pretending.

**Demo console flipped** per operator request: session table top-left, events top-right, driver shell bottom-left (selected on attach), daemon logs bottom-right. The recipe prints its own legend, which described the old layout and moved with it. Verified by running the recipe and reading pane coordinates rather than trusting the split order.

**Docs.** The `just clean` claim in demo.md is corrected and raw-tmux `-L` guidance added. `marvel-watch` is explicitly noted as unaffected: it is the operator's own plain-tmux session on the default server, and its panes reach the daemon over the control socket. I had claimed twice that it was broken, from the session name alone, without reading the recipe; the note is there so the next reader does not repeat it. The user guide gains `marvel reap`, which shipped in #123 with no user-guide entry at all, carrying an explicit known-defect note for #129 until that is fixed.

Verified: build, full suite, vet, `golangci-lint 2.10.1` 0 issues; `config tmux-server` matches the layout derivation and honors the override; both `just clean` paths exercised under a scratch HOME, which derived a different server name than the real one, confirming per-HOME behavior end to end.