### PR TITLE
fix(demo): let the CLI pane absorb slack instead of scaling with the table

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -71,6 +71,20 @@ The acts read better watched than replayed. Two tools:
   defeats the one thing this pane is for. Resize the pane and the clip
   follows it.
 
+  **The console wants a terminal at least 250 columns wide.** The table is
+  content-fixed and the CLI is not, so the CLI takes every column the table
+  does not: at 250 that is 149 and 100, at 300 it is 149 and 150. tmux
+  would otherwise scale both proportionally, which is wrong in both
+  directions, stretching the table into blank padding on a wide terminal
+  and dropping its LLM column on a narrow one. A resize hook re-pins it,
+  including on attach, since attaching is itself a resize.
+
+  Below 250 the CLI keeps a 100-column floor and the table clips instead,
+  because a full table beside an unusable shell is the worse trade. At 220
+  the table runs 119 columns and loses LLM and RUNTIME. Both numbers are
+  `session_pane_width` and `cli_min_width` at the top of the justfile if
+  you want the other trade.
+
   The panes poll until a daemon appears, so start it in whichever order you
   like.
 

--- a/justfile
+++ b/justfile
@@ -214,6 +214,12 @@ demo-all:
 # renderer's tabwriter rather than estimated.
 session_pane_width := "149"
 
+# Floor for the CLI pane. The console wants 149 + 1 + this, which is why
+# the window defaults to 250. On a narrower terminal the CLI keeps this
+# many columns and the session table clips instead, because a full table
+# beside an unusable shell is the worse trade.
+cli_min_width := "100"
+
 # Operator console for watching a demo live: four panes in one tmux
 # session — live session table and a driver CLI side by side on top, event
 # tail and daemon log poll full-width below. Attach from your own terminal:
@@ -222,12 +228,24 @@ demo-watch: build
     #!/usr/bin/env bash
     set -euo pipefail
     tmux kill-session -t marvel-watch 2>/dev/null || true
-    tmux new-session -d -s marvel-watch -x 220 -y 55
+    tmux new-session -d -s marvel-watch -x 250 -y 55
     P0=$(tmux display -p -t marvel-watch '#{pane_id}')
     P2=$(tmux split-window -t "$P0" -v -l 50% -P -F '#{pane_id}')
     P1=$(tmux split-window -t "$P0" -h -P -F '#{pane_id}')
-    tmux resize-pane -t "$P0" -x {{session_pane_width}}
     P3=$(tmux split-window -t "$P2" -v -l 50% -P -F '#{pane_id}')
+    # tmux scales panes proportionally on resize, which is wrong for both
+    # of these. The session table is content-fixed: narrower and it drops
+    # the LLM column, wider and it renders blank padding. The CLI wants
+    # every column it can get. So the table is pinned and the CLI absorbs
+    # all the slack, re-applied on every resize because attaching from a
+    # real terminal is a resize.
+    RESIZE="{{justfile_directory()}}/scripts/demo-watch-resize.sh $P0 {{session_pane_width}} {{cli_min_width}}"
+    $RESIZE
+    # Synchronous on purpose. The script is three tmux calls, and with
+    # run-shell -b a reader can catch the pane at its proportionally
+    # scaled width before the hook re-pins it.
+    tmux set-hook -t marvel-watch client-resized "run-shell '$RESIZE'"
+    tmux set-hook -t marvel-watch window-resized "run-shell '$RESIZE'"
     # Layout: P0 sessions top-left, P1 CLI top-right, P2 events and P3 logs
     # full-width below. The two readouts you act ON sit beside the CLI you
     # act WITH; the two you read AFTER run underneath, full width, because
@@ -248,5 +266,5 @@ demo-watch: build
     tmux select-pane -t "$P1"
     echo "Operator console ready: tmux attach -t marvel-watch"
     echo "  top-left   sessions ({{session_pane_width}} cols: all columns + 12 of the model)"
-    echo "  top-right  CLI (focused)"
+    echo "  top-right  CLI (focused, takes every column the table does not)"
     echo "  bottom     events --follow, then daemon logs (full width)"

--- a/scripts/demo-watch-resize.sh
+++ b/scripts/demo-watch-resize.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Keep the demo console's session-table pane at its content width and let
+# the CLI absorb every remaining column.
+#
+# tmux scales panes proportionally on resize, which is wrong for both of
+# these panes. The session table is content-fixed: below its width it
+# silently loses the LLM and RUNTIME columns, and above it it renders
+# blank padding while the CLI stays cramped. The CLI is the opposite, it
+# wants every column it can get.
+#
+# Bound by a CLI floor, because on a narrow terminal a full table beside
+# an unusable CLI is the worse trade. The table clips gracefully; a
+# 40-column shell does not.
+#
+# Usage: demo-watch-resize.sh <session-pane-id> <target-width> <cli-min>
+set -euo pipefail
+
+pane=${1:?pane id required}
+want=${2:?target width required}
+cli_min=${3:?cli minimum required}
+
+# Floor for the table itself. Below this the pane is not worth keeping
+# wide at the CLI's expense; WORKSPACE through AGENT NAME still fits.
+table_floor=60
+
+width=$(tmux display -p -t "$pane" '#{window_width}' 2>/dev/null) || exit 0
+[[ -n "$width" ]] || exit 0
+
+# 1 column goes to the pane divider.
+afford=$((width - 1 - cli_min))
+target=$want
+((afford < target)) && target=$afford
+((target < table_floor)) && target=$table_floor
+((target >= width)) && exit 0
+
+tmux resize-pane -t "$pane" -x "$target" 2>/dev/null || true


### PR DESCRIPTION
The CLI pane was 70 columns and stayed proportional on resize, so it was cramped at every terminal width and never got better on a wider screen.

Both panes had the wrong sizing behaviour. The session table is content-fixed: scaled down it drops the LLM column, scaled up it renders blank padding. The CLI is the opposite and wants every column it can get. tmux scales both proportionally, which is wrong in each direction.

The table is now pinned at its content width and the CLI takes the rest, re-applied on every resize because attaching from a terminal is itself a resize. Default window width goes 220 to 250 so the default affords both.

| terminal | table | CLI |
|---|---|---|
| 300 | 149 | 150 |
| 280 | 149 | 130 |
| 250 | 149 | 100 |
| 220 | 119 | 100 |
| 190 | 89 | 100 |

Below 250 the CLI keeps a 100-column floor and the table clips instead. A full table beside an unusable shell is the worse trade, and the table already clips gracefully. Both numbers are `session_pane_width` and `cli_min_width` at the top of the justfile.

The hook is synchronous on purpose. With `run-shell -b` a reader can catch the pane at its proportionally scaled width before the re-pin lands, which is how the first measurements of this change came out wrong.

Recipe, a small helper script, and docs. No code paths change.

Refs: aae-orc-5kfw