### PR TITLE
fix(demo): the pane-loss beat targeted the wrong tmux server

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -81,8 +81,12 @@ vanish. Read its pane id first, then kill the pane:
 
 ```sh
 ./bin/marvel describe session recover/line-worker-g1-0   # note "PaneID": "%N"
-tmux kill-pane -t %1                                     # use the PaneID you saw
+tmux -L "$(./bin/marvel config tmux-server)" kill-pane -t %1   # use the PaneID you saw
 ```
+
+The `-L` is load-bearing. Marvel's panes live on a per-HOME tmux server, so a
+bare `tmux kill-pane -t %1` reaches tmux's shared default server instead and
+kills whatever `%1` is there, which is some other pane of yours.
 
 Marvel detects the vacated pane on its next reconcile tick, marks the session
 crashed, and (after a crash-loop backoff) spawns a replacement:

--- a/justfile
+++ b/justfile
@@ -148,7 +148,7 @@ demo-act1: build
     @echo ""
     @echo "Next, cause an unplanned pane loss and watch marvel recover it:"
     @echo "  ./bin/marvel describe session recover/line-worker-g1-0   # note PaneID %N"
-    @echo "  tmux kill-pane -t %1                                     # use that PaneID"
+    @echo "  tmux -L \"\$(./bin/marvel config tmux-server)\" kill-pane -t %1   # use that PaneID"
     @echo "  ./bin/marvel events --kind session.crashed              # immediate"
     @echo "  ./bin/marvel events --kind session.created              # replacement (~30-60s, crash-loop backoff)"
     @echo ""


### PR DESCRIPTION
The demo's one destructive command was pointed at the wrong tmux server, so walking Act 1 in front of an audience either fails visibly or kills one of the operator's own panes.

Act 1 instructs a bare `tmux kill-pane -t %1`. Marvel's panes moved to a per-HOME tmux server (#128), so a bare `tmux` reaches the shared default server, where `%1` is whatever the operator happens to have open. Both sites now ask the binary for the server name, which is the form the rest of the runbook already uses.

The rest of the sweep in #131 got this right everywhere else. `demo-watch`'s bare tmux is deliberate (its watcher session genuinely lives on the default server) and demo.md already documents that.

Verified in an isolated rig (separate HOME, distinct tmux socket, simulator and `sleep` runtimes, no model quota):

- bare `tmux kill-pane -t %6` returned `can't find pane: %6`
- the corrected form killed the worker; `session.crashed` fired immediately with "pane %6 gone", and the replacement `line-worker-g1-2` appeared at ~50s

demo.md gains one sentence on why the `-L` is load-bearing.

Docs and a recipe echo only; no code paths change.

Refs: aae-orc-5kfw