### PR TITLE
probe(marvel): two operator ideas — a marvel console, and a local LLM the cluster can call

### DIFF
--- a/_kos/ideas/local-llm-for-marvels-own-purposes.md
+++ b/_kos/ideas/local-llm-for-marvels-own-purposes.md
@@ -1,0 +1,158 @@
+# A local LLM the cluster can call for its own purposes
+
+Raised by the operator 2026-08-07, alongside
+`operator-console-repl-and-lua.md`. Pre-hypothesis.
+
+## The seed
+
+> How could we extend to the marvel cluster an interface out to ollama,
+> mlx or another local LLM for "AI scripting" for its own purposes?
+> Besides native Lua with a rich marvel-specific control surface, I'd also
+> like to be able to call out to an LLM (perhaps a Rust configurable LLM
+> router? against which maybe the default is ollama with qwen 2B or
+> something like that) for basic logic, tests, self-analysis.
+
+## What exists today, measured
+
+- **Marvel has no model client.** Nothing in `internal/` or `cmd/` opens
+  a connection to any inference endpoint.
+- What it does have is a model-name-to-context-window TABLE
+  (`internal/usage/limits.go`), used to turn token counts into CTX%.
+  Marvel knows model *names* and has never called one.
+- **The fleet already has the tool.** `aae-orc/ai` (Go, Ollama) is a
+  Unix-philosophy CLI: stdin plus a prompt in, model output out. It was
+  built to compose with pipes.
+
+That third point is the cheap path, and it is worth noticing before
+designing a subsystem.
+
+## The line this crosses
+
+Today marvel is a control plane and the agents do the thinking. An LLM
+inside marvel means **the control plane thinks**. That is a category
+change, not a feature, and it lands on ADR-007 and SOUL §8:
+
+> Automate reminding, checking, and proposing, not judging. Promotion,
+> meaning, dissent, and closure remain human acts; automation computes,
+> surfaces, and drafts.
+
+Applied here that is a usable line, not an obstacle:
+
+**Inside the boundary (propose, draft, check):**
+- Summarize an event ring window into a suspected cause.
+- Draft a scaling change for a human or a supervisor agent to apply.
+- Generate test cases and fixtures (the seed's "tests").
+- Flag an anomaly for attention.
+- Screen inbound tool output for injection (vision Gap 8 names "fast
+  local oracles" as the natural mechanism for exactly this).
+
+**Outside it (judge, decide, act):**
+- Deciding a session is unhealthy and restarting it.
+- Deciding to scale, kill, or reclaim.
+- Closing or promoting anything.
+
+This is the same gate as the Lua write-half in the console idea, for the
+same reason, and it should be one ruling covering both rather than two.
+
+## The router is required, not a nicety
+
+vision.md value 10's corollary: *everything we own must front multiple
+external providers; no seam may bind to one vendor.* An inference seam in
+marvel is therefore a router by construction. Ollama with qwen 2B is a
+DEFAULT, not a binding, and mlx/vLLM/llama.cpp/a cloud endpoint have to
+be reachable through the same interface from day one or the seam is
+already wrong.
+
+The 2026-08-01 language ruling permits the Rust shape the seed suggests:
+marvel stays Go, and Rust enters as satellite processes where its
+ecosystem wins. An inference router is a plausible satellite alongside
+VFS/slotefs. Not required, though: the cheap probe below needs no new
+process at all.
+
+## Why this is the bet's first concrete instance
+
+vision.md's bet (horizon ≈ 2027-04) is fleets on local hardware
+coordinating with cloud frontier models, making **"placement across the
+cost/privacy/latency/capability/cache-locality gradient"** load-bearing.
+A router choosing between a local 2B and a cloud model IS that placement
+decision, in miniature, for marvel's own traffic rather than the fleet's.
+
+That makes this a cheaper test of the bet than M6 is. M6 is "run agent
+workloads on local runtimes" and is gated by the tripwire (≤ 2026-10).
+This is "run marvel's own small jobs locally", which needs no fleet, no
+scheduler change, and no tripwire, and it exercises the same gradient.
+
+Resource-matrix framing: a local model is a distinct point on the spend
+row (near-zero marginal cost), the latency row, and the custody row
+(prompt never leaves the host). Marvel *scheduling by* those rows and
+marvel *using* a model are different problems that share one gradient.
+
+## The failure mode to design against, and it is specific
+
+"Self-analysis" is the most seductive and least verifiable item in the
+seed. A 2B model asked to explain why a fleet degraded will produce
+fluent, plausible, confidently-wrong prose, and it will do so at exactly
+the moment an operator is stressed and least able to check it.
+
+This is orc finding-114's lesson in a new place: a green check that means
+nothing. There, stable rustfmt exited 0 on config it could not apply.
+Here, a small model returns an answer whether or not it has one.
+
+So any generated diagnosis has to arrive marked as generated and, where
+possible, carrying the evidence it was derived from (event IDs, session
+keys, log line numbers) so a reader can check rather than trust. An
+unmarked LLM summary in an operator surface is worse than no summary.
+
+The verifiable jobs are the honest starting set: generating test fixtures
+(a test either passes or fails), screening content (a decision that can
+be sampled and scored), and classification with a known answer key.
+"Explain what happened" comes last, if at all.
+
+## Cheapest first probe, which builds nothing
+
+Do NOT build a router first. Shell out to `ai` from a read-only surface
+and answer the only question that gates everything else:
+
+**Is a 2B-class local model actually good enough for the named jobs?**
+
+Concretely: take a real event-ring window and a real daemon log from a
+degraded fleet, hand them to qwen 2B via `ai`, and score the output
+against what actually happened (today's session alone has several: the
+base-pane defect, the socket collision, the headless-crashed confusion).
+If a 2B cannot classify those, the router is moot and the answer is a
+bigger model or a different job. If it can, the router question becomes
+real and well-posed.
+
+This costs one afternoon, needs no marvel change, and its result is
+useful whichever way it falls.
+
+## Open questions
+
+- **Which jobs, ranked by verifiability?** Test generation and screening
+  are checkable; diagnosis is not. Start where you can grade.
+- **Who is the caller?** Lua script, console command, the daemon itself
+  on a timer, or a supervisor agent. The daemon calling a model on its
+  own initiative is the version that most needs the ADR-007 ruling.
+- **Where does the prompt come from?** A prompt that ships with marvel is
+  behavior marvel is responsible for; a prompt from a pack is
+  configuration. Pack provenance (sideshow) already has machinery for
+  the second.
+- **Does this reuse `ai`, absorb it, or ignore it?** SOUL §2 says compose
+  with small tools. `ai` is a small tool that already does this. The
+  argument for a router is multi-provider policy, which `ai` may or may
+  not want to carry.
+- **Custody.** A local model means the prompt never leaves the host,
+  which is a real privacy property worth stating and not accidentally
+  losing the first time the router falls back to a cloud provider.
+  Fallback policy is a custody decision, not a performance one.
+
+## Related
+
+- `operator-console-repl-and-lua.md`: the Lua surface is the obvious
+  caller, and both need one ADR-007 ruling rather than two.
+- vision.md M6 (local model runtimes), the Bet, Gap 8 (adversarial
+  screening via fast local oracles), value 10 and its multi-provider
+  corollary, innovation 1 (the resource matrix).
+- orc finding-114: fluent output from a tool that cannot do the job is
+  the failure mode; mark generated content and carry its evidence.
+- `aae-orc/ai`: fleet prior art, Go plus Ollama, already composable.

--- a/_kos/ideas/operator-console-repl-and-lua.md
+++ b/_kos/ideas/operator-console-repl-and-lua.md
@@ -77,13 +77,13 @@ IOS `set` mutates running-config imperatively. Marvel's model is
 declarative: you edit a manifest and re-apply. A `set` verb in a marvel
 shell has three possible meanings and they are not compatible:
 
-1. **Session-local preference.** `set cluster kinu`, `set workspace mixed`
-   — narrows what subsequent commands address. Harmless, genuinely
-   useful, and not really "set" in the IOS sense at all.
-2. **Mutate desired state.** `set team/role replicas 5` — this is
-   `marvel scale` with a different spelling, and it silently diverges the
-   live desired state from the manifest on disk that produced it. That
-   drift is the thing the declarative model exists to prevent.
+1. **Session-local preference.** `set cluster kinu`, `set workspace mixed`:
+   narrows what subsequent commands address. Harmless, genuinely useful,
+   and not really "set" in the IOS sense at all.
+2. **Mutate desired state.** `set team/role replicas 5` is `marvel scale`
+   with a different spelling, and it silently diverges the live desired
+   state from the manifest on disk that produced it. That drift is the
+   thing the declarative model exists to prevent.
 3. **Mutate actual state.** Meaningless: actual state is an observation.
 
 Reading 1 is safe and small. Reading 2 needs an answer to "where does

--- a/_kos/ideas/operator-console-repl-and-lua.md
+++ b/_kos/ideas/operator-console-repl-and-lua.md
@@ -1,0 +1,166 @@
+# An operator console: a marvel shell, and Lua that reaches the daemon
+
+Raised by the operator 2026-08-07. Pre-hypothesis: generative, not
+committed, and deliberately holding several readings at once.
+
+## The seed
+
+> How could we offer a Lua console or editor or some way to kick off Lua
+> (it is embedded in marvel, isn't it?) and should we offer some runtimes
+> ... think like a Cisco switch with supervisor cards, and include those
+> in the display also, or do those belong as other tmux panes perhaps,
+> with some kind of shell like IOS, but also supporting scripting and all
+> the marvel commands natively (as in, if you enter `marvel cmd arg` you
+> don't need to specify marvel, you can just say `get sessions` or
+> `work < manifest.yaml`) and some settings like set/get/show?
+
+## What exists today, measured
+
+Lua is embedded, and almost entirely unreachable.
+
+- `github.com/yuin/gopher-lua v1.1.2` in go.mod.
+- One implementation: `internal/simulator/lua.go`.
+- One caller: `cmd/simulator/main.go`. **Not the daemon, not the CLI.**
+- Five functions on a `marvel` module: `create_agent`, `kill_agent`,
+  `list_agents`, `scale_team`, `log`.
+- One entry point: an `on_tick(pct, tick)` callback.
+- Two scripts: `scripts/scaler.lua`, `scripts/chaos.lua`.
+
+So the engine, the module pattern, and two worked examples exist. What
+does not exist is any path from an operator to a Lua VM that can see a
+real daemon.
+
+## Four things tangled in the seed, worth separating
+
+**A. A marvel shell.** A REPL where `get sessions` means
+`marvel get sessions`. Cheap in the mechanism: cobra can execute a parsed
+line against the existing root command. The value is not saved keystrokes,
+it is a *session*: one connection, one resolved cluster, one context to
+carry between commands.
+
+**B. Lua that reaches the daemon.** Promote the simulator's VM from
+driving a fake fleet to driving a real one, over the daemon RPC rather
+than over the simulator's in-process objects.
+
+**C. A supervisor/card display.** Cisco `show module`: the control plane
+and its subordinate modules, each with state, all visible in one table.
+
+**D. Where it lives.** A marvel subcommand, a tmux pane in the operator
+console, or both.
+
+## The mapping that earns its keep, and the one that does not
+
+**Earns it: running-config vs startup-config.** IOS distinguishes what
+the box is doing now from what it will do on reboot. Marvel has exactly
+this distinction and has never named it: DESIRED state (manifests plus
+the bolt) versus ACTUAL state (tmux panes and processes). Half of today's
+daemon-isolation work was about that gap. `marvel work manifest.toml` is
+`configure replace`. A console that made desired-vs-actual a first-class
+view would be showing something marvel genuinely has and currently makes
+an operator assemble by hand from `get sessions` plus `reap` plus the
+event ring.
+
+**Does not earn it yet: supervisor cards.** A chassis view needs
+subordinate modules to display. Today there is one daemon on one host, so
+`show module` would render one row. It becomes real at M5 (multi-host),
+where each host IS a card and active/standby means something. Filing the
+display ahead of the thing it displays is building the dial before the
+engine.
+
+Per vision.md value 11 (function first, analogy as annotation): the IOS
+register is fine as naming, but the console has to be justified by the
+desired-vs-actual view, not by resembling a switch.
+
+## The `set` problem, which is the real design question
+
+IOS `set` mutates running-config imperatively. Marvel's model is
+declarative: you edit a manifest and re-apply. A `set` verb in a marvel
+shell has three possible meanings and they are not compatible:
+
+1. **Session-local preference.** `set cluster kinu`, `set workspace mixed`
+   — narrows what subsequent commands address. Harmless, genuinely
+   useful, and not really "set" in the IOS sense at all.
+2. **Mutate desired state.** `set team/role replicas 5` — this is
+   `marvel scale` with a different spelling, and it silently diverges the
+   live desired state from the manifest on disk that produced it. That
+   drift is the thing the declarative model exists to prevent.
+3. **Mutate actual state.** Meaningless: actual state is an observation.
+
+Reading 1 is safe and small. Reading 2 needs an answer to "where does
+desired state live now, the file or the store?" before it can be built
+without creating a config-drift problem marvel does not currently have.
+`show running-config` (render current desired state as a manifest) plus
+`diff` against a file is arguably the honest version of reading 2: make
+divergence visible instead of easy.
+
+## The gate: a Lua console is an authority surface
+
+The simulator's five functions include `kill_agent` and `scale_team`.
+Pointed at a live daemon that is destructive power exercised by a script,
+with no principal attached to it. Marvel's authority model is the M1 gap,
+and the roadmap ruling (2026-08-01) is study first.
+
+This does not block A, C, or D. It blocks the interesting half of B. A
+read-only Lua surface (`list_agents`, `describe`, event queries) has none
+of this problem and is most of the exploratory value.
+
+Sharper framing: **a Lua script that can kill agents is an agent**, in
+the resource-matrix sense. It consumes authority. Giving it a channel
+before there is a principal model means inventing one implicitly, which
+is exactly the failure mode `docs/marvel-remap-2026-08.md` warns about
+for the bus.
+
+## The drift risk to design against
+
+A shell that reimplements command dispatch becomes a second surface that
+ages differently from the first. Every new subcommand would need adding
+twice, and the two would diverge quietly, which is the same shape as the
+socket default that survived a fix by being declared twice (#122).
+
+Constraint, if this is built: the REPL dispatches into the SAME cobra
+tree. A new `marvel` subcommand appears in the shell for free, or the
+design is wrong.
+
+## Where it lives (D), unresolved
+
+- **`marvel console`** as a subcommand: works over `mrvl://` to a remote
+  daemon, needs no tmux, keeps the independence rule (SOUL §2).
+- **A pane in `just demo-watch`**: zero new surface, and the operator
+  console already exists as four panes. But it is a demo recipe, not a
+  product.
+- Both, if the console is a subcommand that the recipe happens to launch.
+  This looks right and costs nothing to keep open.
+
+## Ambiguity to resolve with the operator
+
+"Should we offer some runtimes" has two readings and they lead to
+different work:
+
+1. **More runtime adapters** (more harnesses in the `runtime` field).
+   Independent of the console entirely.
+2. **Marvel's own components rendered as modules** in a card-style
+   display: the daemon, the adapters it has registered, the hosts.
+   This is C.
+
+Reading 2 is what the "include those in the display" clause suggests, but
+1 is what "offer some runtimes" says. Ask before building either.
+
+## Cheapest first probe, if this goes anywhere
+
+`marvel console` with NO Lua and NO `set`: a REPL over the existing cobra
+tree, plus `show desired` and `show actual` as the two views nothing
+currently renders side by side. That tests the one claim worth testing
+first, which is whether a session-scoped console makes operating a fleet
+meaningfully better than the flat CLI. Lua and the card display both
+become easier to judge afterward, and neither is wasted if the answer is
+no.
+
+## Related
+
+- `question-substrate` and finding-004 (shim-in-pane): the console is
+  another consumer of whatever the supervision layer becomes.
+- `aae-orc-412j`: a console is where "which tmux server does this cluster
+  use" would naturally be answered.
+- M1 (principal model) gates the write half of B.
+- M5 (multi-host) is the precondition for C meaning anything.
+- vision.md value 11: function first, analogy as annotation.


### PR DESCRIPTION
Two operator ideas from one thread, captured while they are still cheap to shape and grounded on what marvel actually has rather than on what the seeds assumed. Pre-hypothesis per the kos process: idea files, no commitment, several readings held open on purpose.

Both premises checked out, both narrowly.

**Lua is embedded and almost entirely unreachable.** `gopher-lua v1.1.2`, confined to `internal/simulator`, reachable only from `cmd/simulator`, exposing five functions on a `marvel` module. The engine, the module pattern, and two worked scripts exist; no path from an operator to a VM that can see a real daemon does.

**Marvel has no model client at all.** `internal/usage/limits.go` holds a model-name-to-context-window table, so marvel knows model names and has never called one. The fleet already ships `ai` (Go plus Ollama) as a composable stdin-to-model CLI, which makes the cheapest version of the second idea nearly free.

Four findings change the shape of the ideas rather than just recording them.

**The IOS mapping that earns its keep is not the chassis.** `running-config` versus `startup-config` names a distinction marvel genuinely has and has never named: desired state versus actual state. Half of the 2026-08-07 isolation work was about that gap, and an operator currently assembles the comparison by hand. `show module` needs multi-host (M5) before it has more than one row.

**Both ideas need one ADR-007 ruling, not two.** A Lua surface holding `kill_agent` and an LLM inside the control plane are the same boundary question: propose, draft, and check are inside the automation boundary; decide and act are not. The write half of each gates on M1.

**The LLM router is required rather than optional.** Value 10's corollary forbids binding a seam to one vendor, so ollama with qwen 2B is a default, not a binding.

**The local-model idea is a cheaper test of the bet than M6.** Choosing between a local 2B and a cloud model is placement across the cost/privacy/latency gradient, for marvel's own traffic, needing no fleet change and no tripwire.

Each file names its cheapest first probe, and neither builds the thing it is about. The console probe is a REPL with no Lua and no `set`. The LLM probe builds nothing at all: pipe a real event ring at qwen 2B via `ai` and score it against what actually happened, which today's session supplies several of.

The second file also names a specific failure mode worth carrying forward: a small model asked to explain a degraded fleet returns fluent, confident prose whether or not it has an answer. That is orc finding-114 in a new place, so verifiable jobs come first, diagnosis last, and generated output arrives marked and carrying its evidence.

Cost of merge: two idea files. No code, no commitment.