### PR TITLE
fix: never destroy a tmux pane marvel did not create

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -239,6 +239,12 @@ func (m *Manager) reconcilePrefix(prefix string, policy UnrecordedPolicy) (adopt
 			continue
 		}
 		for _, p := range panes {
+			// The store is checked FIRST and without reference to the
+			// Created marker. A recorded pane is ours by record, and
+			// panes made by builds before the marker existed carry none:
+			// fencing adoption on it would make the first restart after
+			// an upgrade fail to adopt its own agents, which is the one
+			// property this whole path exists to preserve.
 			if sessKey, ok := recordedByPane[p.ID]; ok {
 				adopted++
 				m.recordPanePID(sessKey, p.PID)
@@ -252,6 +258,19 @@ func (m *Manager) reconcilePrefix(prefix string, policy UnrecordedPolicy) (adopt
 				})
 				continue
 			}
+
+			// Unrecorded. Only panes marvel created are candidates for
+			// anything past this point. tmux makes one base shell pane
+			// per session and an operator can open more by hand; neither
+			// is in the store, so before this fence both were reported
+			// here and destroyed by the kill policy (#129). Skipped
+			// silently rather than reported: a healthy fleet's own base
+			// pane is not news, and reporting it is what left reap
+			// unable to ever say clean.
+			if !p.Created {
+				continue
+			}
+
 			if policy == LeaveUnrecorded {
 				acted++
 				log.Printf("%s[%s]: left pane %s running in workspace %s: not in this daemon's records",
@@ -326,6 +345,13 @@ func (m *Manager) UnrecordedTmuxState() ([]string, error) {
 			continue
 		}
 		for _, p := range panes {
+			// Same fence as reconcilePrefix: only panes marvel created
+			// can be candidates. This preview must agree with the action
+			// exactly, or `marvel reap` lists something `reap --confirm`
+			// will not destroy, or worse the reverse.
+			if !p.Created {
+				continue
+			}
 			if _, ok := recordedByPane[p.ID]; !ok {
 				found = append(found, fmt.Sprintf("pane %s in workspace %s", p.ID, workspace))
 			}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -557,3 +557,159 @@ func TestReapDeadCapsCrashedMarkers(t *testing.T) {
 		t.Fatalf("fresh state=%s, want %s", got.State, api.SessionCrashed)
 	}
 }
+
+// The bug this guards is #129: a healthy daemon on its own fleet
+// reported one reap candidate, and `reap --confirm` destroyed it. The
+// candidate was the base shell pane tmux creates with every session,
+// which is not in the store because it is not a marvel session. Every
+// pane in a healthy workspace is either recorded or not marvel's, so
+// the correct answer is nothing at all.
+//
+// finding-012 recorded the old behavior as reap working, because it
+// asserted "one candidate listed, one destroyed" rather than "nothing
+// listed on a healthy fleet". This test makes the assertion that
+// finding should have made.
+func TestReapReportsNothingOnAHealthyFleet(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-reap-healthy"
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &api.Session{
+		Name:      "t-r-g1-0",
+		Workspace: ws,
+		Team:      "t",
+		Role:      "r",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	// Precondition: the base pane really is there and really is
+	// unrecorded, or this test would pass for the wrong reason.
+	panes, err := driver.ListPanes("marvel-" + ws)
+	if err != nil {
+		t.Fatalf("list panes: %v", err)
+	}
+	var base, created int
+	for _, p := range panes {
+		if p.Created {
+			created++
+		} else {
+			base++
+		}
+	}
+	if base == 0 {
+		t.Fatalf("no unmarked base pane present, so this test cannot detect #129 (panes=%d)", len(panes))
+	}
+	if created == 0 {
+		t.Fatal("no marvel-created pane is marked; the marker is not being set at all")
+	}
+
+	found, err := mgr.UnrecordedTmuxState()
+	if err != nil {
+		t.Fatalf("UnrecordedTmuxState: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("healthy fleet reports %d reap candidate(s), want 0: %v", len(found), found)
+	}
+}
+
+// A pane marvel did not create is never a candidate, even when it sits
+// inside a marvel workspace and is not in the store. An operator who
+// opens a shell in a marvel session must not lose it to reap.
+func TestUnrecordedTmuxStateIgnoresPanesMarvelDidNotCreate(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-foreign-pane"
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	tmuxSess := "marvel-" + ws
+	if err := driver.NewSession(tmuxSess); err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	t.Cleanup(func() { _ = driver.KillSession(tmuxSess) })
+
+	found, err := mgr.UnrecordedTmuxState()
+	if err != nil {
+		t.Fatalf("UnrecordedTmuxState: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("reported %d candidate(s) for a workspace whose only pane is tmux's own: %v",
+			len(found), found)
+	}
+}
+
+// The preview being right is not enough: --reclaim runs the kill policy
+// directly. On a healthy fleet it must adopt its own pane and leave the
+// base shell pane alone, or `marvel daemon --reclaim` damages the very
+// fleet it is reclaiming for.
+func TestAdoptOrKillSparesPanesMarvelDidNotCreate(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	ws := "test-reclaim-spares"
+	if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &api.Session{
+		Name:      "t-r-g1-0",
+		Workspace: ws,
+		Team:      "t",
+		Role:      "r",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+	before, err := driver.ListPanes("marvel-" + ws)
+	if err != nil {
+		t.Fatalf("list panes: %v", err)
+	}
+
+	adopted, killed, err := mgr.AdoptOrKill()
+	if err != nil {
+		t.Fatalf("AdoptOrKill: %v", err)
+	}
+	if adopted < 1 {
+		t.Errorf("adopted = %d, want at least 1 (our own recorded pane)", adopted)
+	}
+	if killed != 0 {
+		t.Errorf("killed = %d on a healthy fleet, want 0", killed)
+	}
+
+	after, err := driver.ListPanes("marvel-" + ws)
+	if err != nil {
+		t.Fatalf("list panes after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("panes %d -> %d: the kill policy destroyed part of a healthy fleet",
+			len(before), len(after))
+	}
+}

--- a/internal/tmux/driver.go
+++ b/internal/tmux/driver.go
@@ -81,6 +81,19 @@ func NewDriver() (*Driver, error) {
 	}, nil
 }
 
+// PaneMarker is the tmux user option marvel sets on every pane it
+// creates, and paneMarkerValue is what it sets it to. Read back into
+// PaneInfo.Created and checked before anything destructive runs.
+//
+// A tmux user option rather than marvel state, because the fact has to
+// outlive the daemon: a restarted daemon reconciles against panes it did
+// not create in this process, and a pane's provenance cannot come from a
+// store the daemon just rebuilt from disk.
+const (
+	PaneMarker      = "@marvel_pane"
+	paneMarkerValue = "1"
+)
+
 // SocketEnv is the environment variable that overrides the derived tmux
 // server name. Named here, once, because the driver and every caller
 // that needs to report or reproduce the driver's target must agree on
@@ -206,6 +219,24 @@ type PaneInfo struct {
 	PID     string
 	Command string
 	Title   string
+
+	// Created reports whether marvel made this pane, read back from the
+	// PaneMarker option marvel sets at creation. It is the fence around
+	// every destructive path: marvel must never destroy a pane it did not
+	// create.
+	//
+	// tmux itself creates one pane per session (the base shell from
+	// new-session), and an operator can open more by hand. Neither is a
+	// marvel session, so neither is in the store, so before this field
+	// existed both were reported as unrecorded and both were destroyed by
+	// reap --confirm and daemon --reclaim. A healthy single daemon on its
+	// own fleet reported one candidate that was its own session's base
+	// pane. See ArcavenAE/marvel#129 and finding-012's correction.
+	//
+	// False for panes made by builds older than this field. That is the
+	// safe direction: an untagged pane is left alone rather than
+	// destroyed.
+	Created bool
 }
 
 // NewPane creates a new window in the given session running the specified command.
@@ -238,6 +269,12 @@ func (d *Driver) NewPane(session, command, title string, envs map[string]string)
 
 	// Ensure window closes when command exits (don't leave orphaned shells).
 	_ = d.cmd("set-option", "-t", paneID, "remain-on-exit", "off").Run()
+
+	// Mark the pane as marvel's. Every destructive path checks this, so a
+	// pane marvel did not create is never a candidate. The mark lives in
+	// tmux rather than in marvel's store on purpose: it has to survive a
+	// daemon restart, and tmux is the thing that outlives the daemon.
+	_ = d.cmd("set-option", "-p", "-t", paneID, PaneMarker, paneMarkerValue).Run()
 
 	return paneID, nil
 }
@@ -385,7 +422,7 @@ func (d *Driver) ShowOption(session, option string) (string, error) {
 // ListPanes lists all panes across all windows in a session.
 func (d *Driver) ListPanes(session string) ([]PaneInfo, error) {
 	out, err := d.cmd("list-panes", "-t", session, "-s",
-		"-F", "#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{pane_title}").CombinedOutput()
+		"-F", "#{pane_id}\t#{pane_pid}\t#{pane_current_command}\t#{pane_title}\t#{"+PaneMarker+"}").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("list-panes %s: %s: %w", session, string(out), err)
 	}
@@ -395,7 +432,7 @@ func (d *Driver) ListPanes(session string) ([]PaneInfo, error) {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 4)
+		parts := strings.SplitN(line, "\t", 5)
 		p := PaneInfo{ID: parts[0]}
 		if len(parts) > 1 {
 			p.PID = parts[1]
@@ -405,6 +442,9 @@ func (d *Driver) ListPanes(session string) ([]PaneInfo, error) {
 		}
 		if len(parts) > 3 {
 			p.Title = parts[3]
+		}
+		if len(parts) > 4 {
+			p.Created = parts[4] == paneMarkerValue
 		}
 		panes = append(panes, p)
 	}


### PR DESCRIPTION
`marvel reap --confirm` and `marvel daemon --reclaim` destroy a pane inside a live session on a **healthy** fleet. tmux creates one base shell pane per session before marvel adds its replica windows; that pane is not a marvel session, so it was never in the store, so both destructive paths read it as unrecorded. A healthy daemon could never report clean, which also means the listing an operator is asked to confirm has been wrong every time they have seen it.

The fix is a stronger property than excluding the base pane: **marvel only ever destroys panes it created.** Every pane marvel makes is marked with the `@marvel_pane` tmux option, and nothing destructive considers an unmarked pane. An operator's hand-opened shell inside a marvel session is now safe too, which it was not before.

The mark lives in tmux rather than in marvel's store on purpose. A restarted daemon reconciles against panes it did not create in this process, so a pane's provenance cannot come from a store the daemon just rebuilt from disk. tmux is the thing that outlives the daemon.

**The marker gates the unrecorded branch only.** Adoption still keys off the store alone. Fencing adoption on the marker as well would make the first restart after upgrading fail to adopt panes made by older builds, which is exactly the property this path exists to preserve. I had that wrong in the first draft and the full suite passed anyway, because no test covered the pane branch; that gap is why the original bug shipped.

Panes from older builds carry no mark and are left alone rather than destroyed. That is the safe direction for an unknown.

Three tests, each **verified to fail without the fence** rather than merely passing with it:

- `TestReapReportsNothingOnAHealthyFleet` fails with `pane %0 in workspace test-reap-healthy`, the exact symptom. This is the assertion finding-012 should have made; it asserted "one candidate listed, one destroyed" instead, which is what let the bug read as verified.
- `TestUnrecordedTmuxStateIgnoresPanesMarvelDidNotCreate` covers the operator's own pane.
- `TestAdoptOrKillSparesPanesMarvelDidNotCreate` covers the destructive path directly, since the preview being right is not enough.

The first test also asserts its own preconditions, failing loudly if no unmarked base pane is present or if no pane carries the marker, so it cannot pass for the wrong reason.

Verified: build, full suite, vet, gofumpt clean, `golangci-lint 2.10.1` 0 issues.

Closes #129