### PR TITLE
fix(api): declare the CTX% producer instead of inferring it from field shape

### DIFF
--- a/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
+++ b/_kos/ideas/context-pressure-is-an-operating-point-not-a-fill-level.md
@@ -25,8 +25,16 @@ once, and a fleet makes each of them worse.
    information that makes it actionable.
 3. **Models behave differently at high occupancy, and some get worse.** Above
    roughly 600k, fable and opus become less reliable (operator observation).
-   So there is a region where you pay more per turn AND fail more often,
-   which is strictly dominated: no goal is served by operating there.
+   So there would be a region where you pay more per turn AND fail more
+   often, which is strictly dominated: no goal is served by operating there.
+
+   **Status of this claim, updated 2026-08-08: operator observation only.**
+   One attempt to measure it against the corpus failed to see it (SP1 of
+   `probe-context-operating-points-and-axes.md`): tool-error rate is flat at
+   2.7 to 5.3 percent across every occupancy band. That neither confirms nor
+   refutes, because the proxy is weak, the sample thins exactly where the
+   question lives, and high-occupancy sessions are survivors by construction.
+   Until a better signal exists this must not be built into a default.
 
 ## The one measured thing here
 
@@ -95,7 +103,10 @@ The goal is not the same in every case, and marvel should not encode one:
   and fail more. This one may not need to be a policy at all: a scheduler
   should arguably decline to enter a Pareto-dominated operating point by
   default, with an explicit operator opt-out, rather than requiring every
-  operator to discover the knee independently.
+  operator to discover the knee independently. **Blocked on measuring the
+  knee**, per the status note above; a default built on an unmeasured
+  discontinuity is exactly the silent-wrong failure this arc keeps ruling
+  against.
 
 So the manifest surface is per-role rather than global, and it is a
 POLICY selection plus its parameters, not a threshold percentage. Something

--- a/_kos/probes/probe-context-operating-points-and-axes.md
+++ b/_kos/probes/probe-context-operating-points-and-axes.md
@@ -127,11 +127,82 @@ Three observations that fall out of the table and are worth testing:
 
 ## Sub-probes, in value order
 
-**SP1. Locate the reliability knee.** Pair occupancy with an outcome signal
-from the transcript corpus. Success: a stated occupancy band per model where
-an error or retry rate rises, with its confidence interval, or a statement
-that the corpus cannot support the measurement. This is first because a
-dominated region changes a default rather than a tunable.
+**SP1. Locate the reliability knee.** ATTEMPTED 2026-08-08. Result: the
+corpus cannot support the measurement with the signals available, and the
+reasons are worth more than the attempt was.
+
+The only clean outcome signal in the transcripts that needs no content
+reading is `tool_result.is_error`. Measured across 34,570 tool results,
+bucketed by the occupancy of the assistant turn that issued the call:
+
+```
+occupancy band          tool results   errors   rate
+   50,000 -  99,999           2,471       93   3.76%
+  100,000 - 149,999           4,493      174   3.87%
+  150,000 - 199,999           5,067      162   3.20%
+  200,000 - 249,999           4,799      139   2.90%
+  250,000 - 299,999           4,353      144   3.31%
+  300,000 - 349,999           3,959      161   4.07%
+  350,000 - 399,999           3,621      145   4.00%
+  400,000 - 449,999           2,593       71   2.74%
+  450,000 - 499,999           1,306       38   2.91%
+  500,000 - 549,999             531       28   5.27%
+  550,000 - 599,999             433       16   3.70%
+  600,000 - 649,999             282       10   3.55%
+  650,000 - 699,999             227        4   1.76%
+                    overall  34,570    1,200   3.47%
+```
+
+No knee. The rate sits between 2.7 and 5.3 percent across every band with no
+trend, and the two highest bands show the LOWEST rates.
+
+**This does not falsify the reported knee.** It says this proxy cannot see
+it, and there are four reasons to expect that even if the knee is real:
+
+1. **The proxy measures the wrong thing.** A tool error is mostly a command
+   that legitimately failed: a grep with no match, a file that does not
+   exist, a build broken for reasons unrelated to the model. That noise floor
+   is large and roughly constant, and it would swamp a change in reasoning
+   quality.
+2. **Sample size collapses exactly where the question lives.** Below 500k
+   each band holds thousands of observations; above it, 531, 433, 282, 227.
+   The bands that would show the knee are the ones with no power.
+3. **Survivorship, and this is the serious one.** A session only reaches 700k
+   by not having gone badly wrong. Sessions that degrade get compacted,
+   abandoned, restarted, or taken over by their operator, which removes them
+   from the high-occupancy sample. **The corpus is conditioned on the outcome
+   being measured**, so high-occupancy sessions are a biased sample of
+   well-behaved ones. This is a structural problem for any observational
+   measurement of the knee, not a fixable defect of this attempt.
+4. **No internal quality signal is exposed.** `usage.iterations` is `[]` on
+   every record and `usage.speed` is `standard` on every record, so neither
+   carries retry or degradation information.
+
+**What would actually measure it**, in ascending cost:
+
+- **Rework detection.** Same file edited repeatedly in close succession, or
+  an edit reverted shortly after. Derivable from tool-call metadata without
+  reading content, and a far closer proxy for "the model is not getting it
+  right" than a failed command. Cheapest remaining option; try before
+  anything that costs quota.
+- **Correction-turn detection.** Short operator messages immediately
+  following an assistant turn. Needs care: message length is metadata, but
+  inferring intent from it approaches reading content, which the handling
+  note forbids.
+- **A controlled experiment.** The same task attempted from different
+  starting occupancies. The only design that escapes survivorship, because it
+  fixes the task and varies the condition. Costs quota, and it is the honest
+  answer if the cheap proxies also fail.
+- **critic.** An outcome signal on kept-versus-discarded work is exactly what
+  the knee needs and exactly what critic exists to produce. The knee is now a
+  second question blocked behind it, alongside the throughput unit of work.
+
+**Consequence for the dominated-region argument, recorded against our own
+interest.** The idea file claims the region past the knee is Pareto-dominated
+and that a scheduler should refuse it by default. That claim now rests
+entirely on operator observation, with one attempted measurement that neither
+confirms nor refutes it. It should be stated that way wherever it appears,
+and it should NOT be built into a default until a better signal exists.
 
 **SP2. Separate the cache-rebuild causes.** Decompose the 639M
 `cache_creation` tokens into post-compaction rebuild, segment growth, TTL

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -1726,18 +1726,20 @@ func renderSessionTable(sessions []api.Session) string {
 		// denominator. `marvel describe session` carries the reason, and
 		// the fix is usually one runtime.context_window line.
 		//
-		// The two producers report different shapes, which is why "?" is
-		// keyed on the request count rather than on the window alone. The
-		// accountant stamps ContextRequests on every reading and may have
-		// no window; a heartbeat reports a percentage the agent computed
-		// itself, with no token count and no window to report. Keying "?"
-		// on ContextLimit alone would blank the simulator's column.
+		// Keyed on the DECLARED producer (ContextSource), not on which
+		// fields happen to be populated. The two producers report
+		// different shapes, and an accountant reading with an unresolved
+		// window is shaped like a heartbeat, so inferring from shape
+		// rendered real cooperative readings as "?". See aae-orc-ibu9.
 		ctx := "-"
 		switch {
 		case s.ContextAt.IsZero():
-		case s.ContextLimit > 0:
-			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)
-		case s.ContextRequests > 0:
+		case s.ContextLimit == 0 && s.ContextSource != api.ContextSourceHeartbeat:
+			// No window resolved, so a percentage would be a fiction.
+			// The heartbeat is the one legitimate exception: it reports a
+			// percentage the agent computed itself and never needed a
+			// window to do it. Stating the exception explicitly is what
+			// stops a real cooperative reading being rendered absent.
 			ctx = "?"
 		default:
 			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)

--- a/internal/api/bolt.go
+++ b/internal/api/bolt.go
@@ -218,10 +218,24 @@ func (s *Store) rehydrate() error {
 			}
 			// Nothing can refresh a STREAM reading for a session this
 			// daemon did not launch, so drop it rather than serve a frozen
-			// percentage. A heartbeat reading (percentage only, no request
-			// count) is refreshed by the agent itself and survives. See the
-			// persistence note at the top of the file.
-			if sess.ContextRequests > 0 {
+			// percentage. A heartbeat reading is refreshed by the agent
+			// itself and survives. See the persistence note at the top of
+			// the file.
+			//
+			// Keyed on the declared producer, not on "has a request count":
+			// an accountant reading that never resolved a window looks
+			// identical to a heartbeat by field shape, so the old test
+			// dropped some readings it should have kept and kept some it
+			// should have dropped. See aae-orc-ibu9.
+			//
+			// The ContextRequests arm is the pre-ContextSource legacy
+			// case: marvel upgrades in place (daemon reexec), so a bolt
+			// file written by an older binary carries readings with no
+			// declared producer. Only the accountant ever wrote a request
+			// count, so it is a sound legacy marker. Remove once no
+			// supported upgrade path crosses this boundary.
+			if sess.ContextSource == ContextSourceAccountant ||
+				(sess.ContextSource == ContextSourceNone && sess.ContextRequests > 0) {
 				sess.SessionContext = SessionContext{}
 			}
 			s.sessions[sess.Key()] = &sess

--- a/internal/api/bolt_test.go
+++ b/internal/api/bolt_test.go
@@ -351,6 +351,7 @@ func TestBoltStore_StreamContextReadingZeroedOnRehydrate(t *testing.T) {
 	// disk only when something else writes the record. That is the path
 	// this guards.
 	s1.UpdateSessionContext("ws/agent-0", SessionContext{
+		ContextSource: ContextSourceAccountant,
 		ContextTokens: 34136, ContextLimit: 1_000_000, ContextPercent: 3.4136,
 		ContextRequests: 3, ContextModel: "claude-fable-5[1m]",
 	})
@@ -512,5 +513,65 @@ func TestBoltSchemaVersionUnchangedByBudget(t *testing.T) {
 	t.Parallel()
 	if boltSchemaVersion != 1 {
 		t.Errorf("boltSchemaVersion = %d; adding the Budget field must not bump it, because Rehydrate refuses a lower on-disk version too", boltSchemaVersion)
+	}
+}
+
+// TestBoltStore_LegacyAccountantReadingZeroedOnRehydrate covers the
+// upgrade boundary. marvel replaces its own daemon in place (daemon
+// reexec), so the first rehydrate after this change reads records written
+// by a binary that had no ContextSource field. Those readings deserialize
+// with ContextSource == "" and would otherwise survive as a frozen
+// percentage that nothing can refresh.
+//
+// Only the accountant ever wrote a request count, which is what makes it
+// a sound legacy marker. Delete this test together with the compat arm in
+// bolt.go once no supported upgrade path crosses the boundary.
+func TestBoltStore_LegacyAccountantReadingZeroedOnRehydrate(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "marvel.db")
+
+	s1 := NewStore()
+	if err := s1.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt: %v", err)
+	}
+	if err := s1.CreateWorkspace(&Workspace{Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	sess := &Session{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		Runtime: Runtime{Name: "claude", Command: "claude"},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s1.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	// No ContextSource: exactly what an older binary persisted.
+	s1.UpdateSessionContext("ws/agent-0", SessionContext{
+		ContextTokens: 34136, ContextLimit: 1_000_000, ContextPercent: 3.4136,
+		ContextRequests: 3, ContextModel: "claude-fable-5[1m]",
+	})
+	if err := s1.UpdateSession("ws/agent-0", func(live *Session) error {
+		live.PaneID = "%7"
+		return nil
+	}); err != nil {
+		t.Fatalf("persist session: %v", err)
+	}
+	if err := s1.CloseBolt(); err != nil {
+		t.Fatalf("CloseBolt: %v", err)
+	}
+
+	s2 := NewStore()
+	if err := s2.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #2: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.CloseBolt() })
+
+	got, err := s2.GetSession("ws/agent-0")
+	if err != nil {
+		t.Fatalf("get session after rehydrate: %v", err)
+	}
+	if got.ContextPercent != 0 || got.ContextTokens != 0 || !got.ContextAt.IsZero() {
+		t.Errorf("a pre-ContextSource accountant reading survived rehydrate "+
+			"and would render as live: %+v", got.SessionContext)
 	}
 }

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -509,7 +509,23 @@ func (s *Store) UpdateSessionHeartbeat(key string, contextPercent float64, model
 	if !ok {
 		return fmt.Errorf("session %s: %w", key, ErrNotFound)
 	}
-	sess.ContextPercent = contextPercent
+	// A heartbeat is a COMPLETE reading of its own shape, not a partial
+	// update layered over whatever the accountant left behind. Writing
+	// only the percentage used to leave the accountant's ContextRequests
+	// and ContextLimit standing, and three downstream sites read those
+	// leftovers as provenance: a heartbeat landing after an
+	// unresolved-window accountant reading was rendered "?" even though a
+	// real percentage had arrived. Replace the record, then declare who
+	// wrote it. See aae-orc-ibu9.
+	// ContextPeak is deliberately NOT carried across: an accountant peak
+	// is a high-water mark against a resolved window, and a heartbeat
+	// percentage is the agent's own figure against its own denominator.
+	// Carrying it would reintroduce the cross-producer mixing this fixes.
+	sess.SessionContext = SessionContext{
+		ContextSource:  ContextSourceHeartbeat,
+		ContextPercent: contextPercent,
+		ContextModel:   sess.ContextModel,
+	}
 	sess.LastHeartbeat = time.Now().UTC()
 	// A cooperative reporter that knows its model names it (the
 	// statusline feed does); one that doesn't sends "" and any

--- a/internal/api/store_test.go
+++ b/internal/api/store_test.go
@@ -426,3 +426,100 @@ func TestCloneTeamCopiesBudget(t *testing.T) {
 		t.Errorf("mutating a snapshot cleared the store's admission state: %+v", live.Admission)
 	}
 }
+
+// TestHeartbeatAfterUnresolvedAccountantReadingIsNotSuppressed pins the
+// interaction between the two CTX% producers on ONE session.
+//
+// The accountant stamps ContextRequests on every reading and may have no
+// window (codex carries no in-stream contextWindow, so an unresolved
+// window is its expected state, per finding-007). The cooperative
+// heartbeat stamps a percentage the agent computed itself, with no window
+// and no request count. Neither producer clears the other's fields.
+//
+// The renderer in cmd/marvel keys "?" on ContextRequests > 0 when
+// ContextLimit == 0. So once the accountant has touched a session with an
+// unresolved window, a later heartbeat carrying a REAL percentage is
+// still rendered "?" — absence printed over a measurement that exists.
+// That inverts what "?" is supposed to mean: nobody knows, not "the
+// accountant asked first".
+//
+// Reachable in one manifest line: nothing gates context_feed on runtime
+// mode. SupportsStream requires Mode == headless (claude.go:19) while the
+// feed only checks Runtime.ContextFeed (session/projection.go:126), and
+// manifest validation checks the feed's VALUE but never its mode
+// (api/manifest.go:282). A claude role declaring both gets both
+// producers. See aae-orc-ibu9.
+func TestHeartbeatAfterUnresolvedAccountantReadingIsNotSuppressed(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	sess := &Session{
+		Name: "agent-0", Workspace: "test-ws", Team: "agents", Role: "worker",
+		Runtime: Runtime{
+			Name: "claude", Command: "claude",
+			Mode: RuntimeModeHeadless, ContextFeed: ContextFeedStatusline,
+		},
+		State: SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// The accountant reads, but cannot resolve a window.
+	s.UpdateSessionContext("test-ws/agent-0", SessionContext{
+		ContextTokens:   120000,
+		ContextRequests: 3,
+		ContextLimit:    0,
+	})
+
+	// The agent then reports a percentage it computed itself.
+	if err := s.UpdateSessionHeartbeat("test-ws/agent-0", 61.0, "claude-opus-5"); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession("test-ws/agent-0")
+	if got.ContextPercent != 61.0 {
+		t.Fatalf("heartbeat percentage = %v, want 61", got.ContextPercent)
+	}
+	if got.ContextSource != ContextSourceHeartbeat {
+		t.Errorf("ContextSource = %q, want %q: the producer must be declared, "+
+			"not inferred from which fields are populated",
+			got.ContextSource, ContextSourceHeartbeat)
+	}
+	// The heartbeat replaces the record rather than layering over it, so
+	// no accountant leftovers remain to be misread as provenance.
+	if got.ContextRequests != 0 {
+		t.Errorf("ContextRequests = %d after a heartbeat, want 0: a stale "+
+			"request count is what made the renderer print \"?\" over a real "+
+			"cooperative reading", got.ContextRequests)
+	}
+	if got.ContextTokens != 0 || got.ContextLimit != 0 {
+		t.Errorf("stream fields survived a heartbeat: tokens=%d limit=%d, want 0/0",
+			got.ContextTokens, got.ContextLimit)
+	}
+}
+
+// TestAccountantReadingDeclaresItsProducer is the other half: the
+// accountant must stamp its own provenance, or the renderer cannot tell
+// an unresolved window (render "?") from a cooperative percentage
+// (render the number).
+func TestAccountantReadingDeclaresItsProducer(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	sess := &Session{
+		Name: "agent-0", Workspace: "test-ws", Team: "agents", Role: "worker",
+		Runtime: Runtime{Name: "codex", Command: "codex", Mode: RuntimeModeHeadless},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	s.UpdateSessionContext("test-ws/agent-0", SessionContext{
+		ContextSource:   ContextSourceAccountant,
+		ContextTokens:   120000,
+		ContextRequests: 3,
+	})
+	got, _ := s.GetSession("test-ws/agent-0")
+	if got.ContextSource != ContextSourceAccountant {
+		t.Errorf("ContextSource = %q, want %q", got.ContextSource, ContextSourceAccountant)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -168,6 +168,20 @@ type Session struct {
 // The reading is raw occupancy against the model's window, which is not
 // the figure a harness displays to its own user (see internal/usage).
 type SessionContext struct {
+	// ContextSource names which producer wrote this reading. Two write
+	// the same field set from different places (the usage accountant
+	// parsing a stream, and a cooperative agent reporting a percentage
+	// it computed itself), and before this field existed three sites
+	// inferred the producer from which fields happened to be populated:
+	// the CLI renderer, the bolt rehydrate path, and the store's own
+	// reasoning about what to keep.
+	//
+	// Shape is not provenance. An accountant reading that could not
+	// resolve a window is shaped like nothing at all, so a later
+	// cooperative reading on the same session was rendered absent. See
+	// aae-orc-ibu9. Declared, never inferred, exactly as
+	// ContextLimitSource already is for the denominator.
+	ContextSource  ContextSourceKind
 	ContextPercent float64
 	ContextTokens  int
 	ContextLimit   int
@@ -183,6 +197,23 @@ type SessionContext struct {
 	ContextPeak float64
 	ContextAt   time.Time
 }
+
+// ContextSourceKind identifies a CTX% producer.
+type ContextSourceKind string
+
+const (
+	// ContextSourceNone is the zero value: no reading has landed.
+	ContextSourceNone ContextSourceKind = ""
+	// ContextSourceAccountant is the usage accountant reading a parsed
+	// harness stream. Carries a token count and a request count, and may
+	// carry no window at all when the model is unresolved.
+	ContextSourceAccountant ContextSourceKind = "accountant"
+	// ContextSourceHeartbeat is a cooperative agent reporting a
+	// percentage it computed itself over the heartbeat RPC. Carries no
+	// token count, no window, and no request count: the percentage IS
+	// the whole reading.
+	ContextSourceHeartbeat ContextSourceKind = "heartbeat"
+)
 
 // SessionMetrics is one process-sampler reading for a session, rolled up
 // over the pid subtree.

--- a/internal/usage/accountant.go
+++ b/internal/usage/accountant.go
@@ -703,6 +703,7 @@ func (a *Accountant) TeamSpend(workspace, team string) TeamTotals {
 
 func (st *sessionState) reading() api.SessionContext {
 	out := api.SessionContext{
+		ContextSource:      api.ContextSourceAccountant,
 		ContextTokens:      st.tokens,
 		ContextLimit:       st.limit,
 		ContextLimitSource: string(st.limitSrc),


### PR DESCRIPTION
A cooperative heartbeat landing after an unresolved-window accountant reading was rendered `?`, printing absence over a measurement that had arrived. That inverts what `?` is supposed to mean: nobody knows, not "the accountant asked first."

CTX% has two producers writing the same field set with no record of which one wrote it, so three sites inferred provenance from which fields happened to be populated. An accountant reading that could not resolve a window is shaped exactly like a heartbeat, and shape cannot tell them apart.

`SessionContext` gains `ContextSource`, following the `ContextLimitSource` pattern already ratified one field over. The accountant stamps its own source; `UpdateSessionHeartbeat` replaces the record rather than layering a percentage over the previous producer's leftovers.

### Why now

Codex makes this live rather than theoretical. Per finding-007 codex carries no in-stream `contextWindow`, so an unresolved-window accountant state is its expected case, not an exotic one.

It is reachable in one manifest line, and that part is worth recording: **nothing gates `context_feed` on runtime mode.** `SupportsStream` requires headless (`claude.go:19`), the feed only checks `Runtime.ContextFeed` (`session/projection.go:126`), and manifest validation checks the feed's *value* but never its mode (`api/manifest.go:282`). Three doc comments say "interactive" and no code enforces it. A claude role declaring both gets both producers on one session.

### The upgrade boundary

`bolt` rehydrate keeps the old `ContextRequests` test as an explicit legacy arm. marvel replaces its own daemon in place via `daemon reexec`, so the first rehydrate after this change reads records written without the field. Only the accountant ever wrote a request count, which makes it a sound legacy marker. It is commented for deletion once no supported upgrade path crosses the boundary. An existing test caught this before it shipped.

### Cost of merge

Additive field with a zero value, plus one behavior change: a heartbeat now clears the stream fields on the session it writes, which is what makes the record describe one producer's reading rather than two. `ContextPeak` is deliberately not carried across, since an accountant high-water mark is measured against a resolved window and a heartbeat percentage is the agent's own figure.

Four tests: the suppression case, the accountant's declaration, the upgrade boundary, one fixture update. Full suite and `golangci-lint` green.

Refs #142