### PR TITLE
harvest: question-daemon-isolation-boundary — reap fixed, see finding-014

### DIFF
--- a/_kos/findings/finding-014-reap-destroyed-panes-marvel-did-not-create.md
+++ b/_kos/findings/finding-014-reap-destroyed-panes-marvel-did-not-create.md
@@ -1,0 +1,121 @@
+# finding-014: the destructive paths could not tell a base pane from an orphan
+
+Date: 2026-08-07
+Fixes: ArcavenAE/marvel#129 (PR #132)
+Corrects: finding-012
+Bears on: `aae-orc-2cms`, `aae-orc-wap0`, `aae-orc-5kfw`,
+`question-daemon-isolation-boundary`
+
+## The defect
+
+`marvel reap --confirm` and `marvel daemon --reclaim` destroyed a pane
+inside a live session on a **healthy** fleet.
+
+tmux creates one base shell pane per session, from `new-session`, before
+marvel adds its replica windows. That pane is not a marvel session, so it
+was never in the store, so `reconcilePrefix` and `UnrecordedTmuxState`
+both read it as unrecorded. A healthy single daemon on its own fleet
+therefore reported exactly one reap candidate, always, and confirming
+destroyed it.
+
+Two consequences, and the second is worse than the first:
+
+- The destructive action was wrong on healthy state.
+- `reap` could never report clean, so the listing an operator is asked to
+  confirm has been wrong every time anyone has seen it. The signal that
+  was supposed to make the accepted failure visible was noise.
+
+Bounded honestly: `NewPane` uses `new-window`, so replicas sit in their
+own windows and the base pane is alone in window 0. Killing it closes an
+empty shell window and agents survive. Only a session with no replicas
+yet loses the session itself.
+
+## The fix, and why it is not "skip pane %0"
+
+Marvel now marks every pane it creates with the `@marvel_pane` tmux
+option and considers only marked panes for anything destructive. The
+property is stronger and simpler to state than the bug it fixes:
+
+> Marvel never destroys a pane it did not create.
+
+That also covers a case nobody had filed: an operator opening a shell by
+hand inside a marvel session used to be a reap candidate.
+
+Three shapes were available and two are worse:
+
+- **Exclude `%0`** encodes a tmux numbering assumption. `base-index` is
+  configurable, so the number is not a fact.
+- **Record the base pane in the store** puts a fact that must outlive the
+  daemon into a store the daemon rebuilds from disk at startup.
+- **Mark the pane in tmux** puts the fact in the thing that outlives the
+  daemon. A restarted daemon reconciles against panes it did not create
+  in this process, and the marker is still there.
+
+## The mistake inside the fix, kept because it is the instructive part
+
+The first draft put the marker check **before** the store lookup. That
+reads naturally and is wrong: panes created by builds older than the
+marker carry none, so the first restart after an upgrade would have
+skipped them instead of adopting them, losing exactly the
+restart-without-agent-loss property this path exists to preserve.
+
+**The full suite passed on that draft.** No test covered the pane branch
+at all, which is also why the original defect shipped. The marker now
+gates only the unrecorded branch; adoption still keys off the store
+alone.
+
+## Verification, stated as failure rather than passage
+
+Three tests, each confirmed to fail with the fence disabled:
+
+```
+--- FAIL: TestReapReportsNothingOnAHealthyFleet
+    healthy fleet reports 1 reap candidate(s), want 0:
+    [pane %0 in workspace test-reap-healthy]
+--- FAIL: TestUnrecordedTmuxStateIgnoresPanesMarvelDidNotCreate
+    reported 1 candidate(s) for a workspace whose only pane is tmux's own:
+    [pane %0 in workspace test-foreign-pane]
+```
+
+`TestReapReportsNothingOnAHealthyFleet` also asserts its own
+preconditions: it fails loudly if no unmarked base pane is present, or if
+no pane carries the marker, so it cannot pass for the wrong reason.
+
+`TestAdoptOrKillSparesPanesMarvelDidNotCreate` covers the kill policy
+directly, because a correct preview beside a wrong action is the failure
+mode the preview exists to prevent.
+
+## Why this was reported as verified
+
+finding-012 recorded "`marvel reap` listed one candidate and destroyed
+nothing; `reap --confirm` destroyed it" and read it as orphan
+identification working. It was measuring this bug. The assertion it
+needed was **"reap reports nothing on a healthy fleet"**, which is now a
+test.
+
+This is the third methodology error in this ticket family and all three
+share one shape: a check passed while measuring something other than what
+it claimed. The other two are `pgrep -fc` returning garbage that made a
+comparison vacuously true, and reading `head`'s exit status instead of
+the command's. Orc finding-114 names the general form from a different
+tool: a green check does not mean the thing you declared was the thing
+that got checked.
+
+The pattern is not carelessness in three unrelated places. It is that a
+passing assertion and a correct assertion look identical in the output,
+and only the failing case distinguishes them. Every test in this finding
+was therefore checked by breaking the code, not by watching it pass.
+
+## What this does NOT establish
+
+- Nothing about panes created by older builds inside a workspace that IS
+  recorded but whose panes are NOT. They carry no marker and are now left
+  alone, which is the safe direction and also means an actual orphan from
+  an older build is no longer reapable. No live sessions existed at the
+  time of the change, so this is untested rather than wrong.
+- Nothing about `reap` across tmux servers. It still sees only the
+  daemon's own server (`aae-orc-wap0`).
+- Nothing about whether reap should refuse when a candidate belongs to a
+  live foreign daemon (`aae-orc-2cms`). That question is now narrower:
+  per-HOME tmux servers mean a foreign daemon's panes are not visible at
+  all.

--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -98,11 +98,26 @@ content: |
 
   Read finding-012 WITH its 2026-08-07 correction, not without it. Two
   of its recorded results did not mean what they were recorded to mean,
-  and one of them concerns a destructive path: the single candidate its
-  reap scenario destroyed was tmux's base shell pane, not an orphan, so
-  reap's orphan identification is unverified and in fact wrong
-  (ArcavenAE/marvel#129). Isolation is verified; reap's correctness is
-  not, and the two were reported together.
+  and one of them concerned a destructive path: the single candidate its
+  reap scenario destroyed was tmux's base shell pane, not an orphan.
+
+  That defect is now FIXED (ArcavenAE/marvel#129, PR #132,
+  `_kos/findings/finding-014-reap-destroyed-panes-marvel-did-not-create.md`).
+  Marvel marks every pane it creates and the destructive paths consider
+  only marked panes, so the invariant is now the stronger and simpler
+  one: marvel never destroys a pane it did not create. An operator's
+  hand-opened pane inside a marvel session is covered by the same fence.
+
+  The marker gates the unrecorded branch only; adoption still keys off
+  the store, or the first restart after an upgrade would fail to adopt
+  panes made by older builds. finding-014 records that this exact
+  mistake was made in the first draft of the fix and passed the full
+  suite, because no test covered the pane branch at all. That gap is
+  also why the original defect shipped.
+
+  Residual, untested rather than wrong: a genuine orphan created by a
+  pre-marker build carries no marker and is now left alone rather than
+  reaped. No live sessions existed when the change landed.
 
   1. The isolation unit is the HOME-rooted `paths.Layout` (decision 1).
   2. Yes. Both namespaces now derive from it: the control socket at

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -476,12 +476,15 @@ marvel daemon --reclaim # kill unrecognised state at startup instead of leaving 
 belong to another running daemon, which is worth taking literally: check before
 confirming.
 
-> **Known defect (ArcavenAE/marvel#129).** `reap` currently reports one false
-> candidate per live session, the base shell pane tmux creates before marvel
-> adds replica panes. A healthy daemon therefore never reports clean, and
-> `reap --confirm` on a healthy fleet destroys that pane. Agents survive, since
-> replicas live in their own windows, but do not read a non-empty `reap` listing
-> as evidence of leftovers until this is fixed.
+Marvel never destroys a pane it did not create. Every pane it makes carries a
+tmux marker, and the destructive paths consider only marked panes, so tmux's
+own base shell pane and any pane you opened by hand inside a marvel session
+are both safe. A healthy fleet reports nothing to reap.
+
+Panes created by marvel builds older than this marker carry none, so they are
+left alone rather than destroyed. That means a genuine orphan from an older
+build is not reapable; clean those up with `tmux -L "$(marvel config
+tmux-server)" kill-pane -t <pane>`.
 
 ## Version and upgrade
 


### PR DESCRIPTION
The graph currently tells a reader that reap's orphan identification is wrong and unfixed, which stopped being true when #132 merged. Leaving it that way is the same class of problem as the defect itself: a durable record that misdescribes a destructive path.

finding-014 records three things. The defect, in terms of what an operator saw: `reap` could never report clean, so every listing anyone has ever been asked to confirm was wrong. The fix, stated as the invariant rather than the patch: marvel never destroys a pane it did not create, which also covers an operator's hand-opened pane, a case nobody had filed. And the mistake made inside the fix, which is the part worth keeping: the first draft gated adoption on the marker as well, and would have broken restart-without-agent-loss across the upgrade boundary. The full suite passed on that draft, because no test covered the pane branch at all, which is also why the original defect shipped.

The finding states its verification as failure rather than passage. Every test was checked by breaking the code, since a passing assertion and a correct assertion look identical in the output and only the failing case tells them apart.

The node now says fixed, points at finding-014, and names the residual: an orphan created by a pre-marker build carries no marker and is left alone rather than reaped. Untested rather than wrong, since no live sessions existed when the change landed.

The user guide's known-defect note is replaced by the invariant it was waiting on, plus the manual cleanup path for pre-marker orphans.

Cost of merge: one finding, one node, one doc paragraph. No code.