### PR TITLE
finding(marvel): the predictive denominator, and what context pressure actually is

### DIFF
--- a/_kos/findings/finding-016-effective-autocompact-window-is-the-predictive-denominator.md
+++ b/_kos/findings/finding-016-effective-autocompact-window-is-the-predictive-denominator.md
@@ -1,0 +1,310 @@
+# finding-016: the denominator that predicts compaction is the effective auto-compact window, not the context window
+
+**Date:** 2026-08-08
+**Probe:** `_kos/probes/probe-compaction-ground-truth-mining.md` (SP2, SP3,
+and the three pre-registered falsifiers)
+**Medium:** mining local artifacts. Zero model calls.
+**Question:** `question-interactive-context-pressure`; bears on
+`question-shift-triggers`.
+**Status:** measured, with one retracted intermediate claim recorded below
+because the way it was wrong is the finding's main lesson.
+
+## Retracted intermediate claim, and why it is instructive
+
+The first draft of this finding reported that Claude Code auto-compacts at "a
+hard absolute constant near 467k, not a fraction of anything," on the strength
+of 63 events clustering inside 3,509 tokens.
+
+**That was wrong, and it was wrong in the most ordinary way available: I
+measured a realized value without checking whether a SETTING explained it.**
+
+```
+~/.claude/settings.json        "autoCompactWindow": 500000
+measured p50 fire point                            467,635
+                               500,000 - 467,635 =  32,365
+```
+
+The binary also carries `CLAUDE_CODE_AUTO_COMPACT_WINDOW`,
+`AUTOCOMPACT_PCT_OVERRIDE`, `autoCompactThreshold`, `autoCompactEnabled`, and
+`DISABLE_AUTO_COMPACT`. The behavior is configured, not innate, and the
+~32k gap is inside the 33-45k buffer `internal/usage/doc.go` already reasons
+about. **The doc's model was right in shape. I mistook a configured value for
+a law and briefly concluded the doc was wrong.**
+
+The general rule this earns: **a measured threshold is uninterpretable
+without the settings that govern it.** Raw range is not enough. Every harness
+has its own settings surface, and a fleet controller must read the setting
+and the realized value together or it will confidently describe one machine's
+configuration as the harness's nature.
+
+## The actual result
+
+Against the EFFECTIVE window (the operator-set `autoCompactWindow`), not the
+model's context window:
+
+```
+n = 63 auto-compactions, effective window 500,000
+
+fire point p50            467,635   =  93.5% of the effective window
+headroom at fire  p0 -12,487  p50 32,365  p100 33,932
+IQR of fire point          1,609   =   0.3% spread
+events exceeding the setting: 1 (512,487)
+```
+
+The same 63 events read as **46.8% of a 1M context window**. That is the
+finding in one line: **CTX% computed against the context window is roughly
+half the number that predicts compaction.**
+
+And the effective-window figure converges with the only other harness
+measured for it. codex was independently observed firing at 93.5% and 86% of
+its window (which it publishes already effective, per the sweep). Two
+harnesses, different vendors, both compacting at about 93.5% of whatever
+window is actually in force.
+
+## What this means for the shift trigger
+
+A trigger armed at "90% of the resolved window" behaves completely differently
+depending on which denominator marvel resolved, and marvel currently resolves
+the model's context window:
+
+- Against the effective window (500k): fires at 450k, about 17k before the
+  harness would. Correct and useful.
+- Against a 1M context window: fires at 900k, which the session never reaches
+  because the harness compacts at 467k. **The trigger never fires**, and it
+  looks correctly configured while being unreachable.
+
+So the earlier conclusion survives with a corrected cause. It is not that a
+percentage trigger is unreachable in principle. It is that **it is unreachable
+whenever the denominator marvel divides by is not the denominator the harness
+acts on**, which is the current state for any session whose context window
+exceeds its auto-compact window.
+
+This makes "what is the reported percentage a percentage OF" a required field
+rather than a nicety. `LimitSource` grades where the denominator came from; it
+does not record which QUANTITY it is. A window and an auto-compact threshold
+are both plausible denominators and they differ by 2x here.
+
+## Assign and verify are one loop, not two options
+
+An earlier framing in this arc offered a choice: refuse a derived threshold
+and LEARN the realized one, versus ASSIGN the threshold at spawn since marvel
+constructs the process environment. Both halves were argued as alternatives.
+
+**That framing is wrong. Assignment without measurement is open-loop.** marvel
+cannot know that an assignment took effect, that it is still in effect, or
+that the harness honored it, except by observing the realized fire point.
+`AUTOCOMPACT_PCT_OVERRIDE` existing does not mean it is honored by the build
+in the pane, and a setting written to a config file can be overridden by an
+env var, a project-scope file, or a version that renamed the key.
+
+The correct shape is one control loop:
+
+1. **Assign** at spawn (`CLAUDE_CODE_AUTO_COMPACT_WINDOW`, or the harness's
+   equivalent), because enforcement locus 1 is shipped and this is free.
+2. **Record** what was assigned, as the expected value.
+3. **Observe** the realized fire point from the compaction marker.
+4. **Compare.** A realized point that does not match the assignment means the
+   assignment did not take, and that is a loud, attributable failure of
+   exactly the kind the sweep's "loud-absent versus silent-wrong" ruling wants.
+5. **Correct or refuse.**
+
+Step 4 is the only thing that makes step 1 trustworthy, and no amount of
+assignment removes the need for it. One event in this corpus exceeded the
+configured window (512,487 against a 500,000 setting), which is precisely the
+kind of discrepancy step 4 exists to surface and which pure assignment would
+never have shown.
+
+## Model change invalidates the whole reading, and it is not rare
+
+Every number here is per-model. A model change moves the context window, may
+move the effective auto-compact window, moves the price ratio that the
+early-versus-late cost calculation depends on, and moves the rate limits
+below. Treating model identity as stable for the life of a session is
+unsafe, and the ways it changes are ordinary rather than exotic:
+
+- **Vendor-initiated downgrade.** A provider may move a session to a
+  different model in response to a safety or abuse signal. The session
+  continues; the denominator does not.
+- **Quota-driven downgrade.** Providers prompt or auto-switch toward smaller
+  models as an allowance depletes. codex's own OTEL surface carries
+  `codex.compaction.model_fallback` with a `model_downshift` reason, so the
+  harness itself treats this as a routine event worth instrumenting.
+- **Router-initiated switch.** gemini routes between models mid-session and
+  announces it only on a separate `model_routing` event.
+- **Injection between agents.** One agent's output becomes another's input,
+  and a supervisor or peer may act on content in that output as though it
+  were instruction, including instructions that change a model. This is a
+  defect rather than a feature, and it will happen anyway; a fleet controller
+  should not assume the model it launched is the model running.
+
+Consequence: **the model is part of the reading's identity, not context for
+it.** An occupancy sample, a denominator, and a learned threshold are only
+comparable to others carrying the same model. A learned threshold must be
+keyed by (harness, model, effective-window setting) and invalidated on any
+change, and a model change observed mid-session should invalidate the learned
+value rather than averaging across the discontinuity.
+
+## The denominator is a function of six independent inputs, none of them ours
+
+Model change is one axis. It is not the only one, and the full set is what
+decides the design. The effective window and the point that predicts
+compaction both vary with:
+
+1. **Harness release.** Constants, defaults, and setting names move between
+   versions. This corpus spans one version.
+2. **User settings.** `autoCompactWindow` here, plus
+   `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `AUTOCOMPACT_PCT_OVERRIDE`,
+   `autoCompactEnabled`, `DISABLE_AUTO_COMPACT`. Settable per user, per
+   project, and per environment, with a precedence order marvel does not own.
+3. **Model.** Different windows, prices, and rate limits, changing by the
+   routine mechanisms listed above.
+4. **Backend service.** Measured in the 2.1.226 binary:
+   `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`,
+   `CLAUDE_CODE_USE_FOUNDRY`, `CLAUDE_CODE_USE_MANTLE`,
+   `CLAUDE_CODE_USE_GATEWAY`, `CLAUDE_CODE_USE_ANTHROPIC_AWS`,
+   `CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD`, plus `ANTHROPIC_BASE_URL` for an
+   arbitrary proxy and `ANTHROPIC_BEDROCK_SERVICE_TIER`. The same model id
+   through a different provider can carry a different window, different rate
+   limits, and different quota behavior.
+5. **Entitlement.** `context-1m-2025-08-07` is a BETA HEADER, so the 1M window
+   is gated rather than intrinsic. The same model id is a 200k model or a 1M
+   model depending on whether the beta is enabled for that account on that
+   backend.
+6. **Which model slot.** One session runs up to three: `ANTHROPIC_MODEL`,
+   `ANTHROPIC_SMALL_FAST_MODEL`, and `CLAUDE_CODE_SUBAGENT_MODEL`. A session
+   is not one model, so "the session's window" is already an approximation
+   before any of the above moves.
+
+**This is the argument that settles the design, and it settles it against
+tables.** A model-to-window table is a snapshot of a six-dimensional space in
+which every axis is mutable by a party other than marvel: the vendor ships a
+release, the operator edits a setting, the provider downgrades a model, the
+account gains or loses a beta. A table cannot be wrong loudly. It returns a
+plausible number for a cell whose value changed, which is the silent-wrong
+failure the sweep ruled is the one to avoid.
+
+So the ladder inverts in emphasis. An in-band declaration from the harness
+outranks any table because it is the only source that reflects all six inputs
+at once. A learned value outranks a table for the same reason. **The table is
+the rung of last resort, and its correct behavior when it misses is `?`, not
+a guess.** That is roughly what `limits.go` already grades for; what this
+finding adds is that the table's miss rate is structural rather than a matter
+of keeping it current, so effort spent extending the table buys less than
+effort spent on in-band capture and learning.
+
+It also means the learned key from the previous section is bigger than stated
+there. A learned threshold is keyed by (harness, harness version, backend,
+entitlement, model slot, model id, effective-window setting), and any change
+to any component invalidates rather than averages.
+
+## Context is one constraint among several
+
+This whole arc has treated context pressure as THE resource. It is one row.
+The same session is simultaneously bounded by limits this work has not
+touched at all: input tokens per minute, output tokens per minute, tokens per
+day, request rate, and account or plan quota.
+
+Those bind differently. Context pressure is per-session, resets at
+compaction, and is remediated by a shift. Rate limits are per-account,
+recover on a clock, are SHARED ACROSS THE FLEET, and are not remediated by a
+shift at all: rotating an agent does not restore TPM, and shifting several
+agents at once consumes a burst of it. A shift trigger that knows only
+context can therefore make a rate-limit situation worse at exactly the wrong
+moment.
+
+That is a gap in the framing rather than in the measurements, and it belongs
+in the resource matrix work rather than here. Recorded because this finding
+would otherwise read as though solving context pressure solves scheduling.
+
+## The pre-registered falsifiers
+
+Three numbers were registered in advance as tests of the "fire early, because
+late fails invisibly" argument. Two did not fire; one did.
+
+**(a) Trigger mix. Does not falsify.** 68 auto (88.3%), 9 manual (11.7%).
+The priced failure mode is the common case.
+
+**(b) Cost ratio. FIRES, against the bar set in advance.** The bar was that
+late must be worse by an order, and that inside 1.5x the claim degrades.
+
+```
+median cumulativeDroppedTokens   487,126
+median occupancy at compaction   467,446
+cache read at 10% of input price -> re-warm premium ~420,701 -> 1.16x
+cache read at 25% of input price -> re-warm premium ~350,584 -> 1.39x
+```
+
+Both inside 1.5x. **On cost, firing late is only slightly worse.** This is a
+calculation with stated assumptions, not a measurement: the price ratio is
+not in the corpus, and it is itself model-dependent per the section above.
+
+**(c) What survives verbatim. Does not falsify, and it explains (b).**
+
+```
+preserved messages per event: median 4, mode 4, min 1
+distribution: 1:1 2:8 3:18 4:28 5:7 6:5 7:3 9:2 16:1 17:1 278:1 631:1 799:1
+token retention (post/pre): median 4.3%
+```
+
+59 of 77 events preserve five messages or fewer verbatim. The harness keeps a
+handful of recent messages and compresses roughly 96% of context into a
+summary. It does not preserve the working set.
+
+So the argument's framing survives while its metric fails: the cost of firing
+late is not tokens, it is that 96% of the session's context passes through an
+unauthored summarization. **The case for shifting early is knowledge
+fidelity, and it should stop being argued on cost, where the numbers do not
+support it.**
+
+## Secondary observations
+
+- **Compaction is slow.** Median 154s, max 275s. A session is unavailable for
+  two to five minutes at every boundary. A shift and a compaction racing each
+  other is a real interleaving.
+- **Cluster A is unexplained by the setting.** Five auto events at or below
+  210k (28,814 / 41,597 / 54,596 / 168,174 / 198,537). The last two fit a
+  200k context window compacting near its top. The first three fit nothing
+  yet, and two of them are the events where `postTokens` EXCEEDS `preTokens`
+  (28,814 to 187,208 and 41,597 to 124,308). A compaction that increased
+  occupancy is unexplained; plausibly session resumption, recorded as a guess.
+- **One event exceeded the configured window** (512,487 against 500,000),
+  which is the discrepancy the verify step exists to catch.
+- **Manual compactions do not cluster**: 153k to 969k, operator chosen.
+
+## What this does NOT establish
+
+- **Only Claude Code, and only at one setting value.** The whole corpus ran
+  with `autoCompactWindow: 500000`. Whether the ~32k buffer is a constant, a
+  percentage of the setting, or a function of something else cannot be
+  separated from a single setting value. Varying the setting is the obvious
+  next probe and it is cheap.
+- **The 93.5% convergence with codex is suggestive, not established.** Two
+  harnesses at one setting each.
+- **Whether the assignment mechanisms work at all.**
+  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` and `AUTOCOMPACT_PCT_OVERRIDE` are
+  present as strings. Neither has been exercised.
+- **SP4 is unrun** and is now more urgent, not less: the shipped hysteresis
+  was tuned against a 200k-window geometry and is being asked to fire on a
+  ~450k drop.
+
+## Method note
+
+Records selected by parsing each line and testing
+`subtype == "compact_boundary"`, never by matching the raw string: a loose
+match returns 134 lines of which 77 are records, the other 57 being this
+review's own prose about compaction landing in the directory it mines. Only
+counts, token fields, timestamps, and metadata were read.
+
+## Consequences to carry
+
+1. **Denominator identity is a required field.** `LimitSource` grades where a
+   denominator came from but not which quantity it is. Context window and
+   auto-compact window differ by 2x here and only one predicts compaction.
+2. **Assign and verify ship together or not at all**, and the learned value
+   is keyed by (harness, model, effective-window setting).
+3. **Model change invalidates the reading**, and marvel should treat an
+   observed model change as invalidating rather than averaging across it.
+4. **Rate limits are a parallel constraint class** that a context-only
+   trigger can make worse. Belongs in the resource matrix, not here.
+5. `internal/usage/doc.go` is vindicated in shape and should gain the
+   measured buffer and the effective-window distinction.

--- a/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
+++ b/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
@@ -1,0 +1,221 @@
+# Context pressure is an operating point on a cost-and-reliability curve, not a fill level
+
+**Status: idea, but with one measured result inside it.** The redefinition is
+pre-hypothesis. The carrying-cost measurement is real and is stated as such.
+
+Raised by the operator 2026-08-08, after finding-016 established that the
+denominator marvel divides by is not the denominator that predicts
+compaction. This goes further: it argues the whole quantity is defined wrong.
+
+## The complaint
+
+CTX% treats occupancy as a FILL LEVEL: how much of a container is used, with
+an implied goal of not overflowing. That framing is wrong in three ways at
+once, and a fleet makes each of them worse.
+
+1. **A fleet runs combinations simultaneously.** Different harnesses,
+   models, backends, entitlements, and settings, all at once. A column of
+   percentages computed against six-dimensionally-varying denominators
+   (finding-016) is a column of incommensurable numbers presented as
+   comparable. Sorting by it is meaningless; alerting on it is worse.
+2. **Occupancy is a price multiplier, not a capacity consumption.** You do
+   not spend context once. You re-read the entire context at cache-read price
+   on EVERY subsequent turn. Occupancy is therefore the per-turn carrying
+   rate for all remaining work, and a percentage discards exactly the
+   information that makes it actionable.
+3. **Models behave differently at high occupancy, and some get worse.** Above
+   roughly 600k, fable and opus become less reliable (operator observation).
+   So there is a region where you pay more per turn AND fail more often,
+   which is strictly dominated: no goal is served by operating there.
+
+## The one measured thing here
+
+Across 139 local Claude Code sessions with 50 or more assistant turns,
+carrying cost measured as cache-read tokens paid per output token produced:
+
+```
+sessions with median occupancy BELOW 100k :  107x   (n=13)
+sessions with median occupancy ABOVE 300k :  261x   (n=26)
+                                    ratio:  2.4x
+```
+
+Individual large sessions range from 180x to 571x. One paid 943 million
+cache-read tokens to produce 5.2 million output tokens.
+
+This is the structural confirmation of the operator's figures (roughly 30%
+more at an auto-compact window of 500k than 250k, and roughly 3x if allowed
+to run to 1M). It is not a derivation of them: the operator's numbers compare
+doing the SAME WORK at different auto-compact settings, which folds in
+compaction frequency and re-warm cost, and this measurement is the simpler
+carrying-rate component underneath. Same direction, same order, arrived at
+independently.
+
+**The mechanism is worth stating plainly because it makes the rest obvious:
+context is rent, not purchase.** You pay it every turn until something
+resets it.
+
+## What a better definition would carry
+
+Not one number. At minimum three, all comparable across heterogeneous
+sessions in a way a percentage is not:
+
+- **Carrying rate.** What the next turn costs at this occupancy, in tokens
+  and in money. Comparable across models because money is. This is the
+  quantity that makes "should this agent keep going" answerable.
+- **Distance to the next boundary**, in tokens AND in expected turns, where
+  the boundaries are plural and policy-selected: the auto-compact point, the
+  reliability knee, the team's spend budget, the account's rate limit. Turns
+  matter more than tokens for an actuator, because "three turns from
+  compaction" is actionable and "31k tokens from compaction" requires knowing
+  the growth rate.
+- **Position relative to the model's own curve**, which is what makes two
+  sessions comparable at all. 400k is comfortable for one model and past the
+  knee for another.
+
+Plus a piece of metadata finding-016 already argues for: **which quantity the
+denominator is.** A percentage of a context window and a percentage of an
+auto-compact window differ by 2x and only one predicts the event.
+
+## Policy is the operator's, and it is per-situation
+
+The goal is not the same in every case, and marvel should not encode one:
+
+- **Never auto-compress.** Shift or replace the agent before the harness
+  summarizes anything. Correct when the session's accumulated context is the
+  valuable artifact and an unauthored summary would lose it. This is the
+  knowledge-fidelity argument finding-016 supports.
+- **Allow auto-compression.** Correct when the model performs well at high
+  occupancy, the work is naturally episodic, or a shift costs more than a
+  compaction. If a provider demonstrates consistently good performance at
+  high occupancy, letting it run is the cheaper choice.
+- **Hold below a cost ceiling.** Correct when carrying rate rather than
+  capacity is the binding constraint, which the measurement above suggests is
+  common and under-recognized.
+- **Refuse the dominated region.** Above the reliability knee you pay more
+  and fail more. This one may not need to be a policy at all: a scheduler
+  should arguably decline to enter a Pareto-dominated operating point by
+  default, with an explicit operator opt-out, rather than requiring every
+  operator to discover the knee independently.
+
+So the manifest surface is per-role rather than global, and it is a
+POLICY selection plus its parameters, not a threshold percentage. Something
+in the shape of "context_policy = shift-before-compaction" or
+"= hold-below-cost" or "= allow-compaction", with the numeric limits attached
+to the chosen policy.
+
+## Why this cannot be a static table, restated for this quantity
+
+finding-016 established the denominator varies with six independent inputs.
+The curve varies with the same six plus workload. A knee measured for opus on
+one backend at one release is not a knee for fable, or for opus through a
+different provider, or after the next release.
+
+So the same conclusion applies with more force: **measure, learn, key by the
+full tuple, invalidate on any change, and never guess.** The difference is
+that a wrong window produces a wrong percentage, while a wrong knee produces
+money spent on output that is worse than cheaper output would have been.
+
+## The other side of the ledger: handoffs are not free either
+
+Every policy above turns on shifting instead of compacting, and the argument
+so far has priced only one side. A handoff costs too, and in a different
+currency.
+
+**It costs TIME.** The departing agent drains, the successor spawns, loads
+its configuration, reads the handoff artifact, and orients before it does any
+useful work. That is dead time on the team's clock, and unlike money it
+cannot be recovered by spending more.
+
+The comparison is at least computable, because one side is now measured:
+**compaction takes a median of 154 seconds and up to 275** (finding-016). A
+cold shift plausibly costs the same order or more. So "shift instead of
+compacting" is not obviously a latency win, and may be a latency loss, which
+inverts one of the intuitions this arc has been carrying. Nobody has measured
+a real handoff end to end, and that measurement is now the highest-value
+missing number in the whole ledger.
+
+**Standby tiers trade money for latency, and marvel already owns the
+machinery.** The time cost is not fixed; it is a function of how much of the
+successor exists before it is needed:
+
+- **Cold.** Spawn on demand. Cheapest to hold, slowest to cut over, and the
+  successor starts with an empty cache, so it pays a full re-warm at input
+  price rather than cache-read price.
+- **Warm.** Process alive, harness started, workspace and packs resolved,
+  context not yet loaded. Pays a small idle carrying cost; removes spawn and
+  configuration latency.
+- **Hot.** Context pre-loaded and the prompt cache already warm. Cutover is
+  near-immediate, and the re-warm is paid in advance rather than on the
+  critical path. Most expensive to hold, because a warm cache is maintained
+  by paying for it, and cache entries expire.
+
+That maps directly onto shipped concepts: replicas, generations, and the
+supervisor-last shift ordering. A hot standby is a replica that exists before
+it is scheduled, which is a reconciler question rather than a new subsystem.
+The interesting design question is whether standby warmth is a role-level
+declaration (`standby = "warm"`) or something the reconciler chooses from the
+observed shift rate, and whether a hot standby's cache carrying cost is worth
+it at the occupancies the measurement above shows teams actually running at.
+
+**And a handoff changes behavior, not only timing.** A successor is a
+different instance with different loaded state, and it will not behave
+identically. The expectation is that the change is usually POSITIVE: a fresh
+agent carrying an authored handoff should outperform a degraded agent
+carrying an unauthored auto-summary, particularly past the reliability knee
+where the incumbent is both expensive and unreliable.
+
+But "most likely positive" is a hypothesis, and it is the one that decides
+whether shifting is a cost to be minimised or a benefit to be sought. If a
+handoff systematically improves output, the policy question inverts: the
+right operating point may be to shift MORE often than cost alone would
+justify, treating the handoff as a quality intervention rather than a
+capacity remedy. If it is neutral, shifting is pure overhead to be minimised.
+If it is occasionally negative (a successor misreading intent, or losing an
+unstated thread), that risk has to be priced too.
+
+So the shift-versus-compaction comparison is four-way, not two-way: token
+cost, wall-clock cost, standby carrying cost, and quality delta. Three of the
+four are measurable with instruments this arc has already built, and the
+fourth is what critic exists for.
+
+## The parallel constraint class this still ignores
+
+Rate limits (TPM in and out, TPD, request rate, plan quota) bind per-ACCOUNT
+and are shared across the fleet, recover on a clock, and are not remediated
+by a shift. A context-driven actuator that rotates several agents at once
+consumes a burst of exactly the resource it does not model. Any scheduler
+built on this idea needs both, and shifting is not a remedy for one of them.
+
+## What would make this real
+
+- Measure the reliability knee rather than accepting it. The corpus has
+  per-turn occupancy; pairing it with an outcome signal (retries, tool-call
+  errors, corrections) would locate the knee per model instead of taking it
+  on report.
+- Measure the operator's actual comparison: same work, different auto-compact
+  settings. The carrying-rate measurement above is the component, not the
+  answer.
+- Decide whether carrying rate belongs in `internal/usage` beside occupancy,
+  or in a separate accountant. It is derived from the same samples and
+  answers a different question.
+- **Measure one real handoff end to end.** This is now the single highest-
+  value missing number: compaction is measured at 154s median, and a cold
+  shift is unmeasured. Until both exist in the same units, every policy above
+  is being chosen on intuition.
+- Price the three standby tiers: idle carrying cost per tier against the
+  cutover latency each buys, at the occupancies teams actually run.
+- Test the "handoffs are usually positive" hypothesis, because it decides
+  whether shifting is overhead to minimise or an intervention to seek. This
+  is a critic question (compare successor output against incumbent output
+  past the knee), not a marvel one.
+
+## Provenance
+
+Operator framing 2026-08-08. Carrying-cost measurement over 139 local
+sessions, same date, same method note as finding-016 (parse, never grep;
+counts and token fields only, no message content).
+
+Related: `finding-016-effective-autocompact-window-is-the-predictive-denominator.md`,
+`bound-context-instead-of-measuring-it.md`,
+`ctx-channel-consent-and-fidelity.md`,
+`marvel-agentic-resource-matrix.md`, `question-shift-triggers`.

--- a/_kos/ideas/fleet-throughput-as-the-objective-function.md
+++ b/_kos/ideas/fleet-throughput-as-the-objective-function.md
@@ -1,0 +1,195 @@
+# Fleet throughput: the objective function the resource matrix is implicitly serving
+
+**Status: idea. Pre-hypothesis. Nothing here is measured.**
+
+Raised 2026-08-08 out of the context-pressure work, where mapping operating
+points against operator priorities surfaced one axis that had no instruments,
+no owner, and a failure mode the others do not share: **a per-session
+actuator optimizing context pressure can reduce fleet throughput.**
+
+## The gap, stated plainly
+
+marvel's governing frame is the agentic resource matrix: schedule agents by
+what actually constrains them (context, spend, cache locality, access,
+authority, attention) rather than by CPU and memory. Seventeen rows of
+constraint.
+
+**Constraints are not an objective.** A scheduler needs something it is
+maximizing, and every instrument built so far is per-session: occupancy, CPU
+and RSS, token counts, health, restart policy. There is no quantity in marvel
+that answers "is the fleet doing more useful work this hour than last hour,"
+and therefore no way to tell whether any scheduling decision helped.
+
+That is tolerable at three agents, where the operator is the scheduler. The
+vision's own framing is that past three or four concurrent agents one person
+cannot do this by hand, and throughput is precisely what degrades first and
+least visibly.
+
+## Why per-session optimization can make it worse
+
+This is the part that makes throughput urgent rather than merely absent. Four
+mechanisms, all reachable with what marvel ships or plans:
+
+1. **Correlated shifts burst a shared resource.** Rate limits (input and
+   output TPM, TPD, request rate) are per-ACCOUNT and shared across the whole
+   fleet. A context-pressure trigger that fires on several agents at once
+   consumes a burst of exactly the resource it does not model. The remedy for
+   one session degrades all of them.
+2. **High occupancy consumes shared budget faster per unit of work.** Since
+   context is rent paid every turn, an agent operating at 400k spends roughly
+   four times the input-TPM per turn of one at 100k. So occupancy is not only
+   a per-session cost, it is a per-fleet CONCURRENCY limit: the same account
+   supports fewer simultaneous agents when they run hot.
+3. **Cache locality is a fleet property being managed per session.** The
+   vision already names batching corpus-sharing dispatches inside the cache
+   TTL as converting directly to dollars. That is a scheduling decision about
+   WHICH agents run WHEN and TOGETHER, and no per-session view can make it.
+4. **Coordination overhead grows superlinearly.** Supervisors, handoffs, and
+   review all consume the same shared resources as productive work, and they
+   grow with fleet size rather than with fleet output.
+
+Mechanism 4 is why adding agents does not add throughput indefinitely, and it
+is the one with well-developed prior art (below).
+
+## Candidate use cases, roughly in order of how soon they bite
+
+- **Admission.** Should this agent start now, or queue? `internal/admission`
+  already refuses over-budget work at the operator verbs, so the seam exists;
+  what it lacks is a fleet-level signal to refuse ON. This is the shortest
+  path from idea to shipped behavior.
+- **Shift scheduling.** Stagger versus simultaneous, and how much jitter.
+  Directly addresses mechanism 1, and marvel's shift state machine already
+  has the ordering machinery (supervisor-last, generations).
+- **Cache-locality batching.** Group work that shares a corpus so it lands
+  inside one cache TTL. Mechanism 3, and the one with the clearest direct
+  dollar value.
+- **Placement.** Which host, backend, and model for a given unit of work,
+  once M5 makes more than one host real. Backends have independent rate
+  limits, so placement is also a way to buy concurrency.
+- **Degradation policy.** When the account IS rate-limited, who yields? A
+  fleet without a policy degrades by whoever retries hardest, which is the
+  worst available allocation.
+- **Capacity planning.** How many agents does this account actually support
+  at this operating point? Currently unanswerable, and it is the first
+  question anyone asks before scaling a fleet.
+
+## Value proposition
+
+Three claims, each falsifiable:
+
+1. **There is a peak, and running past it is worse than stopping short of
+   it.** If contention and coordination overhead are real, fleet output rises
+   with agent count, peaks, and then FALLS. An operator adding agents to a
+   fleet past its peak is paying more for less. Nobody can currently see
+   that happening.
+2. **The peak is movable by scheduling, not just by buying more.** Staggering
+   shifts, batching for cache locality, and placing across backends all raise
+   the peak without raising spend. That is the value marvel adds over running
+   the same agents by hand.
+3. **Cost per unit of delivered work is the number an operator actually
+   cares about**, and it is not derivable from any per-session metric. It
+   needs a fleet numerator and an honest denominator (below).
+
+## Methodologies worth stealing rather than inventing
+
+The failure mode here is inventing a scheduling theory. These are mature and
+map cleanly:
+
+- **Little's Law** (`L = λW`). Work in progress equals arrival rate times
+  time in system. Gives the relationship between how many agents are running,
+  how fast work arrives, and how long each unit takes, and it is the cheapest
+  possible sanity check on any throughput claim.
+- **Universal Scalability Law** (Gunther). Extends Amdahl with a COHERENCY
+  term, and it predicts exactly the shape claimed above: throughput rises,
+  peaks, and declines as concurrency grows, because contention (shared rate
+  limits) and coherency (coordination, supervision, handoffs) both grow. If
+  any single model is worth fitting to fleet data, it is probably this one,
+  because it has a peak and marvel needs to find one.
+- **Theory of constraints.** Identify the binding constraint, subordinate
+  everything to it, elevate it, repeat. Directly applicable because the
+  binding constraint here MOVES: rate limit at one operating point, human
+  attention at another, host memory at a third.
+- **Queueing theory, the utilization-latency knee.** Explains why running a
+  shared resource near saturation destroys latency, and gives a principled
+  target utilization rather than a guessed one.
+- **Goodput versus throughput.** From networking, and the honest framing for
+  agent work: output produced is not output KEPT. Discarded variants are
+  screening cost, not waste (the vision's selection-based engineering already
+  says this), but only if they are counted as screening rather than as
+  production.
+
+## The measurement problem, which is the hard part
+
+Throughput needs a unit of work, and every obvious candidate is wrong:
+
+- **Output tokens.** Rewards verbosity. A model that writes twice as much to
+  say the same thing scores double.
+- **Turns or sessions.** Rewards churn and penalizes agents that get it right
+  the first time.
+- **Tasks closed.** Better, but game-able, and it needs task granularity to
+  be comparable across teams.
+- **Per selected outcome.** The vision's own accounting for
+  generate-and-select: cost is attributed to the variant that was KEPT, with
+  discards priced as screening. This is the most honest unit available and
+  it is exactly what critic is designed to produce.
+
+**So throughput likely cannot be measured without critic**, which makes the
+dependency worth naming early rather than discovering it halfway through.
+An interim proxy (tasks closed per unit spend, per team, per day) may be
+enough to detect the peak's EXISTENCE even if it cannot locate it precisely,
+and detecting existence is what claim 1 needs.
+
+## What marvel would have to instrument
+
+Nothing exotic, and most of it is one aggregation away from data already
+collected:
+
+- Per-account rate-limit headroom, which requires reading response headers
+  the harnesses receive and marvel currently does not see. This is the one
+  genuinely missing input, and it may be the strongest argument yet for a
+  channel that carries API response metadata rather than just token counts.
+- Fleet-wide concurrent-agent count over time, trivially available.
+- Aggregate spend rate, available from the same samples occupancy comes from.
+- Queue depth and time-to-start for admitted work, which admission would
+  produce as a side effect of refusing anything.
+- A work-completion signal, which is the critic dependency above.
+
+## Relationship to what already exists
+
+- **Resource matrix**: this is the objective those seventeen constraint rows
+  are implicitly optimizing. Worth deciding whether throughput is an
+  eighteenth row or a different kind of thing entirely, because it is not a
+  resource, it is what resources are spent ON.
+- **Gap 1, operator attention**: attention is a shared resource that binds
+  fleet throughput exactly as rate limits do, and it has no owner either. The
+  two gaps may be the same gap seen from different sides.
+- **Gap 5, cost and quality instrumentation**: the denominator problem above
+  is Gap 5's problem, and solving it once serves both.
+- **critic**: supplies the honest unit of work. Probably a hard dependency
+  for the precise version and not for the existence version.
+- **`internal/admission`**: the shipped seam where a fleet-level signal would
+  first do useful work.
+
+## What would kill this idea
+
+- If the peak turns out to be far above any fleet size an operator actually
+  runs, then throughput is a capacity-planning curiosity rather than a
+  scheduling input, and the per-session view is sufficient.
+- If rate limits turn out never to bind in practice on the plans this fleet
+  uses, mechanisms 1 and 2 evaporate and only cache locality remains, which
+  is a much smaller idea.
+- If no honest unit of work can be defined, throughput cannot be measured and
+  the right move is to instrument the CONSTRAINTS well and let the operator
+  hold the objective in their head, which is the status quo made deliberate.
+
+## Provenance
+
+Fell out of `probe-context-operating-points-and-axes.md`, where fleet
+throughput was the one axis with no instruments and the only one where a
+per-session actuator can actively do harm. Operator asked for it to be
+studied in its own right, 2026-08-08.
+
+Related: `marvel-agentic-resource-matrix.md`,
+`context-pressure-is-an-operating-point-not-a-fill-level.md`,
+`probe-context-operating-points-and-axes.md`, `question-shift-triggers`,
+vision Gap 1 (attention routing) and Gap 5 (cost and quality).

--- a/_kos/probes/probe-context-operating-points-and-axes.md
+++ b/_kos/probes/probe-context-operating-points-and-axes.md
@@ -1,0 +1,180 @@
+# Probe brief: the operating points along context, and the axes an operator might prioritize
+
+**Status:** OPEN (brief only).
+**Question:** `question-interactive-context-pressure`, `question-shift-triggers`.
+**Medium:** mining local artifacts first, then controlled measurement for the
+points the corpus cannot reach.
+**Prior work:** finding-016 (the auto-compact point, measured),
+`context-pressure-is-an-operating-point-not-a-fill-level.md` (the reframing
+and the carrying-cost measurement).
+
+## Why this probe exists
+
+Two operating points have been identified so far, and both by accident while
+looking for something else: the auto-compact point (measured at the effective
+window minus roughly 32k) and the reliability knee (operator-reported near
+600k for fable and opus). Neither was predicted; both changed the design when
+found.
+
+That is a bad way to discover the structure of a metric marvel intends to
+actuate on. **The occupancy axis has multiple distinguished points where
+behavior changes, and an operator prioritizing cost will care about different
+ones than an operator prioritizing latency, fidelity, or fleet throughput.**
+This probe is to enumerate them deliberately, measure the ones that are
+measurable, and say plainly which are conjecture.
+
+## Part 1: candidate operating points
+
+Each is a level (or a moment) at which something discontinuous happens.
+Status is stated per item; most are unmeasured.
+
+### Measured
+
+1. **The auto-compact point.** Effective window minus ~32k, firing at 93.5%
+   of the effective window. n=63, IQR 1,609 tokens. finding-016. Note it is a
+   SETTING, so it is assignable as well as observable.
+
+2. **The carrying-cost gradient.** Not a point but the slope everything else
+   sits on: 107x cache-read per output token below 100k median occupancy,
+   261x above 300k. Context is rent, paid every turn.
+
+### Reported, unmeasured, worth measuring first
+
+3. **The reliability knee.** Near 600k for fable and opus per operator
+   observation: output quality degrades while cost continues rising, making
+   the region past it Pareto-dominated. This is the single most valuable
+   unmeasured point, because a dominated region is one a scheduler should
+   refuse by default rather than expose as a tunable. Measuring it needs an
+   outcome signal paired with occupancy (retries, tool-call errors,
+   self-corrections, rejected diffs), which the transcript corpus plausibly
+   carries.
+
+### Conjectured, from mechanism rather than observation
+
+4. **Cache-rebuild events.** A first pass found 639,142,047 `cache_creation`
+   tokens paid across the corpus on turns where under 20% of prior occupancy
+   was served from cache. That is a large cost line paid at WRITE price
+   rather than read price. **But the detector is not clean:** the median idle
+   gap before such a turn is 3 seconds, so it is catching post-compaction
+   rebuilds and segment boundaries alongside any true expiries. Separating
+   the causes is the work.
+
+5. **Cache TTL expiry, an operating point on the TIME axis rather than the
+   token axis.** A session idle past its cache TTL pays full price to
+   reload context it already had. This is qualitatively different from every
+   other point here because it is triggered by the clock, and it interacts
+   directly with the standby-tier question: a "hot" standby whose cache has
+   expired is a cold standby that cost money to hold.
+
+6. **Cache breakpoint exhaustion.** Prompt caching allows a bounded number of
+   breakpoints. A session whose structure exceeds them stops caching some
+   segment and silently moves that segment from read price to input price.
+   Whether this is reachable in practice under these harnesses is unknown.
+
+7. **Rate-limit interaction points.** Input TPM is consumed per turn in
+   proportion to occupancy, so a high-occupancy session consumes the shared
+   per-account budget faster per unit of work. There should exist an
+   occupancy above which one session's single turn is a material fraction of
+   the minute's budget, and above which two such sessions cannot run
+   concurrently. This is the point where context pressure and fleet
+   scheduling stop being separable.
+
+8. **The handoff-affordability point.** Remaining headroom must exceed the
+   cost of writing a handoff artifact plus the successor reading it. Below
+   it, an authored handoff is no longer possible and only an unauthored
+   summarization remains. This was the original framing of the shift trigger
+   and it has never been measured; it is probably the lowest of the points
+   here and therefore the true floor.
+
+9. **The context-window hard limit.** Request rejection. Almost certainly
+   unreachable when auto-compaction is enabled, which makes it interesting
+   mainly for `DISABLE_AUTO_COMPACT` configurations.
+
+10. **Attention dilution.** Distinct from the reliability knee: retrieval
+    degradation over a long context even where the model does not fail
+    outright. If real and separable, it is a quality cost incurred well
+    before the knee, and it would argue for lower operating points than cost
+    alone justifies.
+
+## Part 2: the axes, and which points each one cares about
+
+The point of enumerating operating points is that different operators
+optimize different things. The same session at 400k is fine on one axis and
+wrong on another.
+
+| Axis | What it minimizes or maximizes | Points it cares about |
+|---|---|---|
+| **Money** | total cost per unit of delivered work | carrying gradient (2), auto-compact point (1), cache rebuild (4,5,6) |
+| **Latency** | wall-clock to completion | compaction pause (measured, 154s median), handoff time (unmeasured), standby tier |
+| **Output quality** | correctness, fewer retries | reliability knee (3), attention dilution (10) |
+| **Knowledge fidelity** | avoiding unauthored summarization | auto-compact point (1), handoff affordability (8) |
+| **Fleet throughput** | total work across all agents | rate-limit points (7), standby carrying cost |
+| **Predictability** | variance, not mean | cache expiry (5), model change, rate-limit proximity |
+
+Three observations that fall out of the table and are worth testing:
+
+- **Money and latency conflict at the auto-compact point.** Shifting early
+  saves carrying cost but spends handoff time; letting the harness compact
+  costs a 154s pause and an unauthored summary. Neither dominates.
+- **Quality and money agree past the knee**, which is why the dominated
+  region is special: it is the one place where two axes point the same way
+  and no tradeoff exists. That is the argument for making it a default rather
+  than a policy.
+- **Fleet throughput is the axis nobody has instrumented at all**, and it is
+  the one where a per-session actuator can do harm: shifting several agents
+  at once to relieve context pressure consumes a burst of the shared rate
+  limit.
+
+## Sub-probes, in value order
+
+**SP1. Locate the reliability knee.** Pair occupancy with an outcome signal
+from the transcript corpus. Success: a stated occupancy band per model where
+an error or retry rate rises, with its confidence interval, or a statement
+that the corpus cannot support the measurement. This is first because a
+dominated region changes a default rather than a tunable.
+
+**SP2. Separate the cache-rebuild causes.** Decompose the 639M
+`cache_creation` tokens into post-compaction rebuild, segment growth, TTL
+expiry, and breakpoint effects. Success: a cost attribution per cause, and a
+verdict on whether TTL expiry is a real operating point on this fleet or a
+theoretical one.
+
+**SP3. Measure a handoff end to end.** Wall-clock and tokens, cold, for one
+real shift. Success: a number in the same units as the 154s compaction
+measurement, so the shift-versus-compact comparison stops being intuition.
+Also establishes the handoff-affordability floor (8).
+
+**SP4. Find the rate-limit interaction point.** For a given plan, the
+occupancy at which one turn is a material fraction of the input TPM budget,
+and the concurrency at which two sessions collide. Success: a stated
+occupancy-by-concurrency boundary, which is the first instrument marvel would
+have for fleet-level admission on a shared resource.
+
+**SP5. Test attention dilution separately from the knee.** Only if SP1
+succeeds and suggests degradation begins before outright failure.
+
+## Excluded scope
+
+- Choosing a policy. This probe produces the map; the operator picks the
+  operating point per role, per the idea file.
+- Building the actuator. Instruments and measurements only.
+- Non-Claude harnesses beyond opportunistic checks. codex has a small
+  compaction corpus locally and gemini has a per-turn token series; both are
+  worth a pass at the end rather than the start.
+
+## Method note
+
+Same discipline as finding-016: parse and filter on record type, never match
+raw strings; the corpus is live and self-contaminating; read counts, token
+fields, timestamps, and metadata only, never message content. Any measurement
+of an outcome signal for SP1 must be designed to avoid reading content, which
+may constrain what signals are usable and should be stated as a limitation
+rather than worked around.
+
+## What would change the read
+
+If the reliability knee turns out not to exist as a measurable discontinuity,
+the dominated-region argument collapses and context pressure becomes a pure
+cost-versus-fidelity tradeoff with no free lunch anywhere on the curve. That
+would simplify the policy surface considerably and is worth knowing early,
+which is why SP1 is first.


### PR DESCRIPTION
The channel sweep asked how to READ context pressure. Running the probe answered a different question: the number marvel currently computes is roughly half the number that predicts the event a shift trigger exists to pre-empt, and "context pressure" as a fill level is the wrong quantity to begin with.

Four documents. One is a measured finding; three are briefs and ideas, labelled as such.

## The finding, including how its first draft was wrong

A first draft claimed Claude Code auto-compacts at a hard constant near 467k, because 63 events clustered inside 3,509 tokens (IQR 1,609). That was wrong in the most ordinary way available: **I measured a realized value without checking whether a setting explained it.** `autoCompactWindow` is `500000` on this host, and 500,000 − 467,635 = 32,365, which sits inside the 33–45k buffer `internal/usage/doc.go` already reasons about. The doc was right in shape and I briefly concluded it was wrong. The retraction is kept in the body because how it was wrong is the transferable part.

What survives is better than the claim it replaced. Against the **effective** window those events read **93.5%** — the same figure codex was independently measured at. Against a 1M context window, 46.8%. So a trigger armed at 90% fires usefully against one denominator and never fires at all against the other, while looking correctly configured either way.

**The denominator varies with six independent inputs, none of them ours**: harness release, user settings, model, backend service (bedrock / vertex / foundry / mantle / gateway / arbitrary base URL), entitlement (`context-1m-2025-08-07` is a *beta header*, so one model id is 200k or 1M by account), and which of three model slots. That settles the design against tables — a table returns a plausible number for a cell whose value moved, which is the silent-wrong failure mode. In-band declarations and learned values outrank it; the table is the last rung and its miss is a `?`.

**Assign and learn were being argued as alternatives. They are one control loop.** Assignment without measurement is open-loop, and this corpus already holds the proof: one event fired at 512,487 against a 500,000 setting.

Of three pre-registered falsifiers, two held and one fired. Dropped-versus-rewarm comes out 1.16–1.39x, inside the 1.5x bar set in advance, so late is only slightly worse *on cost*. But a median of 4 messages survive verbatim at 4.3% token retention, so the harness does not preserve the working set. **The case for shifting early is knowledge fidelity, not cost.**

## Context pressure is an operating point, not a fill level

Measured across 139 local sessions: carrying cost is 107x cache-read per output token below 100k median occupancy and 261x above 300k, a 2.4x ratio that independently corroborates the operator's ~3x figure for 1M vs 250k. **Context is rent, not purchase** — you re-read it all, every turn.

So a better definition carries a carrying *rate*, a distance to the nearest of several policy-selected boundaries in *turns* rather than only tokens, and a position on the model's own curve. Policy is per-role and operator-chosen, including a dominated region past the reliability knee where you pay more and fail more. Handoffs are priced too: compaction is measured at 154s median, a cold shift is not measured at all, and standby tiers (cold/warm/hot) trade money for cutover latency on machinery marvel already owns.

## Two study briefs

**Operating points and axes.** Ten candidate points labelled measured / reported / conjectured, mapped against six axes. Three things fall out: money and latency *conflict* at the auto-compact point so neither dominates; quality and money *agree* past the reliability knee, which is what makes a dominated region worth a default rather than a tunable; and fleet throughput is uninstrumented, which is the axis where a per-session actuator can do harm.

**Fleet throughput.** The resource matrix is seventeen rows of constraint, and constraints are not an objective. Every instrument is per-session, so nothing answers whether the fleet did more useful work this hour than last. The urgency is that per-session optimization can make throughput worse: rate limits are per-account and shared, so a trigger firing on several agents at once bursts the resource it does not model. Methodologies to steal rather than invent (Little's Law, the Universal Scalability Law for its coherency term and its peak, theory of constraints, goodput vs throughput), and the hard part named early — the honest unit of work is per-selected-outcome, which is what critic exists to produce.

## Notes

One measurement is recorded as **unclean rather than banked**: 639M `cache_creation` tokens paid at write price on turns serving under 20% from cache, but the median idle gap before such a turn is 3 seconds, so the detector conflates post-compaction rebuild with true TTL expiry. That is SP2 of the operating-points brief, not a result.

Additive only: three new `_kos/` files plus one, no code changes, no deletions. Branch was rebuilt from current `origin/main` after the original base was found to predate PR #150 and would have reverted its 117-line OTEL scope qualification.

Refs: aae-orc-0tnf, aae-orc-hpeu, aae-orc-mob4, #144