### PR TITLE
probe(marvel): per-channel CTX% catalog for five harnesses

### DIFF
--- a/_kos/ideas/bound-context-instead-of-measuring-it.md
+++ b/_kos/ideas/bound-context-instead-of-measuring-it.md
@@ -1,0 +1,154 @@
+# Bound context by construction instead of measuring it
+
+**Status: idea. Pre-hypothesis. Nothing here has been built or tested, and
+the central claim contradicts how two live tickets are currently sequenced.**
+
+Raised during a design review of the CTX% acquisition channels, 2026-08-08.
+Recorded because it argues that a quarter of measurement work may be
+optional, and an argument of that shape deserves to be tested rather than
+absorbed or ignored.
+
+## The provocation
+
+Before cataloguing one more channel, ask what the consumer needs. The
+consumer is `aae-orc-hpeu`, automatic shift triggers. Does it need a
+percentage, or does it need the answer to "can this session still afford a
+handoff?"
+
+Those are not the same measurement. One is a ratio that must be extracted
+from a stranger. The other is a remainder, computable the moment you know
+where the wall is, and the accountant already carries `ContextLimit` and
+`ContextTokens` as a pair **before it divides**.
+
+## Four claims, each testable
+
+### 1. The consumer wants a remainder, not a ratio
+
+A shift costs a drain, a launch, and a handoff artifact. The real predicate
+is `remaining tokens > cost of a clean handoff`. If that holds, the trigger
+reads an absolute remainder plus a per-role handoff-cost estimate, and CTX%
+stays an operator display quantity that got mistaken for the actuator's
+input.
+
+*Confirms:* measure the token cost of one real handoff. A stable
+few-thousand-token constant means the predicate is well posed.
+*Kills:* handoff cost varies wildly with the work.
+
+### 2. Precision was never the constraint, because of an asymmetry
+
+For a binary actuator with an operator-set conservative threshold,
+precision beyond roughly which-decile buys nothing. You cannot shift more
+usefully at 94.7 percent than at 90.
+
+The asymmetry is the interesting half, and it is not the one usually
+assumed:
+
+- **Firing early** costs KV-cache locality (a resource-matrix row, real
+  dollars), a handoff, and an interruption mid-task. Recoverable, priced in
+  tokens, and **visible**.
+- **Firing late** does not crash. The harness auto-compacts and you get an
+  uncontrolled summarization where you wanted an authored handoff. That is
+  F25's own thesis at session scale, and the cost is **silent knowledge
+  loss**.
+
+Late is worse than early not because it fails harder but because it fails
+invisibly. Which argues for firing early and eating the cache cost, which
+argues in turn that precision was never the binding constraint.
+
+### 3. Therefore the minimum viable signal may be an EVENT, not a level
+
+"This session just compacted" is a defensible moment to shift, because the
+harness has just told you it ran out and did the lossy thing on its own.
+Detecting that is far cheaper than measuring occupancy: a downward step in
+any token series, a transcript compaction marker, an epoch row. **Shift on
+first compaction needs no denominator at all** and would work on every
+runtime including ones with no channel.
+
+Evidence that the signal is real and legible across harnesses, from the
+phase 1 sweep: codex's occupancy level drops to zero at compaction
+(observed three times in one session); Crush writes `prompt_tokens = 0` on
+sessions carrying a summary message; gemini emits a `PreCompress` hook and
+a `chat_compression` metric with before and after token counts; opencode
+has a `session_context_epoch` table and compaction events in its protocol.
+
+*Note against it:* the crude proxies (wall clock, turn count) are monotone
+and never reset, while occupancy resets at every compaction, so crude
+proxies over-fire exactly on the long-lived sessions the trigger exists
+for. That is an argument FOR the event and against the cheap proxies, and
+it should not be read as support for the budget in claim 4.
+
+### 4. The stronger version: bound it, do not measure it
+
+`Role.MaxTurns` or `Role.MaxAge` forcing a shift works on every harness
+today, has no version fragility, no schema pinning, no consent question,
+and no per-runtime probe program. marvel already owns every piece:
+manifest-declared budgets with admission refusal, a shift state machine
+with generations, timeout, and rollback.
+
+The strongest argument for it is one nobody made until late: a handoff path
+exercised every N turns is a path that **works**, while one that first
+fires at 90 percent context will be debuted during the worst session of the
+quarter.
+
+**What it honestly loses**, stated by its own proposer:
+
+- Adaptivity. A cheap session rotates as often as an expensive one.
+- Cache locality, systematically rather than occasionally.
+- It is a rotation policy, not a health signal. It cannot catch the runaway
+  session ballooning context fast, which is the memory-pressure trigger the
+  shift-triggers node names.
+- It gives the operator nothing. CTX% has a second consumer: the human
+  reading `marvel get sessions`.
+
+## The consequence for sequencing, which is the actionable part
+
+If claims 2 and 3 hold, **`hpeu` was never blocked on `dc1j`.** Automatic
+shift triggers could ship on a turn or age budget plus compaction detection,
+on every runtime, without resolving a single remaining channel question,
+and `dc1j` proceeds on its own merits at its own pace.
+
+That is a claim about two live tickets and it has not been tested. It is
+recorded on `aae-orc-hpeu` as a claim to test rather than a ruling.
+
+## The honest resolution offered
+
+Not either-or: bound the trigger by construction **and** continue the
+measurement program, but for the operator column and for calibrating the
+budgets. Two workstreams with different urgency and different acceptance
+bars, and treating them as one is what made this feel blocked.
+
+## What would settle it, none of which has been done
+
+- Measure the token cost of one real handoff.
+- Capture one long session crossing auto-compaction with the occupancy
+  series and compaction metadata. This is already the top named follow-up
+  in finding-007 and is still unrun, which is itself worth noticing.
+- Run a fixed budget and log occupancy at shift time. If it clusters low,
+  the budget is burning window and cache for nothing.
+- Test the trigger's behavior when CTX% is absent. Today that branch is
+  untested, and an actuator reading unresolved as zero percent would admit
+  everything.
+
+## A related inversion, filed here rather than separately
+
+If the auto-compaction threshold and effective window are operator-settable
+environment variables, and marvel constructs the process environment at
+spawn (enforcement locus 1, shipped), then marvel has been trying to
+measure a denominator it is entitled to **assign**. `Runtime.context_window`
+is that move already made once, timidly. If it holds, the resolution ladder
+gains a rung above every harness report.
+
+*Confirms:* set the override, drive past it, observe compaction where you
+said it would happen. *Kills:* the harness ignores the variable, which
+would prove cooperation was never optional.
+
+## Provenance
+
+Party-mode design review, 2026-08-08, problem-solving lane, with the
+cache-locality and operator-display objections from the architecture and
+maintenance lanes. Empirical inputs in
+`probe-interactive-ctx-remainder-sweep.md` phase 1.
+
+Related: `marvel-agentic-resource-matrix.md`,
+`ctx-channel-consent-and-fidelity.md`, `permission-through-environment.md`,
+`question-shift-triggers`, `question-interactive-context-pressure`.

--- a/_kos/ideas/ctx-channel-consent-and-fidelity.md
+++ b/_kos/ideas/ctx-channel-consent-and-fidelity.md
@@ -1,0 +1,200 @@
+# CTX% channels: consent gates, fidelity orders
+
+**Status: idea. Pre-hypothesis. Nothing here has been built or tested.**
+
+Raised during a design review of the CTX% acquisition channels, 2026-08-08,
+alongside phase 1 of `probe-interactive-ctx-remainder-sweep.md`. Recorded
+because it is the most reusable thing the review produced, and because it
+would be expensive to rediscover after a second channel ships.
+
+## The problem it answers
+
+The room kept saying "layered" and meaning four different things: a
+fallback chain, a merge, a vote, and a preference order. Meanwhile the
+sweep turned up a class of channel nobody had a slot for: reading state a
+harness writes for its own purposes, with no cooperation at all
+(`~/.codex/sessions/*.jsonl`, `opencode.db`, a per-project `.crush/`,
+`~/.claude/projects/**`). Where does that rank?
+
+## The claim
+
+Cooperation is not a rung on a fidelity ladder. It is a second axis, and it
+**gates** rather than orders. Consent decides what is admissible; fidelity
+still ranks what got in.
+
+**Axis A, fidelity** (orders): proximity to a per-request prompt level with
+its token classes intact.
+
+**Axis B, consent** (gates), three grades:
+
+- **contracted** — the harness publishes it for consumers. A FIFO stream,
+  an HTTP API, OTEL, a documented hook.
+- **conceded** — the harness handed marvel the pointer. The claude
+  statusline payload contains `transcript_path`; codex hooks carry
+  `agent_transcript_path`; a Crush `PreToolUse` hook exports
+  `CRUSH_SESSION_ID`. One field converts a glob into a handoff.
+- **appropriated** — marvel went looking. Globbing a projects directory,
+  opening someone's sqlite file, guessing a path from a mangled cwd.
+
+An appropriated channel is not a low rung. It is off the ladder: a probe
+instrument, whose production form is whatever conceded or contracted
+variant can be negotiated.
+
+## Why the gate, and not just a low rank
+
+Three arguments were offered, in increasing severity. The third is the one
+that would decide it alone.
+
+1. **Failure mode.** A configured-away channel fails loudly and
+   attributably: marvel wrote the config, so marvel knows it is missing,
+   and absence renders as absence. A refactored-away channel fails
+   silently: the file still exists, the query still succeeds, the number is
+   now wrong. That is finding-007's measured defect (a cumulative total
+   read as a level) with a new delivery mechanism.
+2. **Declaration.** A contracted schema tells you which quantity you hold.
+   An appropriated one does not. `Sample.Cumulation` exists precisely
+   because level-versus-sum must be declared and never inferred, and an
+   appropriated channel cannot declare it. (Crush turned out to be
+   determinable anyway, empirically and from source, which weakens this
+   argument by exactly one instance and is worth noting honestly.)
+3. **Credential adjacency, categorical.** `opencode.db` holds `credential`,
+   `account`, and `control_account` tables in the same file as the token
+   counts. SOUL §3 says marvel never stores or manages credentials and
+   delegates auth to the tool that owns it. A production read path whose
+   access surface is the harness's OAuth store is one bug away from
+   violating marvel's own advertised auth boundary. A capture-pane scrape
+   physically cannot reach a credential; a database handle can.
+
+Consent failure is the user's decision to make. Schema failure is the
+vendor's. SOUL §1 says marvel owns the first and must not pretend to own
+the second.
+
+## The overfit ruling this exposes
+
+The sweep brief ruled capture-pane scraping out for fragility. That is
+right, but the stated reason was slightly wrong, and the wrong reason
+generalizes badly.
+
+A TUI's disqualifying defect is not that it is uncooperative. It is that
+**there is no version number on the screen**, so it can only fail quietly.
+Both candidate databases carry a migration-version table
+(`goose_db_version`, `migration`). Uncooperative-with-a-version-handle is a
+different animal from uncooperative-without-one, and the graph currently
+conflates them.
+
+Counter-argument recorded in the same breath, and it is strong: pinning a
+schema version is false comfort where the volatile part is inside an opaque
+column. opencode keeps its token classes in a `data TEXT` JSON blob that no
+`sqlite_master` fingerprint can see, and it shipped 38 migrations in five
+months. The proposed answer is to **fingerprint the data, not the schema**:
+assert an arithmetic identity inside the payload (`total == input + output
++ reasoning + cache.write + cache.read`, which holds on live rows) and
+refuse when it stops holding.
+
+## Consent as an operator decision, not a vendor one
+
+A separate line of argument reached a rule the room could ratify without
+resolving the philosophy: the consent that matters here belongs to the
+**operator**, who owns both tools, not to the harness vendor. But it must
+be given rather than assumed. Concretely: uncooperative reads are opt-in
+per runtime in the manifest (a sibling of the shipped `context_feed`
+setting), never a default, confined to a named table allowlist excluding
+credential-bearing tables, and read-only or not at all.
+
+Also recorded: the room reached for "no conscription" (SOUL §2) to argue
+against uncooperative reads, and that was a misuse. §2 is a
+dependency-direction rule, and reading a peer's files compels the peer to
+do nothing. What is actually at stake is user sovereignty pointed the other
+way, and the platform has no rule for it. That gap may be worth its own
+node.
+
+## What it would cost in code, if it survives
+
+The claim is that this needs no new architecture, only a field and a
+refusal:
+
+- `Source` gains a value per channel class plus a consent grade, reusing
+  the pattern `LimitSource` already ratified for the denominator.
+- One ingest verb, so transport lifecycle stays outside `internal/usage`.
+- A refusal at ingest for the trap the new class introduces: a
+  session-cumulative sample that is not terminal has no level in it, and
+  folding it would resurrect finding-007's defect through a new door.
+- Reach is not a tiebreaker. A channel that cannot reach the host is simply
+  not eligible there, handled by the same mechanism as staleness, which
+  keeps the ladder one-dimensional and answers multi-host without a special
+  case.
+
+## Multi-host, dissolved rather than solved
+
+Every file and sqlite channel dies when the harness runs on another host
+(roadmap M5), while OTEL and a projected callback survive. The counter is
+that **the per-host collector already exists and is called the marvel
+daemon**: a local read is the same class as `internal/procstat` sampling
+the host process table. Nobody ships the process table across hosts; the
+local daemon samples and the reading travels.
+
+The honest consequence: a channel available exactly where the harness
+happens to run cannot be a foundation, because a foundation must be uniform
+across the fleet. It is an optimization that raises fidelity where it
+exists. That costs no new machinery, only the discipline of never treating
+it as the plan.
+
+## A third axis the two above do not predict
+
+The consent axis was built to gate uncooperative reads, and one of its
+supporting arguments was that an appropriated read is not passive (a
+read-only sqlite connection opens `-wal` and `-shm` read-write, because WAL
+readers write read-marks). Round 3 produced a sharper instance of
+not-passive on the CONTRACTED side, where that argument was supposed not to
+reach.
+
+Crush's event stream is as contracted as a channel gets: a documented socket,
+a `/v1` route prefix, a versioned endpoint. And attaching to it registers
+marvel as a REAL client. `AttachClient` bumps a stream count,
+`attached_clients` is exposed on the session, and `proto.go` carries a
+comment that observers use stream count to detect live subscribers. During
+the probe an unobserved workspace was reaped before use, so keeping the
+reading alive may require holding a stream open, which changes the harness's
+own view of whether anyone is watching.
+
+A second instance came from the probe's own hygiene disclosure: merely
+starting a Crush server refreshed the shared global caches
+`~/.local/share/crush/providers.json` and `hyper.json`, and `--data-dir`
+scopes the project database rather than the global config directory. So
+instantiating the contracted channel mutated host-global state outside the
+probe's sandbox.
+
+Neither is a consent failure. Both are observation-changing-the-system, and
+both land on the contracted channel, which means **the consent axis does not
+predict perturbation**. Either the model needs a third property per channel
+(does observing it alter the observed system, and does the harness's own
+behavior key on being observed) or perturbation belongs in the arbitration
+logic as an eligibility cost rather than in the grading.
+
+The practical consequence is small and immediate: a channel can be fully
+contracted and still not free. That belongs in the arbitration design before
+a second channel ships, which is the whole reason this file exists.
+
+## What would kill this idea
+
+- If the arbitration never actually fires because no session ever has two
+  eligible channels, the whole apparatus is ceremony and one channel per
+  harness plus an honest absent state is correct.
+- If the consent grades turn out to collapse in practice (every conceded
+  channel is also contracted, or no harness ever concedes a pointer), the
+  axis is a distinction without a difference.
+- If an operator rules that appropriated reads are simply fine, the gate
+  becomes a preference and this is over-thought.
+
+## Provenance
+
+Produced in a party-mode design review, 2026-08-08. The consent grading and
+the multi-host dissolution came from the architect's lane; the
+fingerprint-the-data counter and the silent-failure taxonomy from the
+maintenance lane; the operator-consent rule and the overfit-ruling
+observation from the problem-solving lane. Empirical inputs are catalogued
+in `probe-interactive-ctx-remainder-sweep.md` phase 1. The eight code
+observations the same review produced are `ArcavenAE/marvel#141` to `#148`.
+
+Related: `stream-attachment-strategies.md`, `marvel-channel-design-principles.md`,
+`marvel-agentic-resource-matrix.md`, `permission-through-environment.md`.

--- a/_kos/probes/probe-compaction-ground-truth-mining.md
+++ b/_kos/probes/probe-compaction-ground-truth-mining.md
@@ -1,0 +1,208 @@
+# Probe brief: compaction ground truth is already on disk, dozens of times
+
+**Status:** OPEN (brief only; not started).
+**Question:** `question-interactive-context-pressure`, and the compaction
+half of `question-shift-triggers`.
+**Probe medium:** mining existing local artifacts. No model calls, no
+harness sessions, no daemon.
+**Timebox:** one sitting.
+**Prior work it extends:** finding-007 named "capture one long session
+crossing auto-compaction with the occupancy series and compaction
+metadata" as its top follow-up. It has never been run, and it is cited as
+unrun by finding-008, `aae-orc-dc1j`, and `aae-orc-hpeu`.
+
+## Why this probe exists
+
+The measurement has been treated as expensive because crossing
+auto-compaction on purpose costs real quota and a long session. That
+premise is false: the crossings already happened, and Claude Code wrote
+them down.
+
+Observed on kinu, 2026-08-08, over `~/.claude/projects/**/*.jsonl`
+(1535 files across 54 project directories):
+
+```
+  44 files contain a system/compact_boundary line
+ 112 such lines, of which:
+      71  carry compactMetadata with 8 keys (incl. preCompactDiscoveredTools)
+       7  carry compactMetadata with 7 keys (no preCompactDiscoveredTools)
+      34  carry no top-level compactMetadata at all
+```
+
+So the usable corpus is **78 labelled events across two schema
+generations**, not the flat count.
+
+**A correction, and a method note that matters more than the number.** An
+earlier draft of this brief said 46 files and 126 lines. A second count by
+another reader said 44 and 105. The recount above says 44 and 112. All three
+were taken on the same host within an hour. The counts diverge because the
+counting methods diverge (match on `compact_boundary`, match on
+`compactMetadata`, parse and inspect the object) and because the corpus is
+LIVE: sessions are being appended to while it is being counted, including
+the session doing the counting.
+
+The rule that follows is the useful part: **state the method, not the
+number, and re-count at probe time.** Do not inherit any figure in this
+brief, including this one. Snapshot the corpus before mining so the
+denominator of the analysis does not move underneath it.
+
+The two key sets present, with the more recent one first:
+
+```
+trigger, preTokens, postTokens, cumulativeDroppedTokens,
+durationMs, preservedSegment, preservedMessages, preCompactDiscoveredTools
+```
+
+and the same list without `preCompactDiscoveredTools`. One sampled record:
+
+```
+trigger: auto
+preTokens 467021  ->  postTokens 13774
+cumulativeDroppedTokens 453247
+durationMs 154351
+```
+
+So the ground truth finding-007 wanted is a local corpus of labelled
+compaction events, each paired with the full per-assistant-message
+`message.usage` series that precedes and follows it in the same file.
+Mining it costs zero model calls.
+
+The 34 lines with no top-level `compactMetadata` are the first thing to
+resolve, since they are 30 percent of the matches. Either they are an older
+generation that predates the field, or `compact_boundary` appears on them in
+some other position (a nested value, a tool result). Whichever it is, it
+decides whether the usable corpus is 78 or larger.
+
+**This is a probe, not a finding.** Nothing below has been computed. The
+numbers above are a count and one sampled record.
+
+## Hypothesis
+
+The existing transcript corpus is sufficient to (a) measure the real
+relationship between marvel's computed occupancy and the harness's actual
+compaction trigger point, (b) retire the accountant's inferred
+compaction-detection heuristic in favor of an explicit marker, and (c)
+price the cost of a late shift, which is the number
+`bound-context-instead-of-measuring-it.md` needs and does not have.
+
+## Sub-probes and success signals
+
+### SP1. Does marvel's occupancy formula predict the compaction point?
+
+For each labelled boundary, compute occupancy from the preceding
+assistant message using marvel's own additive rule (`input +
+cache_read + cache_creation`) and compare against `preTokens`.
+
+**Success signal:** a stated relationship between the two, with its spread.
+If `preTokens` equals marvel's occupancy, the formula is validated against
+the harness's own accounting on real data. If it differs by a constant or
+a proportion, that constant is the correction marvel currently lacks. If it
+differs unpredictably, the formula is wrong and that is the most valuable
+possible outcome.
+
+### SP2. Where does auto-compaction actually fire?
+
+Group by `trigger`. For the `auto` cases, compute `preTokens` against the
+window for that session's model.
+
+**Success signal:** the effective auto-compaction threshold as a measured
+distribution rather than the reasoned "threshold plus a 33-45k buffer"
+currently carried in `internal/usage/doc.go`. Note the known complication:
+`message.model` reads `claude-opus-5` with no variant marker even on a 1M
+build, so sessions must be separated by observed window rather than by
+model id alone, and some may not be separable at all.
+
+### SP3. What does a late shift actually cost?
+
+`cumulativeDroppedTokens` is the size of the uncontrolled summarization
+that happens when nobody shifted in time. The specimen above dropped
+453,247 tokens.
+
+**Success signal:** a distribution of dropped-token counts across every real
+event in the snapshot. This is the number that decides whether the early-versus-late
+asymmetry argument in `bound-context-instead-of-measuring-it.md` holds. If
+drops are consistently large, firing early is cheap by comparison and the
+precision argument collapses. If drops are small, the asymmetry is weaker
+than claimed.
+
+### SP4. Would the accountant's inferred detector have caught these?
+
+The accountant infers compaction from a downward step with a hysteresis
+that its own source marks as reasoned rather than measured. The comment at
+`internal/usage/accountant.go:14-31` says so in as many words: the bound was
+"chosen to be un-fireable by ordinary variation rather than calibrated: no
+live compaction was crossed on any harness". The constants are
+`defaultHysteresisTokens = 2048` and `defaultHysteresisFraction = 0.10`, and
+the single compaction geometry the comment cites is one instance recovered
+from orc finding-066 (roughly 167k down to 96k). This probe would replace an
+n-of-1 with the whole snapshot.
+
+Replay the occupancy series across each boundary and check whether the
+existing detector fires, at the right record, without false positives
+elsewhere in the file.
+
+**Success signal:** a false-positive and false-negative count for the
+shipped heuristic against every labelled event. That is a regression fixture
+as well as a measurement, and it is the cheapest validation of shipped
+behavior available anywhere in this arc.
+
+### SP5. Does the same marker exist in the other harnesses?
+
+Phase 1 of the remainder sweep recorded compaction signals per runtime that
+have not been checked against real data: codex drops its occupancy level to
+zero (observed three times in one session) and writes `compacted` and
+`context_compacted` records; Crush writes `prompt_tokens = 0` on sessions
+carrying a summary message; opencode has a `session_context_epoch` table,
+empty on this host; gemini emits a `chat_compression` metric with before
+and after counts.
+
+**Success signal:** for each runtime with local artifacts, either a labelled
+compaction corpus of its own or a statement that none exists on this
+machine.
+
+Two further corpora are confirmed present on kinu as of 2026-08-08, which
+widens this sub-probe from a long shot into the second half of the job:
+
+- **codex**: roughly 209 session files under `~/.codex/sessions/`. The
+  likeliest second compaction corpus.
+- **gemini**: 26 files under `~/.gemini/tmp/*/chats/`, carrying **477
+  messages with a per-turn token series** shaped `{input, output, cached,
+  thoughts, tool, total}` with the model name alongside. Measured directly,
+  not inferred from docs. Notably richer than gemini's documented
+  `AfterModel` hook payload, which promises only `totalTokenCount`. Whether
+  any compaction marker rides these files is unknown; gemini's compaction
+  numbers are documented on its OTEL path
+  (`gemini_cli.chat_compression{tokens_before, tokens_after}`), which is a
+  different channel and may mean the local files carry the series without
+  the labels.
+
+Three independent local corpora is the argument for doing this probe before
+any probe that spends model quota.
+
+## Excluded scope
+
+- **Building anything.** This probe produces measurements and fixtures. Any
+  change to the detector, the threshold handling, or the shift trigger is
+  downstream work.
+- **Forcing a compaction.** The premise is that this is unnecessary. If a
+  sub-probe genuinely needs a controlled crossing, record that as a result
+  rather than running it here.
+- **The subagent question.** No `isSidechain: true` assistant line exists in
+  the local corpus, so subagent context is not minable this way and stays
+  with `subagentStatusLine`.
+
+## Handling note
+
+The corpus is the operator's own working history across 52 project
+directories, including private repositories. This probe reads token counts,
+timestamps, and compaction metadata. It has no reason to read message
+content, and should not. Any artifact it produces (fixtures, tables) should
+carry counts and derived numbers, never transcript text.
+
+## What would change the read
+
+Two schema generations are already visible in the counts above, and 34 of
+112 matching lines carry no top-level `compactMetadata` at all. If the older
+generation turns out to dominate, the usable corpus shrinks and the probe
+should say so rather than mixing generations. Field presence is checked per
+instance before anything is aggregated, not assumed from the match count.

--- a/_kos/probes/probe-interactive-ctx-remainder-sweep.md
+++ b/_kos/probes/probe-interactive-ctx-remainder-sweep.md
@@ -87,3 +87,1214 @@ the statusline precedent.
   that question, not this probe).
 - Settings-precedence documentation for projected statuslines (7hzb
   remainder, docs work, not research).
+
+---
+
+# Phase 1 results, 2026-08-08
+
+**Status: phase 1 run for all four runtimes.**
+**These are candidates, not results. Nothing below has been through phase 2.**
+
+Produced by a desk sweep with spot verification on kinu (macOS 26, tmux
+3.7b). Read-only throughout: no harness session was started for the sweep,
+no harness state was modified. Where a claim was checked against a real
+artifact on this machine it is marked VERIFIED-ON-DISK; where it comes from
+upstream source at a pinned commit, VERIFIED-IN-SOURCE; where only a doc
+asserts it, DOCUMENTED.
+
+A candidate verdict here means "worth building a rig for," nothing more.
+The brief's phase-2 success signal (a live `marvel get sessions` row showing
+CTX% for an interactive session of that runtime) has not been met for any
+runtime.
+
+## The question changed during phase 1
+
+The brief asks each runtime what it EXPORTS. That framing generalized the
+wrong half of its own precedent: interactive claude was won with an
+execution hook (`statusLine` runs a command marvel supplies), not with a
+data feed. So phase 1 was run asking both questions, and the second one is
+the one that found the most:
+
+> What will this runtime RUN for me?
+
+A runtime with no export but with an execution point is a configuration
+problem. A runtime with neither is the honest `no channel` case. Phase 2
+and any successor brief should carry both questions, in that order.
+
+## Candidate table
+
+| Runtime | Verdict | Channel | Carries |
+|---|---|---|---|
+| codex | `candidate` | rollout JSONL on disk | occupancy level AND denominator, same record |
+| opencode | `candidate` | HTTP server (port pinned at spawn), or `opencode db`, or a plugin | occupancy; denominator from a separate on-disk catalog |
+| Crush | `candidate` | server SSE (TUI is a client of it) | occupancy level; denominator from a 1405-model on-disk catalog |
+| gemini | `candidate`, deferred | `AfterModel` hook | occupancy; denominator is client-side only, never exported |
+
+**Every runtime surveyed has an execution point. They differ in what the
+payload carries, and that is the useful distinction.**
+
+| Runtime | Execution point | Payload carries |
+|---|---|---|
+| claude | `statusLine` command | occupancy AND denominator |
+| gemini | `AfterModel` hook | occupancy (`promptTokenCount`) |
+| opencode | plugin (`chat.params`, `event`) | occupancy AND denominator, in process |
+| Crush | `PreToolUse` hook | neither; session id only, so a trigger |
+| codex | `notify`, `hooks` (10 events) | neither; a pointer to the file |
+
+So the interactive-claude win was not a Claude Code accident, and the
+brief's original export-first question would have missed gemini and
+opencode entirely. It also reframes the two that carry nothing: a trigger
+plus a separate read is still a cooperative feed, assembled from two
+channels rather than one, and both Crush and codex hand over the session
+identity needed to join them.
+
+Where a hook exists but carries no tokens, the cheapest move may be
+upstream rather than architectural. Crush's own docs invite requests for
+further hook events and it already parses Claude Code's hook-output
+envelope, so a usage-carrying turn-end hook is a small, well-formed ask
+rather than a feature marvel has to work around.
+
+### codex
+
+The strongest candidate found, and the surprise of the sweep: it is a local
+file read that carries its own denominator, which the sweep's working
+assumption said local reads never do.
+
+- `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`, record
+  `event_msg` / `token_count`, carries `last_token_usage` (six token
+  classes), `total_token_usage`, and `model_context_window` in one record.
+  VERIFIED-ON-DISK.
+- **It is a level, not a delta.** In one 414-record interactive session,
+  `last_token_usage.input_tokens` drops to zero at record indexes 49, 242,
+  and 378 (three auto-compactions) against a peak of 240,736. A running sum
+  cannot decrease. VERIFIED-ON-DISK, independently reproduced.
+- Denominator present on 413 of 414 records, constant at 258,400. The one
+  exception is the first record (~4s in), where `info` is null entirely.
+  VERIFIED-ON-DISK.
+- Cadence is per model API request, median gap 9.7s, not per user turn.
+  Written live during an interactive TUI session. VERIFIED-ON-DISK.
+- `state_5.sqlite` `threads.tokens_used` equals `total_token_usage.total_tokens`
+  exactly, so that column is spend and NOT occupancy. VERIFIED-ON-DISK.
+- Trap: `session_meta.payload.context_window` is a UUID (`window_id`), not a
+  size. VERIFIED-ON-DISK.
+- No execution point carrying tokens: `notify` fires only on
+  `agent-turn-complete`, and `hooks` has ten events; neither payload carries
+  tokens or a window. Both DO carry a pointer (`thread-id`,
+  `agent_transcript_path`), so the projection a supervisor writes would say
+  which file to read rather than reporting the number. VERIFIED-ON-DISK.
+- `tui.status_line` is NOT an analog of Claude Code's `statusLine`. It is an
+  ordered list of built-in footer item identifiers and executes nothing.
+  DOCUMENTED.
+- OTEL exists (`codex.conversation_starts` carries the window;
+  `codex.turn.token_usage` carries classes) but metrics carry no session
+  identifier, so per-session attribution from metrics alone is not
+  available. VERIFIED-IN-SOURCE.
+
+**Open before this can be built,** and phase 2 exists to settle them:
+pane-to-file binding (the sweep used `lsof` on the pane pid, which worked
+but is untested under marvel's own spawn); the constant offset between
+`last_token_usage / model_context_window` and the footer's rendered
+"% context left" (`core/src/session/context_window.rs`, unread); behavior
+under `codex exec --ephemeral` and a relocated `CODEX_HOME`, either of
+which removes the channel entirely; and whether the cadence holds under
+sustained fleet load rather than one operator's session.
+
+### opencode
+
+Two shapes, and the sweep did not settle which marvel should carry.
+
+- **Contracted, and cheap.** `--port` is a global flag on the DEFAULT TUI
+  command, not only on `serve`. So marvel could pin a port at spawn and the
+  HTTP surface becomes available for an interactive pane.
+  `internal/runtime/opencode.go:51-55` passes `Runtime.Args` verbatim and
+  nothing else; the file's own comment already anticipates a later adapter
+  for this. VERIFIED-ON-DISK (help text at 1.18.11 and 1.18.14).
+- `opencode serve` starts a headless server; `/api/model`, `/doc`, and
+  `/global/event` all answer 200 at 1.18.14. `/api/model` returned zero
+  models against a bare server with no provider context, so the
+  `limit.context` payload is NOT yet confirmed live. VERIFIED-ON-DISK for
+  reachability; UNVERIFIED for content.
+- Server startup warns `OPENCODE_SERVER_PASSWORD is not set; server is
+  unsecured`, so an auth posture has to be chosen before marvel pins a port.
+  VERIFIED-ON-DISK.
+- `GET /api/session/{id}/context` is documented in upstream source as "all
+  messages after the last compaction," which would be a compaction-correct
+  numerator. VERIFIED-IN-SOURCE at pinned SHA; UNVERIFIED at any installed
+  version.
+- **Uncooperative alternative:** `opencode db "<sql>" --format json` is a
+  shipped subcommand, so the sqlite path needs no sqlite driver in marvel.
+  `message.data` JSON carries the token classes; `session` carries
+  cumulative per-session columns. VERIFIED-ON-DISK.
+- **Denominator is a file:** `~/.cache/opencode/models.json` (3.6 MB,
+  refreshed by opencode itself) carries `limit.context` per model.
+  VERIFIED-ON-DISK.
+- **Execution point exists:** the plugin API's `PluginInput` hands a plugin
+  `serverUrl` and a client, and the `chat.params` hook receives the `Model`
+  object carrying `limit.context`, while `event` receives the whole event
+  feed including token payloads. Numerator and denominator, in process.
+  VERIFIED-ON-DISK (the plugin package is installed on this host).
+- Dead ends: no OTEL (removed upstream in sst/opencode#1738), no `/metrics`
+  route, `opencode mcp` is client-role only, `opencode stats` is cumulative
+  spend with no occupancy or window, and the default-level log file carries
+  token keys only on session-created records with zero values.
+- The `opencode api` subcommand and the `server.json` daemon-discovery file
+  are dev-branch: absent at 1.18.11 and at 1.18.14. VERIFIED-ON-DISK.
+  A sweep claim built on them was corrected by installing the upgrade.
+
+**Open before this can be built:** whether an installed version serves the
+v2 `/api/*` paths at all; what the SSE frames look like on the wire; the
+auth posture for a marvel-pinned port; and whether `session_context_epoch`
+means what its name suggests (0 rows on this host, so unexercised).
+
+### Crush
+
+The sweep's biggest reversal. Three non-specialist readers examined the
+sqlite artifact and returned a provisional `no channel`; the platform
+catalog overturned it on every point, and the reversal is verified.
+
+- **`crush server` ships** in v0.88.0, and `-H --host` is a flag on the
+  ROOT (TUI) command with the same unix-socket default. **The interactive
+  TUI is itself a client of that server**, so an interactive session is
+  observable over the same API as a headless one, with no pane scraping.
+  VERIFIED-ON-DISK.
+- **`sessions.prompt_tokens` is a LEVEL, not a sum.** Live rows on this
+  machine: 35,267 at 2 messages, 35,290 at 4, 35,745 at 12. Flat under 6x
+  message growth. Both rows carrying a `summary_message_id` read 0, which
+  is the compaction reset visible in the data. VERIFIED-ON-DISK,
+  independently reproduced.
+- Source agrees: `updateSessionTokenCounters` assigns rather than adds
+  (`internal/agent/agent.go:1941-1948`), written once per API request.
+  VERIFIED-IN-SOURCE.
+- **The trap that produced the wrong provisional verdict.**
+  `internal/db/sql/sessions.sql` also contains `UpdateSessionTitleAndUsage`
+  with `SET prompt_tokens = prompt_tokens + ?`, which has no caller outside
+  the generated db layer. Reading the schema or the `.sql` file alone yields
+  accumulate semantics, which is wrong. VERIFIED-IN-SOURCE.
+- **Denominator is a complete catalog on disk.**
+  `~/.local/share/crush/providers.json`: 40 providers, 1405 models, and
+  **zero** with a missing or zero `context_window`. VERIFIED-ON-DISK.
+- Composition differs from marvel's: Crush computes `input + cache_read`
+  and EXCLUDES cache-creation tokens, where marvel's additive layout is
+  `input + cache_read + cache_creation`. A Crush layout must encode that or
+  CTX% reads low right after a cache write. VERIFIED-IN-SOURCE.
+- **The estimated-versus-measured flag is persisted nowhere.** When a
+  provider returns zero usage, Crush estimates input tokens at roughly four
+  characters per token and sets an `EstimatedUsage` flag that exists only in
+  memory. It is not a `sessions` column and not an API field. The TUI shows
+  a tilde; the database and the API do not. No channel distinguishes a
+  measured level from a character-count guess, which bears directly on
+  `internal/usage/doc.go`'s stance on false precision.
+- Execution point exists but does not carry tokens: `hooks` implements only
+  `PreToolUse`, whose payload has no usage field. It works as a TRIGGER (it
+  exports `CRUSH_SESSION_ID`) into one of the channels above, not as a feed.
+  Crush parses Claude Code's `hookSpecificOutput` envelope and its docs
+  explicitly invite requests for further hook events, which makes a
+  usage-carrying turn-end hook the cheapest upstream ask in this survey.
+  VERIFIED-IN-SOURCE.
+- `projects.json` maps a workspace path to the `.crush` directory holding
+  its database, so marvel never has to crawl for it. VERIFIED-ON-DISK.
+- Dead ends: no OTEL, no `/metrics`, no MCP server role. PostHog analytics
+  exist and are Charm's stream, not marvel-addressable.
+
+**The prior blocker was misread, and the correction matters beyond Crush.**
+`charmbracelet/crush#1765` was treated in this graph as evidence that Crush
+architecturally refused a serve mode. It was created at 15:35:37Z and closed
+at 15:38:39Z **by its own author**, who said they would repost as a
+discussion per contributing guidelines. It was never a maintainer design
+ruling. VERIFIED via issue state. The client/server split was already
+shipping in v0.70.0 (2026-05-18) while the prior survey pinned 0.67.0
+(2026-05-11): a one-week version gap produced a three-month-stale verdict.
+
+**Open before this can be built:** no crush server was started for this
+sweep, so the SSE frame encoding, the config endpoint's JSON shape, and live
+socket behavior are source-read only. The server also idle-shuts-down after
+60 seconds by default (`CRUSH_SERVER_IDLE_TIMEOUT`), so a poller must
+tolerate the socket vanishing or marvel must set that env var at spawn. The
+socket path is macOS-specific per B13. Locally-discovered providers (ollama,
+lmstudio) get their window at runtime and it is written nowhere, so those
+sessions need the config endpoint or an operator-set `Runtime.context_window`,
+and this host's daily driver is exactly such a model.
+
+### gemini
+
+`candidate`, and the recommendation is to record it and defer it.
+
+- **`AfterModel` hook is the candidate.** Gemini CLI runs an
+  operator-supplied command and pipes it JSON on stdin;
+  `llm_response.usageMetadata` carries `promptTokenCount`,
+  `candidatesTokenCount`, `totalTokenCount`. Fires on every model response,
+  TUI or headless. Structurally the same shape as the claude win.
+  VERIFIED-IN-SOURCE (`packages/core/src/hooks/hookTranslator.ts:379-412`).
+- **Per-session projection lever exists.**
+  `GEMINI_CLI_SYSTEM_SETTINGS_PATH` is returned verbatim as the system
+  settings path, so marvel could project a hook config per process without
+  touching the user's own `~/.gemini/settings.json`. That is the isolation
+  property Tobias's proposed adapter rule asks for.
+  VERIFIED-IN-SOURCE (`packages/cli/src/config/settings.ts:105-106`).
+- Hook roster: eleven events, only `AfterModel` carries tokens.
+  `PreCompress` marks the compaction crossing without quantifying it. Every
+  event carries `session_id` and `transcript_path`.
+- **The denominator is never exported.** `tokenLimit(model)` is computed
+  client-side (`DEFAULT_TOKEN_LIMIT = 1_048_576`, Gemma variants 256,000),
+  and the TUI's context display is nine lines dividing `promptTokenCount`
+  by it. marvel would supply the window from its own table, which
+  `Runtime.context_window` already accommodates. VERIFIED-IN-SOURCE.
+- **OTEL is the weaker channel, and this settles an open graph question.**
+  The emitting code carries token counts only: `gemini_cli.token.usage`,
+  `gemini_cli.session.count`, `gemini_cli.chat_compression`,
+  `gemini_cli.token.efficiency`, plus a GenAI-convention histogram. Nothing
+  named for context window or occupancy, and no `conversation_starts`
+  analog carrying a limit the way codex has. VERIFIED-IN-SOURCE
+  (`packages/core/src/telemetry/metrics.ts`). The `session.id` common
+  attribute is DOCUMENTED only; the code attaching it was not found, and
+  per-session correlation is the whole point for marvel.
+- `gemini_cli.chat_compression` (attrs `tokens_before`, `tokens_after`) is
+  the one thing OTEL adds: it quantifies the compaction step both
+  finding-007 and finding-008 flag as unmeasured.
+- Upstream states marvel's own rule in their words:
+  `uiTelemetry.ts:248-250` reads "the total tokens of the last Gemini
+  message represents the context size at that point in time." They also
+  carry a mild internal inconsistency (restore path uses `tokens.total`,
+  live TUI path uses `promptTokenCount`).
+- Headless `--output-format json` and `stream-json` both emit cumulative
+  sums at completion with no window, so they are the wrong shape.
+- Dead ends: no statusline concept, no Prometheus scrape, no server mode
+  exposing session state, extensions do not get hooks (#14449 closed).
+
+**Both blockers this graph held gemini behind are stale, one by ten
+months.** `gemini-cli#9009` (no JSON output) closed COMPLETED 2025-09-26;
+`#13561` (non-interactive asking questions) closed as DUPLICATE 2026-04-09.
+VERIFIED via issue state. The 2026-07 note carrying them forward as live
+gates should be retired.
+
+**Why defer anyway.** marvel has no gemini adapter (`aae-orc-6c2r`), and
+this brief's own rule is that a channel for a runtime marvel cannot launch
+is shelf inventory. A phase-2 rig would have to build the adapter first.
+Deferring is cheap rather than lossy here: the expensive part is done and
+durable (channel named, payload fields source-verified, projection lever
+identified), so whoever schedules the adapter starts at implementation.
+
+**One framing correction for the graph:** gemini should stop being
+described as the OTEL-capable-but-unverified runtime. Its OTEL is the
+weaker of its two channels and carries no denominator. Left under the old
+framing, the next reader re-derives all of this.
+
+## What phase 1 also turned up, and where it went
+
+The sweep read enough of marvel's own code to raise eight observations about
+shipped behavior. Those are filed as `ArcavenAE/marvel#141` through `#148`
+with linked beads, each written as a request to validate rather than a
+verdict. Two of them bear directly on this probe: `#141` (ctx-forward
+discards the classes, the window, and `transcript_path`) and `#142` (the
+numerator carries no provenance, so two producers print identically).
+
+## Revised phase 2
+
+Unchanged in shape, revised in content. Per surviving candidate, the rig
+now has named unknowns rather than a general "verify against ground truth":
+
+1. **codex.** Bind a marvel-spawned interactive pane to its rollout file and
+   hold the binding across a turn; resolve the offset against the rendered
+   footer figure; confirm behavior when the file is absent by configuration.
+2. **opencode.** Pin `--port` at spawn on the default TUI command, then
+   confirm the HTTP surface answers with real content for that session, and
+   settle the auth posture. Compare against the `opencode db` path for the
+   same session to see whether the server adds anything the file does not.
+3. **Crush.** Do not run phase 2 unless the platform catalog overturns the
+   provisional verdict.
+4. **gemini.** Run phase 1 first.
+
+Ordering note: both surviving candidates are LOCAL to the host running the
+harness. Neither survives multi-host scheduling (roadmap M5) without the
+daemon on that host doing the reading. That does not disqualify either, but
+it does mean phase 2 should record what it is building as host-local by
+construction.
+
+## Two cross-cutting results the per-runtime sections do not carry
+
+### The callout tiers, and why no runtime is a dead end
+
+The execution-point table above is better stated as three tiers that
+compose upward:
+
+- **FEED** — the invocation carries the numbers (claude `statusLine`,
+  gemini `AfterModel`, opencode plugin).
+- **POINTER** — the invocation carries a handle to where the numbers live
+  (every claude hook carries `transcript_path`; codex `notify` and hooks
+  carry the rollout path).
+- **CLOCK** — the invocation carries only identity and timing (Crush
+  `PreToolUse`).
+
+A clock plus a derivable path is a pointer; a pointer plus a file carrying
+usage is a feed. So the right question for a fifth harness is not "does any
+callout carry tokens" (usually no) but "does any callout carry an
+identifier I can turn into a path, and does that path hold usage." On that
+test no runtime in the roster is unsolved, only differently priced.
+
+Two secondary observations worth keeping: an in-process extension (a
+plugin) can read live state and therefore usually gets the denominator,
+where an out-of-process command can only read what the harness chose to
+serialize; and chrome-rendering callouts are the richest out-of-process
+feeds, because a harness that must DRAW a context meter has to serialize
+both terms to draw it. That gives a concrete search list for any new
+harness: statusline, prompt, window title, notification command, theme
+command.
+
+### Following these channels correctly, measured on kinu
+
+The sweep's channels are files and databases, and the cost of reading them
+was measured rather than assumed:
+
+- **`PRAGMA data_version` costs 1.72 microseconds** on a persistent
+  read-only connection, roughly 140x cheaper than the occupancy query it
+  gates. It is per-connection: open-poll-close makes it a silent constant.
+- **`stat` on a sqlite file is wrong.** `logs_2.sqlite` held its mtime for
+  ten minutes while its WAL grew 218 KB to 750 KB. A poller on the db file
+  concludes idle while three quarters of a megabyte lands. WAL size is also
+  unreliable, since sqlite resets to offset zero after checkpoint rather
+  than truncating.
+- **A read-only sqlite connection is not passive.** It opens `-wal` and
+  `-shm` read-write, because WAL readers write read-marks. The achievable
+  goal is a lock that cannot block the writer, not the absence of one, and
+  the rule that follows is to keep the connection alive but never wrap a
+  poll in a transaction, since a pinned snapshot grows the writer's WAL
+  without bound.
+- **`mode=ro` while the harness runs, `immutable=1` only when it does not.**
+  `immutable=1` against a live writer skips the WAL and returns stale data
+  with no error, which for a freshness metric is the worst available
+  failure.
+- **`CGO_ENABLED=0` is set at `.goreleaser.yml:15` and `ci.yml:102`**, which
+  rules out `mattn/go-sqlite3` entirely. The pure-Go driver is an ADR, not
+  an implementation detail, and shelling to `sqlite3` costs ~8 ms per
+  invocation and discards the persistent connection change detection needs.
+- **Per-pid `lsof` costs 49 ms**, so binding fifty panes that way is 2.45
+  seconds per reconcile tick. Worse, **it cannot find the claude transcript
+  at all**: the live harness holds 54 fds, none of them the JSONL, because
+  it opens, appends, and closes. So `lsof` is serving as a cwd oracle
+  rather than a file finder, and the codex binding that worked in this
+  sweep does not generalize.
+- **Read the tail, never the head.** The thing that actually stops scaling
+  is reading a growing JSONL from offset zero every tick. A fixed 64 KB
+  tail window with `(dev, ino)` tracking is the difference between hundreds
+  of sessions and about six. Never parse a line lacking its terminating
+  newline.
+- **Linux inotify is the tighter side**: watches count against
+  `max_user_watches` and instances against `max_user_instances`, commonly
+  128, so one shared watcher with many paths rather than one per session.
+  macOS kqueue is four orders of magnitude from its ceiling here.
+
+### The cwd gap decides which channels are even addressable
+
+`internal/api/types.go:84` defines `Workspace` as `Name string` and
+`CreatedAt time.Time`. marvel's documented isolation boundary touches the
+filesystem nowhere, and the adapters pass the workspace name as a label.
+
+That splits the file channels cleanly:
+
+- **codex is addressable today.** Fixed home (`~/.codex/sessions/**`), plus
+  `state_5.sqlite` mapping cwd to rollout path, plus `cwd` in-band in
+  `session_meta`. A second independent reason it leads.
+- **claude and Crush are not**, until marvel holds a path: their locators
+  are functions of cwd (a mangled-cwd directory, and a per-project
+  `.crush/`).
+- **opencode is in between**: one fixed-home database for every session, so
+  addressable without cwd, but `session.directory` is needed to attribute a
+  row to a marvel session.
+
+The point is that marvel CHOSE the working directory at spawn and did not
+keep it. Discovering it afterward with a 49 ms probe is paying to recover
+data the daemon already had. That is a design gap worth filing rather than
+a lookup problem worth optimizing.
+
+### One untried claude door worth its own line
+
+`totalTokensReminder: "countdown"` is a settings key that emits remaining
+tokens into the conversation itself, reconciled exactly against the raw
+occupancy level (200000 minus a 33622 prompt level minus 113 output equals
+the emitted 166265). It rides the projected-settings mechanism marvel
+already owns, needs no forwarder process, and works identically headless
+and interactive. It is marked internal in the binary, so it is revocable
+and would need a version pin, and it costs context and is read by the model,
+which is an unmeasured behavioral effect. Recorded as a candidate, not a
+recommendation.
+
+### And one clean negative
+
+There is no `isSidechain: true` assistant line anywhere in the local
+transcript corpus, so transcripts do NOT carry subagent context.
+finding-011 stands unamended: `subagentStatusLine` is the only channel
+breaking out per-subagent token counts and window sizes.
+
+## Phase 1, round 3: the framework was wrong in a way worth keeping
+
+Round 3 re-ran the per-runtime verdicts as verification rather than survey.
+Three results change the shape of the catalog, and one of them corrects the
+tiering this brief introduced two sections above.
+
+### Tier is a property of the CHANNEL, not of the harness
+
+The FEED/POINTER/CLOCK tiering was written as though a harness has a tier.
+It does not. A harness has a channel INVENTORY, and each channel is tiered
+separately.
+
+The decisive counterexample is gemini's `PreCompress` hook. It fires at the
+single most informative instant in a session, the moment context pressure
+peaks, and its payload is `trigger: "auto" | "manual"` plus base fields. A
+CLOCK at exactly the instant you most want a feed. The numbers for that same
+event exist and are precise, on a different channel:
+`gemini_cli.chat_compression{tokens_before, tokens_after}` on the OTEL path.
+One event, two channels, two tiers.
+
+gemini alone spans all three tiers at once: CLOCK at `PreCompress`, POINTER
+via `transcript_path` and a derivable project-hash directory, FEED via OTEL.
+Cataloguing it as "a FEED harness" because `AfterModel` exists would have
+selected the worst of its three channels. The catalog is therefore per
+channel, and a runtime's row is a list.
+
+**A second refinement: split FEED by how many terms it carries.**
+
+- **FEED-2** carries occupancy AND window. claude `statusLine`, Copilot CLI
+  `statusLine`, Qwen Code `statusLine`.
+- **FEED-N** carries occupancy only. gemini `AfterModel`, gemini OTEL
+  outfile, gemini local chat files, aider `--analytics-log`.
+
+The distinction is operational, not cosmetic. A FEED-N harness forces marvel
+to own a model-to-limit table, and that table goes wrong precisely when the
+harness switches models mid-session. gemini has a router that does exactly
+that, announced only by a separate `model_routing` event carrying
+`decision_model`. A denominator marvel infers from a model name is stale the
+moment the router moves.
+
+### "Must draw it, must serialize it" survives, with its mechanism corrected
+
+The claim was that a harness which must DRAW a context meter has to
+serialize both terms. Three independent harnesses delegate footer rendering
+to an external command, and all three serialize `context_window` with both
+terms, with field names converged on Claude Code's schema
+(`context_window.context_window_size`, `used_percentage` appear near-verbatim
+in all three). A scraper written once ports across them with field aliasing
+only.
+
+The negative case sharpens it. Cursor's TUI draws a context meter too and
+serialized nothing for months, because it draws IN-PROCESS. So the mechanism
+is **delegation, not display**. A harness that renders its own chrome is
+under no pressure to serialize anything.
+
+That prediction is falsifiable on the next harness, which is what makes it
+worth keeping. Crush is a Charm project and Charm builds TUIs in-process, so
+the framework predicts Crush delegates nothing and therefore serializes
+nothing to a callout.
+
+### Spawn-time pinning: marvel is entitled to assign identity, not discover it
+
+The binding problem (mapping a tmux pane marvel spawned to the file or
+session carrying its usage) was being treated as a discovery problem, priced
+at a 49 ms per-pid `lsof` probe that cannot even find the claude transcript.
+It is not a discovery problem on most of the roster. marvel constructs the
+process environment at spawn (enforcement locus 1, shipped), so anything
+settable there is free.
+
+| Runtime | Pin available at spawn | Measured |
+|---|---|---|
+| claude | `--session-id <uuid>`: marvel ASSIGNS the session id | yes, 2.1.226 help |
+| gemini | `GEMINI_TELEMETRY_TARGET=local` + `GEMINI_TELEMETRY_OUTFILE=<path>`: marvel names the usage file. `GEMINI_CLI_HOME` pins the config root, which pins where `tmp/<projectHash>/chats/` lands | docs |
+| aider | `--analytics-log <path>`: exact, explicit, per-invocation | docs |
+| codex | no id pin (`resume` takes an existing one). `OTEL_RESOURCE_ATTRIBUTES` honored, so stamp identity instead | binary strings |
+| Copilot CLI | not needed: `session_id` and `transcript_path` ride the statusLine payload marvel itself installs | docs |
+
+`OTEL_RESOURCE_ATTRIBUTES` is honored by both claude and codex, and claude
+promotes resource attributes to datapoint labels by default. So marvel can
+stamp its own pane identity into exported data at spawn on both. That is
+free, it makes any later OTEL work attributable, and it should be done
+whether or not OTEL is ever consumed.
+
+### OTEL: a dead end for pressure, possibly the cheapest actuator signal
+
+Measured across the installed binaries:
+
+- Every OTEL token instrument that exists is a monotonic **Counter** of
+  cumulative tokens. `or.tokenCounter=t("claude_code.token.usage",
+  {description:"Number of tokens used",unit:n("tokens")})` is verbatim from
+  the 2.1.226 binary. Folding an OTLP counter into occupancy reproduces
+  finding-007's defect exactly, and it grows with request count, so the
+  longest sessions read worst.
+- Only codex publishes the denominator, and it publishes it on a logs event
+  rather than a metric: `context_window` and `auto_compact_token_limit` sit
+  adjacent to `provider_name` and `reasoning_summary` in the codex 0.146.0
+  binary. `model_context_window`, `model_auto_compact_token_limit`, and
+  `effective_context_window_percent` are also present. codex computes the
+  number marvel wants and names it that.
+- Crush cannot export at all: it links the otel API plus `metric/noop` and
+  `trace/noop` transitively, and carries no SDK or OTLP exporter.
+- opencode bundles `@opentelemetry/api` and `sdk-trace` only, with no
+  exporter and no metrics SDK, so its `gen_ai.usage.*` strings are Vercel AI
+  SDK span attributes that stay inert until a plugin registers a provider.
+
+So OTEL is ruled out as the pressure foundation. But the metrics channel is
+not the only channel, and the ruling may not carry to the actuator:
+`claude_code.compaction` is a **span**, not a metric, carrying
+`attrs:{trigger: "auto"|"manual"}` (verbatim from the binary). gemini emits
+`gemini_cli.chat_compression` as both a counter and a log event with
+`tokens_before` and `tokens_after`. If the minimum viable shift signal is a
+compaction EVENT rather than an occupancy level, that event is cheaply
+available over tracing on at least two harnesses and needs no denominator.
+That question belongs to `bound-context-instead-of-measuring-it.md`.
+
+Two listener-free receive paths exist and are worth more than a collector:
+claude's Prometheus **pull** exporter (`OTEL_EXPORTER_PROMETHEUS_HOST`/`_PORT`,
+both present in the binary), where marvel allocates the port per agent and
+scrapes on its own cadence, and gemini's genuine file exporter. Both make
+attribution a function of a path or port marvel itself assigned, which is
+the same move as the session-id pin.
+
+### Two more local corpora, both verified on this machine
+
+The compaction-mining probe was written against 46 claude transcript files
+carrying labelled `compact_boundary` events (see that brief for why the
+count is stated as a method rather than a number). Two more corpora exist
+here:
+
+- **gemini**: 26 files under `~/.gemini/tmp/*/chats/`, **477 messages
+  carrying a per-turn token series** shaped
+  `{input, output, cached, thoughts, tool, total}` with the model name
+  alongside. Richer than the documented `AfterModel` hook payload, which
+  promises only `totalTokenCount`. The directory name is a 64-hex hash and
+  the file field is literally `projectHash`, so the path is derivable from
+  the workspace root.
+- **codex**: roughly 209 session files under `~/.codex/sessions/`.
+
+Three independent local corpora is enough that the measurement program's
+first phase should be mining rather than running sessions.
+
+### Roster additions worth a row
+
+- **GitHub Copilot CLI**, not previously on the list and the strongest find.
+  Its `statusLine` payload is FEED-2 and POINTER at once: `session_id`,
+  `transcript_path`, `model.{id,display_name}`, and a `context_window` object
+  carrying `current_context_tokens`, `context_window_size`,
+  `displayed_context_limit`, `used_percentage`, `last_call_input_tokens`, and
+  cumulative totals. Caveat to verify: it was behind a `STATUS_LINE` feature
+  flag as of 2026-05.
+- **Qwen Code**, a gemini-cli fork that added the statusline gemini lacks,
+  with `context_window.{context_window_size, used_percentage,
+  remaining_percentage, current_usage}`. Configured under `ui.statusLine`,
+  not at settings root, which is a documented footgun. Inheriting gemini's
+  hook and OTEL surfaces would make it the best-instrumented harness in the
+  catalog.
+- **goose**, whose sessions moved to a sqlite `sessions.db` at v1.10.0
+  storing token usage and working directory. A queryable database beats a
+  log tail. Denominator unverified.
+
+Dismissed on the spawnability test: roo-code and zed's agent are
+editor-hosted with no terminal CLI. Deferred pending one check each: cline,
+kilo, continue, amp (whose `--stream-json` usage field is the highest-value
+unverified claim in the round), cursor-agent (capable via stream-json since
+2026-02 but its hook and statusline story is unsettled).
+
+### Counterexample worth keeping: hook richness does not predict tier
+
+cursor-agent has a Claude-Code-compatible hook system with parallel
+execution and optimized latency, and its hooks still carry no token usage
+while its `stream-json` output gained usage in February. Richness of a hook
+system predicts nothing about whether the channel carries what you need. The
+search list is right to enumerate channels rather than rank harnesses.
+
+### Crush moves from candidate to measured, and leads on semantics
+
+Phase 1 called Crush a candidate via its server. Round 3 measured it end to
+end against v0.88.0 (build_id `dkd26so3zabk`, darwin/arm64), with source read
+at the matching tag. The channel is real, and the reason it matters is not
+the transport.
+
+**Crush computes context pressure natively and acts on it.** The same
+expression appears in two places: `internal/ui/model/header.go:149` renders
+`(CompletionTokens + PromptTokens) / model.ContextWindow * 100`, and
+`internal/agent/agent.go:1044` uses that identical numerator as the
+StopCondition for auto-summarize. The semantics marvel wants are the
+semantics Crush already ships and already actuates on. That is a stronger
+position than any harness where marvel reconstructs the ratio.
+
+Channel inventory, tiered per channel:
+
+| Channel | Tier | Carries |
+|---|---|---|
+| Server SSE session events | FEED-N | `prompt_tokens`, `completion_tokens`, `cost`, `message_count`, `summary_message_id`, pushed at every turn boundary |
+| Server REST `/v1/workspaces/{id}/agent` | denominator, one-shot | `model.context_window` (measured 40960 for qwen3:0.6b). Static per model, so fetch on model change, not per turn |
+| Local sqlite `sessions` table | FEED-N, poll only | identical numbers (read back 28639 / 414 matching the last SSE frame exactly) |
+| `PreToolUse` hook | CLOCK | `event`, `session_id`, `cwd`, `tool_name`, `tool_input`. No tokens |
+| Chrome callouts | ABSENT | nothing |
+| Headless output | none | `crush run` has no `--json` or `--output-format` |
+| OTEL | ABSENT for export | API plus noop only, 0 SDK symbols, 0 OTLP exporter |
+
+The denominator does NOT ride the SSE stream. It is a separate call on the
+same socket, which splits Crush's feed into FEED-N plus a one-shot lookup
+rather than a FEED-2.
+
+**Occupancy is a LEVEL, proven by measurement rather than by field name.**
+Three consecutive turns in one session: `prompt_tokens` 28593, 28611, 28639.
+Cumulative would have put turn 2 near 57186. Source corroborates
+(`agent.go:1942` assigns `session.PromptTokens = usage.InputTokens +
+usage.CacheReadTokens`, with `session.Cost += cost` on the line above as the
+deliberate contrast), but the series settles it independently.
+
+**The compaction edge is clean and observable.** After
+`POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize`, `prompt_tokens`
+went 28639 to 0 and `summary_message_id` became non-empty
+(`agent.go:1460` sets it to zero post-summary). Phase 1 had inferred this
+from "`prompt_tokens = 0` on sessions carrying a summary message"; it is now
+measured.
+
+**Nadia's delegation prediction was tested here and held.** Zero hits for
+statusline, status_line, or status-line across all Go and JSON files. No
+delegated footer, no external chrome command, therefore nothing serialized
+and no `context_window.*` field names to alias. The only `exec.Command` under
+`internal/ui` is the TUI's run-a-shell-command feature. Charm draws
+in-process exactly as predicted. The prediction survived an attempt to
+refute it, which is worth more than the confirmations.
+
+**The hook is the framework's other lesson, restated.** Crush has exactly one
+hook event, `PreToolUse`. No PreCompact, no Stop, no SessionEnd. It fires on
+tool use rather than turn boundary, which is the wrong edge for pressure, and
+a consumer holding its `session_id` would have to go hit the server API for
+numbers, at which point the hook has added nothing the SSE stream did not
+already give with better timing.
+
+**One trap to flag before anyone cites it.** `internal/agent/event.go`
+`eventTokensUsed` emits input, output, cache-read, cache-creation, total
+tokens, and cost. It looks exactly like the channel you want. It is PostHog
+analytics egress to `data.charm.land` (`internal/event/event.go`) and never
+touches the local SSE stream.
+
+Discovery is cheap: the default host is
+`unix://$TMPDIR/crush-<uid>.sock`, printed verbatim as the `-H/--host` default
+in `crush --help`, and clients auto-spawn a detached server when none is
+listening, so the socket exists whenever anyone runs crush at all. One server
+serves many workspaces, so a single socket sees every Crush agent on the
+host. Access control is socket file permissions; the SSE `client_id` need only
+parse as a UUID.
+
+Unestablished, and the first two are the ones that would change the read:
+
+- Measured only against the ollama provider. Source says `PromptTokens =
+  InputTokens + CacheReadTokens`, so prompt-cached Anthropic or Bedrock
+  traffic should still yield a correct level, unconfirmed.
+- `completion_tokens` level-versus-cumulative is not proven by measurement;
+  the 83/166/414 series is consistent with both. `prompt_tokens` is the
+  unambiguous term and dominates the numerator.
+- Workspace lifetime. A workspace vanished before use when no client held a
+  stream; the reap timeout was not characterized.
+
+### Observer perturbation, which the consent axis did not anticipate
+
+The consent idea file argued that a read-only sqlite connection is not
+passive (WAL readers write read-marks). Crush produces a sharper instance on
+the CONTRACTED side of the axis, where the argument was supposed not to
+apply: `AttachClient` bumps a stream count, `attached_clients` is exposed on
+the session, and `proto.go` carries a comment that observers use stream count
+to detect live subscribers. **A marvel observer registers as a real client,
+not a passive tap**, and an unobserved workspace got reaped during the probe.
+So keeping the reading alive may require holding a stream open, which changes
+the harness's own view of whether anyone is watching.
+
+That is not a consent problem. It is an observation-changes-the-system
+problem, and it lands on the contracted channel rather than the appropriated
+one, which means the consent axis does not predict it. Worth its own line in
+the arbitration design: a channel can be fully contracted and still not free.
+
+The round produced a second, smaller instance from the probe's own hygiene
+disclosure: starting a Crush server refreshed the shared global caches
+`~/.local/share/crush/providers.json` and `hyper.json`, and `--data-dir`
+scopes the project DB rather than the global config dir. Merely instantiating
+the contracted channel mutated host-global state outside the probe's
+sandbox.
+
+### The codex denominator is two terms, not one
+
+An earlier read in this brief treated `effective_context_window_percent` as
+codex computing the ratio marvel wants. That was an over-read. It is a field
+of `struct ModelInfo with 38 elem` (verbatim), sitting alongside
+`context_window`, `max_context_window`, `auto_compact_token_limit`, and
+`comp_hash`. Static model config: the fraction of the window codex will
+actually use.
+
+The correction sharpens the row rather than weakening it. **codex's real
+denominator is `context_window` times `effective_context_window_percent`.** A
+marvel reading that used the raw `context_window` runs optimistic by exactly
+that fraction, which is the silent-misreport failure `limits.go` exists to
+refuse. Both terms have to travel together or the rung is unsound.
+
+`session_meta` and `context_compaction` are both confirmed in codex's
+`rollout_item_type` enum, so the rollout has named record types for the two
+things this brief needs from it.
+
+### The actuator over OTEL, narrowed
+
+Round 4 re-ran the OTEL verdict against the tracing and logs channels rather
+than metrics. The actuator event exists on three of five harnesses; the
+listener-free half holds on exactly one.
+
+| Runtime | Actuator event over OTEL | Trigger attr | Tokens on it | Reachable without a listener |
+|---|---|---|---|---|
+| claude | `claude_code.compaction` span | `trigger: auto\|manual`, `message_count` | no | no |
+| codex | `codex.task.compact`, plus `codex.compaction.model_fallback` | fallback carries a four-value reason enum (`user_requested`, `context_limit`, `model_downshift`, `comp_hash_changed`) | yes, same span as the seven turn token levels | no |
+| gemini | `gemini_cli.chat_compression`, log event and metric | none documented | yes, `tokens_before` / `tokens_after` | **yes** |
+| opencode | plugin only | no | plugin counters | no |
+| Crush | none | no | no | n/a |
+
+Two things about the claude span before anything is built on it. It is gated
+behind `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`, which is beta and withdrawable.
+And the numbers you would want on a compaction do exist in-process
+(`preCompactTokenCount`, `postCompactTokenCount`, `truePostCompactTokenCount`,
+`autoCompactThreshold`, `willRetriggerNextTurn`) but they are arguments to
+the vendor's internal analytics sink, not to the OTEL span, which gets
+trigger and message_count and nothing else.
+
+Claude Code's only file-writing telemetry path is `OTEL_LOG_RAW_API_BODIES`,
+and it is not narrowable: three modes, no event filter, and it writes whole
+Messages API request and response bodies. A volume and privacy problem rather
+than a metrics path.
+
+**gemini's `outfile` is the one genuinely new capability OTEL offers.** It
+writes logs and metrics to a file, overrides the OTLP endpoint, and is
+recommended by the project's own docs for local use. A per-agent path
+assigned at spawn gives marvel the compaction event with both token counts,
+read the way the process-table sampler reads anything else: no listener, no
+receiver dependency, attribution by a path marvel itself chose. It is the
+only harness where OTEL gives marvel something it cannot get more cheaply
+elsewhere.
+
+One inference recorded and explicitly not recommended: at auto-compaction
+gemini's `tokens_before` is approximately the threshold fraction times the
+window, so a window is arithmetically recoverable. That would be a new rung
+below `table-alias`, and it would be wrong whenever the threshold moves,
+which is the silent-misreport mode `limits.go` refuses. Do not ship it.
+
+Net revision to the OTEL verdict: a narrow optimization with one new
+capability, not a foundation. If the shift signal is an actuator event, build
+it on the structured stream for claude and codex, and treat gemini's
+`outfile` as the cheap way to bring a harness marvel cannot stream into the
+same actuator vocabulary. The resource-attribute stamping at spawn stays
+worth doing regardless, because it costs nothing and makes any of this
+attributable later.
+
+### opencode: five channels, and the specimen that justifies the additive rule
+
+Measured against opencode 1.18.14 with plugin SDK `@opencode-ai/plugin@1.18.5`.
+Five real channels, tiered separately.
+
+| Channel | Occupancy | Window | Live | Notes |
+|---|---|---|---|---|
+| Plugin API | yes | yes | in-process | `chat.params` gives `input.model.limit.context`; `event` on `message.updated` gives `properties.info.tokens` |
+| HTTP SSE `/event` | yes | no | out-of-process | same AssistantMessage payload the plugin hook receives |
+| HTTP REST | yes | yes | polled | `GET /config/providers` for the window, `GET /session/{id}/message` for tokens |
+| sqlite direct | yes | **no** | poll | the window is not in the file at all |
+| `opencode db` | yes | no | poll | identical data at roughly 800x the latency (0.81s vs 0.00s); it boots a 140MB binary |
+
+`GET /session/status` carries no tokens. It is `{}` when idle, else a map of
+session id to `idle|busy|retry`. If anything in phase 1 hoped that was the
+pressure endpoint, it is not.
+
+**The specimen.** Three turns in one session, captured through the plugin
+event hook:
+
+```
+turn1  total=30177  in=28241  out=2  reasoning=14  cache.read=1920
+turn2  total=30189  in=20203  out=2  reasoning=0   cache.read=9984
+turn3  total=30199  in=117    out=2  reasoning=0   cache.read=30080
+```
+
+`total` is a LEVEL: cumulative would have been 30177 / 60366 / 90565.
+Confirmed again on a real six-turn production session in the store (37059,
+37229, 41882, 42473, 44022, 46092).
+
+But the level result is not the important half. Across those three turns
+`input` collapses from 28241 to 117, a 99.6 percent drop, while `cache.read`
+climbs from 1920 to 30080. The sum stays near-constant at 30161 / 30187 /
+30197. **A consumer polling `input` alone would report the context emptying
+out while it was in fact filling.** That is the most vivid empirical support
+the additive rule has: occupancy is `input + cache.read + cache.write`, never
+`input` alone, and the failure mode of getting it wrong is not a small
+underestimate but an inverted trend line. It belongs in the evidence lineage
+behind `internal/usage/doc.go` when this is harvested.
+
+**opencode carries both representations, which is the trap.** Per-message
+`tokens` are levels. The `session` table columns are cumulative sums: for one
+session `tokens_input = 44634` is exactly the sum of that session's
+per-message inputs, and `tokens_cache_read = 202240` is exactly the sum of
+its per-message cache reads. Both measured. Reading a session column as
+occupancy overstates pressure without bound as the session runs. That is
+finding-007's defect available through a new door, in the same file as the
+correct numbers, one join away. It is the concrete case the consent idea file
+anticipated when it asked for a refusal at ingest for session-cumulative
+samples.
+
+Corrections to phase 1, both mine:
+
+- "Token classes live in a `data TEXT` JSON blob" is right for `message` and
+  incomplete. The `session` table has typed first-class columns
+  (`tokens_input`, `tokens_output`, `tokens_reasoning`, `tokens_cache_read`,
+  `tokens_cache_write`, `cost`, plus `model` and `agent`). No JSON extraction
+  at session grain, which is exactly why the cumulative trap is easy to fall
+  into: the typed columns look more trustworthy than the blob.
+- The arithmetic identity holds: 219 assistant rows, 211 satisfy
+  `total == input + output + reasoning + cache.read + cache.write`, **zero
+  violations**, and 8 carry no `total` key at all (all-zero aborted turns).
+  So the fingerprint-the-data proposal is viable here. One caveat: `total` is
+  present in the persisted JSON but ABSENT from the SDK's declared
+  `AssistantMessage.tokens` type, so the type cannot be trusted alone and a
+  missing `total` must be handled.
+
+**The docs are stale in our favor.** opencode's documentation states there is
+no chat-params hook and no token hook. Both exist. The installed
+`index.d.ts` is authoritative and lists `chat.params`, `chat.headers`,
+`chat.message`, `permission.ask`, `tool.execute.before`/`after`,
+`experimental.session.compacting`, and `experimental.compaction.autocontinue`.
+Anything in this catalog sourced from opencode docs rather than from the
+installed types should be re-checked.
+
+Two plugin traps worth carrying into any implementation:
+
+- **Awaiting any `client.*` call during plugin init deadlocks instance
+  bootstrap silently.** A probe plugin that called `client.config.providers()`
+  at init hung the instance after config load: it served nothing and logged
+  nothing at DEBUG. Removing the plugin restored HTTP 200. Defer all client
+  calls into hooks.
+- **`message.updated` fires three times per assistant message**, the first
+  with `total` absent and all token classes zero. Take the last per message
+  id, or a naive consumer reads zero occupancy at every turn boundary.
+
+Also measured: both `.opencode/plugin/` and `.opencode/plugins/` load, though
+the docs name only the plural. And ollama models report `limit.context: 0`
+(all three on this host), so any provider without catalogue metadata yields a
+zero denominator. That is a live concern for roadmap M6 local model runtimes,
+where the ladder would have to fall through to marvel's own table.
+
+**OTEL is dead on opencode for a second, sharper reason.** Amelia's missing
+exporter is confirmed independently (zero hits for exporter-trace-otlp,
+exporter-metrics, or sdk-metrics; `NodeTracerProvider` and
+`BatchSpanProcessor` present). Two refinements kill the path rather than
+narrow it. First, `experimental_telemetry` gates emission per call in the
+Vercel AI SDK, so a plugin registering a provider is not sufficient; the
+spans are not produced at all, and no config surface exposes the toggle.
+Second, and decisively: the standard `gen_ai.usage.*` attributes in this
+bundle are exactly `input_tokens` and `output_tokens`. No cache, no
+reasoning. Applied to turn 3 above, a gen_ai-based reading would have
+reported 117 against a true occupancy of 30199. The richer `ai.usage.*`
+namespace is present (`cachedInputTokens`, `reasoningTokens`,
+`inputTokenDetails`) but under AI-SDK-proprietary names rather than the
+standard ones. So the semantic convention that makes OTEL portable is
+precisely the thing that would make it wrong here.
+
+Hazards, both structural rather than incidental:
+
+- `credential`, `account`, and `control_account` live in the same file as the
+  telemetry. Row counts are zero on this host, so credentials live elsewhere
+  here, but the access surface stands: anything granted read on
+  `opencode.db` for token counts is one query from the credential table.
+  Give a collector a copy or a view, never the file. This is the categorical
+  argument from the consent idea file, now with a row-count check attached.
+- `opencode serve` prints `OPENCODE_SERVER_PASSWORD is not set; server is
+  unsecured`. Unauthenticated localhost HTTP that can list sessions, read
+  transcripts, and submit prompts.
+
+Pinning: the `migration` table has 38 rows with timestamped ids (latest
+`20260602002951_lowly_union_jack`); `PRAGMA user_version` is 0 and useless.
+`session.version` records the writing opencode version per row (198 rows at
+1.18.11, 9 at 1.18.5, 2 at 1.18.10), so **a store is legitimately
+mixed-version** and the assertion has to be per row, not per file.
+
+Ranking: plugin API first (both halves, live, in-process, no open port, no
+credential-file exposure; costs an in-process extension per harness plus
+deferred-init discipline), HTTP SSE plus REST second (both halves, and the
+only cross-host option; costs an unauthenticated port and two calls), sqlite
+third (fast and dependency-free but numerator only), `opencode db` fourth
+(ad-hoc only), OTEL not viable.
+
+### codex: the occupancy formula is per-harness, not shared
+
+Measured against codex-cli 0.146.0 over the 209-file local corpus, plus four
+live probes under an isolated `CODEX_HOME`. This section corrects two of my
+own claims above, one of which corrects a correction.
+
+**The denominator correction was right about the field and wrong about the
+direction. marvel must NOT multiply.**
+
+`~/.codex/models_cache.json` carries `context_window = 272000` and
+`effective_context_window_percent = 95` for all eight catalog models.
+272000 x 0.95 = 258400, and **258400 is exactly the value the rollout emits
+as `.payload.info.model_context_window`, in 206 of 209 files, with no other
+value corpus-wide.** The rollout's number is already the effective,
+pre-multiplied denominator.
+
+So the earlier instruction in this brief was backwards. Reading the raw
+catalog number would run optimistic, which is where the concern came from,
+but marvel is not reading the catalog. A marvel that multiplies again lands
+on 245,480, runs 5 percent PESSIMISTIC, and fires shifts early.
+
+Adapter rule: read `model_context_window` from the same `token_count` record
+as the level. Never read `models_cache.json`. Never apply
+`effective_context_window_percent` yourself. Two supporting facts:
+`effective_context_window_percent`, `context_window`, `max_context_window`,
+and `auto_compact_token_limit` appear in no codex-emitted rollout record (the
+only corpus hits sit inside a `function_call_output`, where a tool the
+operator ran printed model config); and `max_context_window` diverges from
+`context_window` for at least one model (gpt-5.4 at 1000000 vs 272000), which
+is a second reason the catalog is the wrong source.
+
+Also: `session_meta.payload.context_window` is a one-key object
+`{"window_id": "..."}`. It is compaction-generation identity, not a size.
+
+**`context_compaction` is in a telemetry enum, not the on-disk discriminant.**
+An earlier line here said `session_meta` and `context_compaction` are both in
+the `rollout_item_type` enum. That conflated two adjacent enums in the same
+string region. The on-disk `type` variants are `session_meta`,
+`response_item`, `inter_agent_communication`,
+`inter_agent_communication_metadata`, `compacted`, `turn_context`,
+`world_state`, `event_msg`. Corpus census over all 209 files: 7336
+`response_item`, 4237 `event_msg`, 385 `turn_context`, 246 `world_state`, 209
+`session_meta`, 16 `compacted`. `context_compaction` never appears as a
+`.type` value. SP5 should search for `compacted` (top-level) and
+`context_compacted` (an `event_msg` payload type, 16 occurrences, exactly
+matching).
+
+**Level versus sum, settled over 2098 records rather than three turns.** Both
+shapes live in the same record and only one is usable:
+`.payload.info.last_token_usage` is a per-request LEVEL;
+`.payload.info.total_token_usage` is a CUMULATIVE SUM that reached 2,653,437
+against a 258,400 window in one session and 51.9M in another. The level
+series from one file runs 16415, 17971, 24981, 25431 ... 89467, 94749 against
+the sum's 16415, 34386, 59367, 84798 ... 2642802 over the same records.
+`state_5.sqlite` `threads.tokens_used` is also the cumulative total and is
+not an occupancy source.
+
+#### The result that changes the architecture
+
+**codex's `input_tokens` already includes `cached_input_tokens`. Claude
+Code's does not.**
+
+Verified two ways across all 209 files: `total_tokens == input_tokens +
+output_tokens` holds for every non-zero record with zero violations, so
+cached is not a term in that sum; and `cached_input_tokens > input_tokens`
+never occurs, so it is a subset.
+
+Correct codex occupancy is `last_token_usage.input_tokens` ALONE. Applying
+marvel's `input + cache_read + cache_creation` to codex nearly doubles it
+(in=17971 with cached=16128 would report 34,099 instead of 17,971) and at the
+top of a window reports over 100 percent pressure.
+
+This is the sharpest cross-harness result of the sweep, and it is
+uncomfortable, because the two harnesses disagree in opposite directions from
+the same field name. opencode's specimen showed that summing `input` alone
+UNDER-reports by 99.6 percent at the extreme; codex's shows that adding cache
+OVER-reports by nearly 2x. **The occupancy formula therefore belongs in the
+adapter, not in `internal/usage`.** Shipping the shared additive rule against
+codex is a guaranteed defect of exactly the class marvel already shipped once.
+This belongs in a ticket body, not a code comment.
+
+#### Binding: no id pin, but a container pin that is better
+
+Plainly, as a measured negative: codex 0.146.0 has no equivalent of
+`claude --session-id`. `CODEX_THREAD_ID` was tested twice, once malformed and
+once with a valid UUIDv7, and codex minted a fresh id both times. In the
+binary it sits inside an environment allowlist next to SHELL, TMP, LC_ALL,
+LOGNAME, and the `*KEY*` / `*TOKEN*` patterns, so it is a variable codex SETS
+for children rather than one it reads. No `--session-id` flag, no
+`session_dir`, `rollout_dir`, or `force_session_id` config key.
+
+What exists is better for marvel's purpose, and both are measured live:
+
+- **`CODEX_HOME` relocates the entire state tree** (`sessions/`,
+  `state_5.sqlite`, `logs_2.sqlite`, `history.jsonl`, `shell_snapshots/`).
+  Set it per spawned pane and that pane's rollouts are the only files in that
+  directory: no cwd matching, no sqlite join, no ambiguity when two agents
+  share a cwd. Auth carries by symlinking `auth.json`.
+- **The `SessionStart` hook pushes the binding at spawn**, Claude-Code-
+  compatible shape, carrying `session_id`, an ABSOLUTE `transcript_path`,
+  `cwd`, `model`, `permission_mode`, and a `source` enum of
+  `startup|resume|clear|compact`.
+
+So marvel does not assign identity here; it assigns the CONTAINER and codex
+reports the identity into it. Functionally equivalent for binding, and
+strictly weaker only if a stable id across restarts were needed.
+
+Two operational caveats, both measured. Hooks need persisted trust or
+`--dangerously-bypass-hook-trust` per invocation, so pre-seeding trust is on
+the critical path and marvel cannot ship a design requiring the flag. And
+`CODEX_*` variables are NOT propagated to hook subprocesses (a hook running
+`env | grep ^CODEX_` produced an empty file), so agent identity has to ride
+the hook command line.
+
+Full hook set: PreToolUse, PermissionRequest, PostToolUse, PreCompact,
+PostCompact, SessionStart, SessionEnd, UserPromptSubmit, SubagentStart,
+SubagentStop, Stop.
+
+#### Compaction, and a live defect vector
+
+Phase 1's "three in one session" is corrected: 16 compactions across 6 files,
+largest single session 2. The signature, in order:
+
+```
+token_count  input=241665 win=258400          last pre-compaction sample
+{"type":"compacted", payload:{message, replacement_history,
+   window_number, first_window_id, previous_window_id, window_id}}
+token_count  input=0 cached=0 output=0 total=13221   ALL-ZERO SENTINEL
+{"type":"event_msg","payload":{"type":"context_compacted"}}   bare
+token_count  input=18389 win=258400           first post-compaction sample
+```
+
+No before/after counts, unlike Claude Code's `compactMetadata`; they bracket
+exactly from the series instead. Observed triggers at 93.5 percent and 86
+percent of window.
+
+**The all-zero sentinel is a live defect vector.** A naive "read the newest
+token_count" reports occupancy 0 against a valid 258400 denominator at
+exactly the moment the session is most stressed. Discard records where
+`input_tokens == 0 && total_tokens > 0`, and discard `info == null` (measured
+once, at the first token_count of a session).
+
+On the compaction reason enum: the rollout does not carry one. The four
+values (`user_requested`, `context_limit`, `model_downshift`,
+`comp_hash_changed`) are OTEL-side only. What the rollout-adjacent surface
+gives instead is PreCompact and PostCompact hooks carrying
+`trigger: manual|auto` plus session_id, transcript_path, model, and turn_id.
+Coarser than the enum, but a live push signal WITH CAUSE, which no other
+harness offers and which no file-tailing design can produce.
+
+Generation tracking is free: `previous_window_id` of generation N equals
+`window_id` of N-1, `first_window_id` equals the session id, seeded by
+`session_meta.payload.context_window.window_id`.
+
+#### Tail discipline: one correction and one new risk
+
+Append-only NDJSON confirmed; all 209 files end `0x0a`, line count equals
+record count exactly on the two largest, and live growth across a running
+session (41937, 46897, 52999, 57429, 64080, 65810 bytes at 5s intervals) was
+monotonic with every one of 12 samples ending on a newline. So `(dev, ino)`
+tracking is sound.
+
+**But the fixed 64 KB window proposed earlier in this brief is not safe.**
+The largest single record corpus-wide is 1,776,483 bytes, and the largest
+byte gap between consecutive `token_count` records is 1,792,874. A window can
+land entirely inside one tool-output record and yield zero complete records.
+At rest it is benign (max distance from EOF back to the last token_count is
+9,107 bytes, roughly 7x headroom), but mid-turn a large tool output pushes
+the sample out of range. Start at 64 KB, grow on miss (256 KB, 1 MB, 4 MB,
+capped), and HOLD the previous reading on a miss rather than emitting zero.
+Occupancy is monotone within a generation, so stale is safe and missing is
+not the same as low.
+
+**New risk, unestablished and worth a ticket.** The binary carries a metric
+family `codex.rollout_compression.{run, materialize, temp_cleanup,
+file.source_bytes, file.compressed_bytes, file.compression_ratio,
+file.duration_ms}` plus `jsonl.zst` and the string "compressed rollout reader
+is busy". Rollout compression is a background JOB, not archive-on-demand. No
+`.zst` files exist on this host so it could not be tested, but a tailer must
+handle its file being replaced by a `.zst` sibling.
+
+#### Pinning
+
+No `schema_version` field anywhere in the rollout. `session_meta.payload
+.cli_version` is the entire pin. Corpus spread: 0.146.0 (203), 0.145.0 (5),
+0.42.0 (1).
+
+#### Verdict, and two conditions on it
+
+codex should lead, by a wider margin than phase 1 concluded, but not for the
+reason phase 1 gave. The rollout file is good; what makes codex lead is that
+it is the only harness offering a PUSH binding (SessionStart with an absolute
+path at spawn) over a HARD isolation primitive (`CODEX_HOME`), which
+dissolves the binding problem instead of working around it. PreCompact and
+PostCompact with trigger attribution is a second capability no file-tailing
+design reproduces.
+
+Two conditions, both of which are the difference between leading and
+shipping a defect:
+
+1. **The occupancy formula must be per-adapter before the codex adapter
+   merges.** Input includes cache on codex and excludes it on Claude Code.
+2. **Sentinel-discard and grow-on-miss land in the first commit**, not as
+   hardening. Both failure modes report LOW pressure at HIGH pressure, which
+   is the direction that silently disables shift rotation.
+
+As a mining corpus for SP5, codex is adequate to cross-validate a threshold
+model against Claude Code's larger set, and not adequate as a primary: 16
+events across 6 files, with before/after derived by bracketing rather than
+read from metadata.
+
+Carried forward as unestablished: `CODEX_ROLLOUT_TRACE_ROOT` and
+`CODEX_SQLITE_HOME` behavior; whether zstd compression can fire under a live
+consumer; whether hook trust can be pre-seeded without the dangerous flag
+(critical path); whether `SessionStart source:"compact"` ever opens a NEW
+rollout file, which would defeat `(dev, ino)` tracking and leave PostCompact
+as the only recovery; and denominator behavior if two models ever differ in
+effective window, which is untestable here because all eight local models are
+identical at 272000 and 95 percent.
+
+## The sweep's own best result: marvel already had the hard part right
+
+The strongest cross-harness result above is that the two harnesses disagree
+about the same field name in opposite directions. opencode's `input` alone
+under-reports occupancy by 99.6 percent at the extreme; codex's `input`
+already contains its cache term, so adding cache over-reports by nearly 2x.
+The natural conclusion, and the one the codex report drew, is that the
+occupancy formula has to move out of `internal/usage` and into the adapters.
+
+That conclusion is wrong, and checking it is the most valuable thing this
+round did. **marvel already ships the correct design**, and the sweep's
+independent measurements confirm it rather than correcting it.
+
+`internal/runtime/events/events.go:99-110` defines a `Layout` per harness,
+declared BY THE PARSER and carried on the payload:
+
+```go
+// LayoutAdditive means occupancy is In + CacheReadIn + CacheCreationIn.
+// Claude Code. Measured: In alone understated real context roughly
+// 3000x on a warm session (finding-007 recorded In 10 against 29903).
+LayoutAdditive Layout = "additive"
+// LayoutSubsumptive means occupancy is In alone. Codex, whose
+// input_tokens already contains cached_input_tokens (measured 13992
+// with 11008 cached), so summing double-counts.
+LayoutSubsumptive Layout = "subsumptive"
+```
+
+`codex/parser.go:179` sets subsumptive; `claudecode/parser.go:280` and
+`opencode/parser.go:197` set additive. `Occupancy()` in both `sample.go:63`
+and `events.go:162` branches on it. The comment at events.go:94-98 states the
+reason the discriminant rides the payload rather than a consumer-side table:
+the parser knows its own harness, so a declared Layout cannot drift out of
+sync with the fields beside it, and an unknown harness cannot be silently
+mis-summed.
+
+So the codex condition "the occupancy formula must be per-adapter before the
+codex adapter merges" is already satisfied, and was satisfied on the strength
+of a two-number observation (13992 with 11008 cached). What the sweep adds is
+scale: the same conclusion now rests on `total == input + output` holding
+across every non-zero record in 209 files with zero violations, and on
+`cached_input_tokens > input_tokens` never occurring. A reasoned design
+decision has become a measured one.
+
+**One live check fired for the first time.** `AdditiveConfirmed()`
+(`events.go:198`) is a deliberately one-sided test: `Layout == LayoutAdditive
+&& CacheReadIn > 0 && In < CacheReadIn`, true only when `In` is smaller than
+the count served from cache, which is impossible if `In` already contained
+it. Its comment says it "needs a caching turn to fire" and calls itself "the
+only signal marvel has for OpenCode's unverified cache layout." opencode's
+turn 3 above is that turn: In 117 against CacheReadIn 30080. The check fires,
+and opencode's additive declaration moves from assumption to measurement.
+
+**And one thing it did NOT confirm.** The same parser sets
+`TotalExcludesCache: true`, and 211 of 219 live rows satisfy
+`total == input + output + reasoning + cache.read + cache.write` with zero
+violations, so opencode's total is defined over five classes rather than
+three. With the flag set, `TotalMismatch()` reports a phantom mismatch equal
+to `CacheReadIn` on every caching turn, which is precisely the failure the
+flag was added to prevent. Filed as `ArcavenAE/marvel#145`; the round-3
+evidence is in a comment there rather than duplicated here.
+
+The pattern worth carrying out of this: **check the codebase before accepting
+an architectural recommendation derived from measurement.** Two of the four
+runtime reports proposed a change marvel had already made, and the value was
+not in the change but in the evidence. The same move is what turned the
+compaction-mining brief from "we should measure this someday" into "the
+measurement is on disk," and what turned the accountant's hysteresis from a
+reasoned constant into a testable one.


### PR DESCRIPTION
Marvel can read context pressure from Claude Code today and from nothing else, which is why `aae-orc-hpeu` (automatic shift triggers) has been sitting behind `aae-orc-dc1j`. This branch is the desk-research phase of unblocking that: a per-channel catalog of every way to get occupancy and a context window out of claude, codex, opencode, Crush, and gemini, plus the two design arguments the review produced and one probe brief that turned out to be cheap.

**Nothing here is a finding.** No probe has been run to its own success signals. These are briefs, candidate channels, and measurements taken against local artifacts. Three of the four runtime sections correct claims the graph previously carried, including several of mine.

## What is worth reading if you read one thing

The two harnesses tested for it disagree about the same field name in opposite directions. opencode's `input` collapsed 28241 to 117 across three consecutive turns while `cache.read` climbed 1920 to 30080 and the sum held near 30190, so a consumer reading `input` alone would report the context emptying out while it was filling. codex's `input` already contains its cache term, so adding cache there nearly doubles occupancy and reports over 100% pressure at the top of a window.

The obvious conclusion is that the occupancy formula has to move into the adapters. It is wrong: marvel already ships `Layout` on the parser payload, codex already declares `subsumptive`, and `Occupancy()` already branches on it. What the sweep adds is scale, turning a two-number observation into `total == input + output` holding across every non-zero record in 209 files with zero violations. And `AdditiveConfirmed()`, which its own comment says "needs a caching turn to fire," fired for the first time on real data, resolving opencode's layout from assumption to measurement.

The one thing that did not confirm is `TotalExcludesCache` on the opencode parser. Evidence added to #145 rather than duplicated here.

## The rest, briefly

- **Tier is a property of the channel, not the harness.** gemini's `PreCompress` hook is a CLOCK at the exact instant you most want a FEED, while that same event's numbers ride its OTEL path. A runtime's row is a list.
- **marvel is entitled to assign identity, not discover it.** `claude --session-id`, codex's `CODEX_HOME` plus a `SessionStart` hook pushing an absolute rollout path at spawn, gemini's named telemetry outfile. The binding problem was being priced at a 49ms per-pid `lsof` probe that cannot find the claude transcript at all.
- **OTEL is a dead end for pressure** (every token instrument that exists is a cumulative counter) and possibly the cheapest actuator signal (`claude_code.compaction` is a span carrying `trigger: auto|manual`).
- **Crush leads on semantics**: it computes the pressure ratio itself in two places with the same expression and actuates auto-summarize on it.
- **`_kos/probes/probe-compaction-ground-truth-mining.md`** exists because finding-007's top unrun follow-up turns out to be minable from artifacts already on disk. Its counts moved three times in one hour, so it states its counting method and tells the probe to re-count rather than inherit a number.
- **Two idea files**: consent as a gate rather than a fidelity rung (with a third axis Crush exposed, since attaching to a fully contracted stream registers marvel as a real client), and bounding context by construction instead of measuring it.

Additive only. No code changes, no behavior changes; `_kos/` documents plus one comment on an existing issue.

Refs: aae-orc-dc1j, aae-orc-6c2r, aae-orc-hpeu