### PR TITLE
probe(marvel): SP1 attempted — the corpus cannot locate the reliability knee

### DIFF
--- a/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
+++ b/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
@@ -25,8 +25,16 @@ once, and a fleet makes each of them worse.
    information that makes it actionable.
 3. **Models behave differently at high occupancy, and some get worse.** Above
    roughly 600k, fable and opus become less reliable (operator observation).
-   So there is a region where you pay more per turn AND fail more often,
-   which is strictly dominated: no goal is served by operating there.
+   So there would be a region where you pay more per turn AND fail more
+   often, which is strictly dominated: no goal is served by operating there.
+
+   **Status of this claim, updated 2026-08-08: operator observation only.**
+   One attempt to measure it against the corpus failed to see it (SP1 of
+   `probe-context-operating-points-and-axes.md`): tool-error rate is flat at
+   2.7 to 5.3 percent across every occupancy band. That neither confirms nor
+   refutes, because the proxy is weak, the sample thins exactly where the
+   question lives, and high-occupancy sessions are survivors by construction.
+   Until a better signal exists this must not be built into a default.
 
 ## The one measured thing here
 
@@ -95,7 +103,10 @@ The goal is not the same in every case, and marvel should not encode one:
   and fail more. This one may not need to be a policy at all: a scheduler
   should arguably decline to enter a Pareto-dominated operating point by
   default, with an explicit operator opt-out, rather than requiring every
-  operator to discover the knee independently.
+  operator to discover the knee independently. **Blocked on measuring the
+  knee**, per the status note above; a default built on an unmeasured
+  discontinuity is exactly the silent-wrong failure this arc keeps ruling
+  against.
 
 So the manifest surface is per-role rather than global, and it is a
 POLICY selection plus its parameters, not a threshold percentage. Something

--- a/_kos/probes/probe-context-operating-points-and-axes.md
+++ b/_kos/probes/probe-context-operating-points-and-axes.md
@@ -127,11 +127,82 @@ Three observations that fall out of the table and are worth testing:
 
 ## Sub-probes, in value order
 
-**SP1. Locate the reliability knee.** Pair occupancy with an outcome signal
-from the transcript corpus. Success: a stated occupancy band per model where
-an error or retry rate rises, with its confidence interval, or a statement
-that the corpus cannot support the measurement. This is first because a
-dominated region changes a default rather than a tunable.
+**SP1. Locate the reliability knee.** ATTEMPTED 2026-08-08. Result: the
+corpus cannot support the measurement with the signals available, and the
+reasons are worth more than the attempt was.
+
+The only clean outcome signal in the transcripts that needs no content
+reading is `tool_result.is_error`. Measured across 34,570 tool results,
+bucketed by the occupancy of the assistant turn that issued the call:
+
+```
+occupancy band          tool results   errors   rate
+   50,000 -  99,999           2,471       93   3.76%
+  100,000 - 149,999           4,493      174   3.87%
+  150,000 - 199,999           5,067      162   3.20%
+  200,000 - 249,999           4,799      139   2.90%
+  250,000 - 299,999           4,353      144   3.31%
+  300,000 - 349,999           3,959      161   4.07%
+  350,000 - 399,999           3,621      145   4.00%
+  400,000 - 449,999           2,593       71   2.74%
+  450,000 - 499,999           1,306       38   2.91%
+  500,000 - 549,999             531       28   5.27%
+  550,000 - 599,999             433       16   3.70%
+  600,000 - 649,999             282       10   3.55%
+  650,000 - 699,999             227        4   1.76%
+                    overall  34,570    1,200   3.47%
+```
+
+No knee. The rate sits between 2.7 and 5.3 percent across every band with no
+trend, and the two highest bands show the LOWEST rates.
+
+**This does not falsify the reported knee.** It says this proxy cannot see
+it, and there are four reasons to expect that even if the knee is real:
+
+1. **The proxy measures the wrong thing.** A tool error is mostly a command
+   that legitimately failed: a grep with no match, a file that does not
+   exist, a build broken for reasons unrelated to the model. That noise floor
+   is large and roughly constant, and it would swamp a change in reasoning
+   quality.
+2. **Sample size collapses exactly where the question lives.** Below 500k
+   each band holds thousands of observations; above it, 531, 433, 282, 227.
+   The bands that would show the knee are the ones with no power.
+3. **Survivorship, and this is the serious one.** A session only reaches 700k
+   by not having gone badly wrong. Sessions that degrade get compacted,
+   abandoned, restarted, or taken over by their operator, which removes them
+   from the high-occupancy sample. **The corpus is conditioned on the outcome
+   being measured**, so high-occupancy sessions are a biased sample of
+   well-behaved ones. This is a structural problem for any observational
+   measurement of the knee, not a fixable defect of this attempt.
+4. **No internal quality signal is exposed.** `usage.iterations` is `[]` on
+   every record and `usage.speed` is `standard` on every record, so neither
+   carries retry or degradation information.
+
+**What would actually measure it**, in ascending cost:
+
+- **Rework detection.** Same file edited repeatedly in close succession, or
+  an edit reverted shortly after. Derivable from tool-call metadata without
+  reading content, and a far closer proxy for "the model is not getting it
+  right" than a failed command. Cheapest remaining option; try before
+  anything that costs quota.
+- **Correction-turn detection.** Short operator messages immediately
+  following an assistant turn. Needs care: message length is metadata, but
+  inferring intent from it approaches reading content, which the handling
+  note forbids.
+- **A controlled experiment.** The same task attempted from different
+  starting occupancies. The only design that escapes survivorship, because it
+  fixes the task and varies the condition. Costs quota, and it is the honest
+  answer if the cheap proxies also fail.
+- **critic.** An outcome signal on kept-versus-discarded work is exactly what
+  the knee needs and exactly what critic exists to produce. The knee is now a
+  second question blocked behind it, alongside the throughput unit of work.
+
+**Consequence for the dominated-region argument, recorded against our own
+interest.** The idea file claims the region past the knee is Pareto-dominated
+and that a scheduler should refuse it by default. That claim now rests
+entirely on operator observation, with one attempted measurement that neither
+confirms nor refutes it. It should be stated that way wherever it appears,
+and it should NOT be built into a default until a better signal exists.
 
 **SP2. Separate the cache-rebuild causes.** Decompose the 639M
 `cache_creation` tokens into post-compaction rebuild, segment growth, TTL


### PR DESCRIPTION
The dominated-region claim (above ~600k, models cost more AND fail more) was carrying policy weight it had not earned. It was an operator observation, and one of the ideas merged in #151 was already reasoning from it toward a scheduler default. This runs the first attempt to measure it and reports a clean negative, so the claim stops being load-bearing until something better measures it.

SP1 of `probe-context-operating-points-and-axes.md`: pair per-turn occupancy against tool-call error rate across the local session corpus.

Result: tool-error rate is flat at 2.7 to 5.3 percent across every occupancy band. That neither confirms nor refutes the knee. Three reasons, recorded in the probe: the proxy is weak (tool errors are not the failure mode the observation describes), the sample thins exactly where the question lives, and high-occupancy sessions are survivors by construction, since a session that degraded badly got compacted or abandoned before it reached the band that would show it.

Survivorship is the structural part, and it means no purely observational read of this corpus can locate the knee. That is worth knowing before someone runs the same query again with a different outcome column.

Consequence, applied in the same commit: the dominated-region claim in `context-pressure-is-an-operating-point-not-a-fill-level.md` is downgraded to operator-observation-only, with an explicit note that it must not be built into a default until measured.

Additive only. Two documents, no code.