### PR TITLE
feat(demo): put the CLI beside the session table, events and logs full width

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -45,15 +45,32 @@ The acts read better watched than replayed. Two tools:
   compose with it (`--workspace`, `--kind`, `--warnings`).
 - `just demo-watch` builds a four-pane tmux operator console:
 
-  |  | left | right |
-  |---|---|---|
-  | **top** | live session table | live event tail |
-  | **bottom** | driver shell | daemon log poll |
+  ```
+  +---------------------------+----------+
+  | live session table (149w) | CLI      |   50% height
+  +---------------------------+----------+
+  | live event tail                      |   full width
+  +--------------------------------------+
+  | daemon log poll                      |   full width
+  +--------------------------------------+
+  ```
 
-  Attach with `tmux attach -t marvel-watch`, drive the beats from the
-  bottom-left pane (already selected on attach), and watch states flip in
-  real time. The readouts sit on top: the session table directly above the
-  shell acting on it, the daemon log directly below the events it explains.
+  Attach with `tmux attach -t marvel-watch` and drive the beats from the
+  CLI pane, top right, already selected on attach. The session table sits
+  beside it because those two are the pair you work in: you type a command
+  and watch the states flip next to it. Events and logs run full width
+  underneath because their lines are long, and a half-width pane wraps
+  them into noise.
+
+  The table pane is 149 columns, which is every column of `marvel get
+  sessions` plus 12 characters of the model. That is where the LLM column
+  starts in the worst case the demo actually produces, a
+  `crashloop-backoff` state (Act 1 demonstrates it) beside a 26-character
+  agent name. Rows are clipped to the pane rather than wrapped: a row
+  carrying a real model name runs past 160 columns, and a wrapped table
+  defeats the one thing this pane is for. Resize the pane and the clip
+  follows it.
+
   The panes poll until a daemon appears, so start it in whichever order you
   like.
 

--- a/justfile
+++ b/justfile
@@ -207,26 +207,46 @@ demo-all:
     @echo ""
     @echo "Between acts: just stop && rm -f ~/.marvel/state/marvel.bolt && just start-bg"
 
+# Width of the session-table pane: every column of `marvel get sessions`
+# plus 12 characters of the model. 137 is where the LLM column starts in
+# the worst case the demo actually produces (STATE=crashloop-backoff, which
+# Act 1 demonstrates, and a 26-character agent name), measured against the
+# renderer's tabwriter rather than estimated.
+session_pane_width := "149"
+
 # Operator console for watching a demo live: four panes in one tmux
-# session — driver shell, live session table, live event tail, daemon
-# log poll. Attach from your own terminal: tmux attach -t marvel-watch
+# session — live session table and a driver CLI side by side on top, event
+# tail and daemon log poll full-width below. Attach from your own terminal:
+# tmux attach -t marvel-watch
 demo-watch: build
     #!/usr/bin/env bash
     set -euo pipefail
     tmux kill-session -t marvel-watch 2>/dev/null || true
     tmux new-session -d -s marvel-watch -x 220 -y 55
     P0=$(tmux display -p -t marvel-watch '#{pane_id}')
-    P1=$(tmux split-window -t "$P0" -v -P -F '#{pane_id}')
-    P2=$(tmux split-window -t "$P0" -h -P -F '#{pane_id}')
-    P3=$(tmux split-window -t "$P1" -h -P -F '#{pane_id}')
-    # Layout: P0 top-left, P2 top-right, P1 bottom-left, P3 bottom-right.
-    # Readouts on top, driver shell bottom-left under the session table it
-    # acts on, logs bottom-right under the events they explain.
-    tmux send-keys -t "$P0" 'while :; do ./bin/marvel get sessions -w 1 2>/dev/null; sleep 2; clear; done' C-m
+    P2=$(tmux split-window -t "$P0" -v -l 50% -P -F '#{pane_id}')
+    P1=$(tmux split-window -t "$P0" -h -P -F '#{pane_id}')
+    tmux resize-pane -t "$P0" -x {{session_pane_width}}
+    P3=$(tmux split-window -t "$P2" -v -l 50% -P -F '#{pane_id}')
+    # Layout: P0 sessions top-left, P1 CLI top-right, P2 events and P3 logs
+    # full-width below. The two readouts you act ON sit beside the CLI you
+    # act WITH; the two you read AFTER run underneath, full width, because
+    # event and log lines are long and a half-width pane wraps them.
+    #
+    # The session table is clipped to the pane rather than wrapped. A row
+    # with a real model name runs past 160 columns, and a wrapped table is
+    # unreadable at a glance, which is the only thing this pane is for.
+    # Clipping to the live pane width keeps it correct if you resize.
+    #
+    # The -t "$TMUX_PANE" is load-bearing. Bare `tmux display -p` resolves
+    # against the client's ACTIVE pane, which is the CLI, so the table
+    # would clip to 70 columns and lose everything from STATE rightward.
+    tmux send-keys -t "$P0" 'while :; do clear; ./bin/marvel get sessions 2>/dev/null | cut -c1-$(tmux display -p -t "$TMUX_PANE" "#{pane_width}"); sleep 2; done' C-m
+    tmux send-keys -t "$P1" 'clear; echo "CLI — run demo beats here (runbook: docs/demo.md). Daemon: ./bin/marvel daemon &"' C-m
     tmux send-keys -t "$P2" 'while :; do ./bin/marvel events --follow 2>/dev/null; sleep 2; done' C-m
-    tmux send-keys -t "$P1" 'clear; echo "DRIVER — run demo beats here (runbook: docs/demo.md). Daemon: ./bin/marvel daemon &"' C-m
-    tmux send-keys -t "$P3" 'while :; do clear; ./bin/marvel daemon logs -n 14 2>/dev/null || echo "(daemon not up yet)"; sleep 2; done' C-m
+    tmux send-keys -t "$P3" 'while :; do clear; ./bin/marvel daemon logs -n 10 2>/dev/null || echo "(daemon not up yet)"; sleep 2; done' C-m
     tmux select-pane -t "$P1"
     echo "Operator console ready: tmux attach -t marvel-watch"
-    echo "  top-left  sessions (live) top-right  events --follow"
-    echo "  bot-left  DRIVER          bot-right  daemon logs"
+    echo "  top-left   sessions ({{session_pane_width}} cols: all columns + 12 of the model)"
+    echo "  top-right  CLI (focused)"
+    echo "  bottom     events --follow, then daemon logs (full width)"


### PR DESCRIPTION
The operator console put the driver shell diagonally opposite the events, so the two things you use together were the two furthest apart. This is the layout the console is actually operated in.

The pair you work in is the CLI and the session table: you type a command and watch states flip. Those go side by side on the top half. Events and logs run full width underneath, where their long lines stop wrapping into noise.

```
+---------------------------+----------+
| live session table (149w) | CLI      |   50% height
+---------------------------+----------+
| live event tail                      |
+--------------------------------------+
| daemon log poll                      |
+--------------------------------------+
```

The session pane is 149 columns: every column of `marvel get sessions` plus 12 characters of the model. That is where the LLM column starts in the worst case the demo actually produces, a `crashloop-backoff` state (Act 1 demonstrates it) beside a 26-character agent name, measured against the renderer's tabwriter rather than estimated. Rows are clipped to the pane rather than wrapped, since a row carrying a real model name runs past 160 columns and a wrapped table defeats the one thing the pane is for.

One bug worth calling out because it would have shipped silently: the first draft clipped with a bare `tmux display -p '#{pane_width}'`, which resolves against the client's ACTIVE pane. That is the CLI, so the table clipped to 70 columns and lost everything from STATE rightward. It only surfaced by rendering live data into the pane instead of reading the layout back. The `-t "$TMUX_PANE"` form is now used and commented as load-bearing.

Verified: panes measure 149x27, 70x27, 220x13, 220x13; focus lands on the CLI; a live five-session table renders through the LLM column with no wrap.

Recipe and docs only; no code paths change.

Refs: aae-orc-5kfw