### PR TITLE
harvest: question-daemon-isolation-boundary — two was not the count

### DIFF
--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -125,6 +125,19 @@ content: |
      `Layout.TmuxSocketName` (marvel #128, `aae-orc-by6j`). Whether two
      is the count is still not established, which is why both live in
      `internal/paths` rather than each in its own package.
+
+     Two is NOT the count. A third surfaced 2026-08-07 while running
+     the demo end to end under an isolated HOME (`aae-orc-5kfw`): the
+     policy projection directory. `policy.projected` reported
+     `$TMPDIR/marvel-policies-<pid>/...` while HOME was
+     `/private/tmp/mrig`, so the projected settings file a harness
+     reads does not follow the layout. It is PID-suffixed, so two
+     daemons do not collide, and that is why this is a data point
+     rather than a bug: the namespace is scoped by something, just not
+     by the isolation unit. The pattern the first two shared holds
+     here too. Each was found by working an unrelated problem, never
+     by enumerating namespaces, which is the argument for enumerating
+     them rather than waiting for a fourth.
   3. Leave alone (decision 5, marvel #123). Killing is `marvel daemon
      --reclaim` or `marvel reap --confirm`.
   4. Still a precondition for `question-multi-host`, now satisfied for


### PR DESCRIPTION
The daemon-isolation question left one sub-question open with a hedge attached, and running the demo answered it by accident.

Sub-question 2 asked whether every machine-global namespace should derive from the isolation unit, and recorded plainly that two were found by working one bug and nothing established two as the count. A third turned up while running the demo end to end under an isolated HOME for `aae-orc-5kfw`: `policy.projected` reported `$TMPDIR/marvel-policies-<pid>/...` while HOME was `/private/tmp/mrig`. The projected settings file a harness actually reads does not follow the layout.

It is PID-suffixed, so two daemons do not collide. That is why the node records it as a data point rather than a bug: the namespace is scoped by something, just not by the isolation unit.

The provenance is the part worth keeping. All three were found by working an unrelated problem, none by enumerating namespaces, which is the argument for enumerating them rather than waiting for a fourth.

Node text only.

Refs: aae-orc-5kfw