### PR TITLE
The feed rung, the readiness event, the dropped rate limits, and zero leaked sockets

### DIFF
--- a/_kos/probes/probe-shift-handoff-artifact.md
+++ b/_kos/probes/probe-shift-handoff-artifact.md
@@ -1,0 +1,647 @@
+# probe-shift-handoff-artifact: what a successor reads, when its predecessor writes it, and what that costs
+
+**Date:** 2026-08-08
+**Status:** DESIGN PROBE. Not a finding. Nothing here is measured against a
+running handoff, because none exists. The parts I read out of this
+repository or ran are marked MEASURED; the parts I reasoned to are marked
+HYPOTHESIS; the parts I took from a document rather than from software are
+marked INFERRED.
+**Question:** `question-shift-triggers` (this is its blocking measurement,
+per finding-018 consequence 2). Bears on `question-marvel-graceful-stop`
+and `question-agent-communication-broker`.
+**Designs within:** `elem-handoff-schema-ownership` (bedrock, ratified
+2026-08-01): marvel owns the schema, meaning, location, lifecycle, and
+generation binding; the departing agent owns the content. That split is
+settled and is not reopened below.
+**Prior:** finding-018 (cold-shift wall clock, price classes),
+finding-016 (compaction median, what survives a compaction),
+finding-011 (the statusline side channel), finding-024 (policy
+projection), finding-015 (a finished headless role reads as a crash).
+
+## Why this is the blocking item and not a nicety
+
+finding-018 measured a one-role shift at 8.92 s median against
+compaction's 154 s median (finding-016), then said plainly that the two
+numbers do not measure the same thing. A compaction preserves the working
+context, compressed. A shift preserves nothing. Marvel today hands the
+successor an empty desk, and the shift is fast partly because packing the
+desk is work it never does.
+
+So the end-to-end comparison is undetermined, and it stays undetermined
+until a successor has something to read. This document designs that
+something, prices it, and pre-registers the experiment that would settle
+the comparison.
+
+## What I established from the code, before designing anything
+
+| fact | how |
+|---|---|
+| `grep -ri handoff --include="*.go"` returns 0 hits repo-wide | MEASURED, re-run in this worktree |
+| `shiftDrain` deletes one old-gen session per tick via `sessMgr.Delete`, which calls `retireInstance` then `KillPane`. No signal, no wait, no ack | MEASURED, `internal/team/controller.go`, `internal/session/manager.go:868` |
+| `instanceTeardownGrace = 3 * time.Second` bounds marvel's own stream teardown, not the agent's turn | MEASURED, `internal/session/manager.go:809` |
+| `ReconcileInterval = 2 * time.Second`; `reconcileShift` advances at most one phase per tick | MEASURED, `internal/daemon/daemon.go:48` |
+| Generation already exists and is already in the session name: `<team>-<role>-g<gen>-<index>` | MEASURED, `shiftLaunch` |
+| Marvel already constructs the pane environment: `MARVEL_SESSION`, `MARVEL_ROLE`, `MARVEL_TEAM`, `MARVEL_WORKSPACE`, `MARVEL_SOCKET` | MEASURED, `internal/runtime/adapter.go:160` |
+| An in-pane process already calls the daemon back over `MARVEL_SOCKET` using those env vars: `marvel ctx-forward` posting a `heartbeat` | MEASURED, `cmd/marvel/ctxforward.go:206` |
+| Marvel already writes a per-session file the harness reads, verbatim, and already grades adapters on whether they can read one (`ProjectionTarget.Supported`, `StatuslineFeeder`) | MEASURED, `internal/session/projection.go`, `internal/runtime/adapter.go` |
+| Marvel does not set a pane working directory: no `-c` flag anywhere in the tmux driver, so pane cwd is inherited and marvel does not own it | MEASURED, `internal/tmux/driver.go` |
+| `marvel capture` returns literal pane scrollback, and `NewSession` raises `history-limit` above tmux's 2000-line default | MEASURED, `internal/tmux/driver.go:197`, `handleCapture` |
+| The event ring already carries per-turn token counts (`agent.turn.completed ... tokens in=19235 out=5`) | MEASURED, quoted transcript in finding-015 |
+| Marvel emits no event when a successor becomes ready | MEASURED by finding-018, re-confirmed against `allReady` |
+
+Two of these are load-bearing and easy to miss. Marvel already owns a
+one-way file contract with the harness (projection) and already owns a
+one-way callback contract from the pane (ctx-forward). A handoff needs
+exactly those two contracts and one thing neither provides: a way for
+marvel to ask.
+
+## 1. What the artifact is
+
+### The envelope
+
+Marvel owns every field except two. Proposed v1, and `schema_version` is
+required because every declarative contract in this fleet carries one:
+
+```json
+{
+  "schema_version": 1,
+  "workspace": "mixed",
+  "team": "matrix",
+  "role": "analyst",
+  "predecessor": {
+    "session_key": "mixed/matrix-analyst-g2-0",
+    "generation": 2,
+    "runtime": "claude",
+    "model": "claude-haiku-4-5"
+  },
+  "successor_generation": 3,
+  "requested_at": "2026-08-08T17:03:11Z",
+  "finalized_at": "2026-08-08T17:03:19Z",
+  "reason": "shift",
+  "completeness": "authored",
+  "content_origin": "agent",
+  "content_type": "text/markdown",
+  "content_tokens_estimate": 1840,
+  "content": "...verbatim, agent-authored, never read by marvel..."
+}
+```
+
+`content` and `content_type` are the departing agent's. Marvel writes
+everything else and never parses, summarizes, rewrites, or truncates
+`content`. That is the ratified split, and section 5 argues it is also the
+technically correct one under this project's own measured position on
+summarization.
+
+Three envelope fields carry the design's honesty and deserve naming:
+
+- **`completeness`**: `authored` (the agent finished), `partial` (the
+  agent acknowledged and a partial write landed before the deadline),
+  `absent` (nothing arrived), `involuntary` (marvel attached observations
+  because the agent could not be asked). Marvel owns this field because it
+  is a fact about the transaction, not a judgment about the content. The
+  agent may declare `authored` or `partial`; marvel overwrites with
+  `absent` or `involuntary` when it must.
+- **`content_origin`**: `agent` or `observed`. The involuntary path
+  (section 2) attaches pane scrollback and the session's event slice,
+  which are props rather than an account. A successor must be able to tell
+  a predecessor's reasoning from a transcript of its keystrokes.
+- **`model`**: finding-016's ruling that model identity is part of a
+  reading's identity applies here too. A handoff authored under one model
+  and read under another is not obviously comparable, and a successor that
+  can see the discontinuity can act on it.
+
+The content field is untrusted data, not instruction. Marvel cannot
+enforce that, and section 2 FM-D says so plainly.
+
+### Location
+
+Requirements, in order of how much they constrain:
+
+1. A successor must find it without being told in prose.
+2. It must survive a daemon restart, because a session outlives the daemon
+   that spawned it (adopt-on-restart is shipped).
+3. Marvel must not write it into the user's working tree. Marvel does not
+   own a pane's cwd (MEASURED: no `-c` in the driver), and the repo rule
+   is that marvel never deletes user files. A retention policy over files
+   in someone's project directory would collide with both.
+
+Proposal: `~/.marvel/handoff/<workspace>/<team>/<role>/g<N>.json`, resolved
+through `paths.Layout` alongside `StateDir()` and `RunDir()`, dirs 0700 and
+files 0600 per the layout's existing mode discipline.
+
+Not the projection directory, and the reason is recorded in the code
+already. `defaultProjectionDir` carries a comment explaining that a
+pid-keyed temp directory broke adoption: a restarted daemon computed a
+different path, rewrote a file no agent was reading, and a policy edit
+appeared to apply while changing nothing. A handoff is more durable than a
+projected settings file, not less, so it belongs under the layout's stable
+home rather than a temp directory.
+
+Discovery is two environment variables added to `BaseEnv`, which is the
+only discovery channel that is both harness-agnostic and already shipped:
+
+- `MARVEL_HANDOFF_IN`: absolute path to the predecessor's artifact.
+  **Set only when a bound predecessor artifact exists.** Absence is the
+  signal that the successor is starting with nothing.
+- `MARVEL_HANDOFF_OUT`: absolute path this session writes to when asked.
+
+Setting `MARVEL_HANDOFF_IN` to a path that does not exist would be the
+silent-wrong failure `internal/usage/doc.go` already refuses in the
+denominator case. Absent means absent.
+
+### Generation binding, and how a stale read is prevented
+
+The rule is strict predecessor binding: marvel sets `MARVEL_HANDOFF_IN`
+for a session at generation N only if an artifact exists whose
+`successor_generation == N`. Not "the newest artifact for this role", and
+not "the highest generation below N".
+
+That distinction is the whole answer to "cannot read a stale one". If
+generation N-1 left nothing, the newest artifact on disk is from N-2, and
+handing it forward would give the successor a confident account of a state
+two generations gone. A gap must read as a gap.
+
+Three cases the binding has to survive, all reachable with shipped code:
+
+- **Rollback.** `abortStuckShift` rolls a failed shift back to
+  `OldGeneration`. If the aborted generation wrote an artifact, that
+  generation never operated, so its artifact must not be handed to the
+  next attempt. Marvel marks it `superseded: true` rather than deleting it
+  (the no-deletion posture applies to a file whose content the agent
+  authored), and superseded artifacts are never bound.
+- **Multiple replicas.** A role with N replicas produces N artifacts per
+  generation. The filename needs the replica index, and binding is
+  index-to-index. Whether index-to-index is even meaningful when
+  `nextIndex` does not gap-fill is an open sub-question; I have not
+  resolved it and it is listed in section 8.
+- **Restart, not shift.** A restarted replica keeps its generation. It is
+  not a successor to itself, so a restart must not bind. Binding on
+  `successor_generation` rather than on session key gets this right by
+  construction.
+
+### Lifecycle
+
+Requested at the moment `allReady` currently flips a shift to draining.
+Finalized at write or at deadline. Read once, at the successor's spawn.
+Retained per role as a bounded ring (three generations is a starting
+number, no evidence behind it) so an operator can read what was lost.
+Never mutated after finalization except for the `superseded` flag.
+
+Bounded retention follows this codebase's own habits rather than
+inventing one: the event ring is bounded, and `ReapDead` keeps at most one
+crashed marker per role.
+
+## 2. When it is written
+
+### The change to the state machine
+
+Today: `ShiftLaunching` -> (`allReady`) -> `ShiftDraining` -> kill.
+
+Smallest change that creates a window: one phase and one deadline.
+
+```
+ShiftLaunching -> (allReady) -> ShiftHandoff -> (all finalized OR deadline) -> ShiftDraining
+```
+
+- New `ShiftPhase` constant `ShiftHandoff`.
+- New `ShiftState.HandoffDeadline time.Time`, set on entry.
+- New `Role.HandoffGrace` (duration) and `Role.Handoff` (`best-effort` |
+  `off`), following how `MaxRestarts` and `RestartPolicy` already sit on
+  `Role`.
+- `reconcileShift` gains one case. `shiftDrain` is untouched.
+- `abortStuckShift` gains the new phase in its rollback handling. This is
+  a real touchpoint, not a formality: an abort inside handoff must not
+  leave a half-written artifact bound.
+
+`Handoff = off` reproduces today's behavior exactly, which is what keeps
+every existing manifest's timings intact.
+
+### What it costs against the measured 8.92 s
+
+The measured per-role cost is four reconcile ticks (7.99 s at the 2 s
+default). The handoff phase adds one tick to observe, plus the agent's
+authoring time rounded up to a tick.
+
+MEASURED baseline, INFERRED additions:
+
+| case | added ticks per role | added seconds at 2 s tick |
+|---|---|---|
+| `Handoff = off` | 0 | 0 |
+| predecessor pane already gone | 1 | 2.0 |
+| no acknowledgement within one tick | 1 | 2.0 |
+| agent authors in 8 s | 5 | 10.0 |
+| agent authors in 30 s | 16 | 32.0 |
+| agent acks then never finishes, 60 s grace | 31 | 62.0 |
+
+**This is the design's largest liability and I will not soften it.** A
+three-role team whose agents each burn a 60 s grace costs 3 * (7.99 + 62)
+= 210 s, which loses to the 154 s compaction that finding-018's headline
+beat by an order. The handoff does not merely add cost; at a long grace it
+can invert the finding it was built to complete.
+
+Two consequences follow. First, the grace default must be short, and I
+have no evidence for a number, so section 7 pre-registers measuring it
+rather than guessing it. Second, the unresponsive cases must short-circuit
+rather than wait the grace out, which is what the two-step protocol below
+buys.
+
+### The two-step protocol, and why the second step is cheap and the first is not
+
+**Agent to marvel is already solved in shape.** `marvel handoff write`,
+invoked from inside the pane, reads `MARVEL_SOCKET`, `MARVEL_WORKSPACE`,
+`MARVEL_SESSION` from the environment and posts to a new daemon method
+alongside `heartbeat`. This is `marvel ctx-forward` with a different verb.
+No new transport, no new trust boundary, and the daemon's request
+dispatcher is a switch over method names (MEASURED, `handleRWC`).
+
+**Marvel to agent is not solved, and this is where the design stops.**
+What ships today is `marvel inject`, which is `tmux send-keys` and works
+only against an interactive pane, plus nothing at all for headless. The
+clean channel for "marvel asks an agent to do something" is the M2 per-team
+bus, which is unbuilt and ruled to be external NATS supervised by marvel.
+**I name that dependency and stop. I am not inventing a transport.**
+
+What can ship before the bus is a capability ladder that mirrors one this
+codebase already has. `ProjectionTarget.Supported` grades adapters on
+whether the harness reads a settings file marvel chooses, and marvel's
+ruling for adapters that cannot is to log the policy as advisory rather
+than write into the user's own config. The same grading applies:
+
+| adapter capability | request delivery | artifact |
+|---|---|---|
+| harness exposes a per-turn hook surface marvel already writes (the projection path) | marvel drops a request file; the hook checks it at a turn boundary and runs `marvel handoff write` | `authored` |
+| no hook surface, pane alive | none available pre-bus | `involuntary` |
+| pane gone | none possible | `involuntary` or `absent` |
+
+I have NOT verified that any harness has a hook that fires at a usable
+point. finding-011 established that Claude Code exposes `statusLine` and
+`subagentStatusLine` and that marvel writes its settings verbatim, which
+establishes the mechanism but not the event. Asserting a specific hook name
+here would be reading a document and calling it software. Section 7
+registers verifying the hook surface as the first step of the follow-on
+probe, and section 8 records it as unestablished.
+
+### The involuntary path, which is the answer to the motivating case
+
+The prompt's objection is correct and it deserves a direct answer: a
+mechanism that works only when the agent is healthy does not serve the case
+that motivates shifts.
+
+Two halves to the answer.
+
+**Half one: the primary trigger's agent IS healthy.** The trigger
+`question-shift-triggers` is actually about is context pressure. An agent
+at 95% occupancy is not sick, it is full. It can still author. So the
+cooperative path does serve the leading trigger, and saying otherwise
+overstates the problem.
+
+**Half two: every other trigger gets an involuntary artifact, built only
+from things marvel already holds.** When the agent cannot be asked, marvel
+attaches, verbatim:
+
+- the last N lines of pane scrollback (`marvel capture` is shipped, and
+  `NewSession` already raises `history-limit` above tmux's default), and
+- the session's slice of the event ring, which already carries the 12
+  `agent.*` kinds including per-turn token counts.
+
+Marvel is copying, not summarizing, which is why this does not violate
+section 5's discipline and does not violate the ownership ruling either:
+marvel is not writing the departing agent's account, it is attaching a
+transcript, and `content_origin: observed` says which one the successor is
+holding.
+
+HYPOTHESIS, and it is testable as arm A1 in section 3: an involuntary
+artifact is worth strictly more than nothing and strictly less than an
+authored one. If it turns out to be worth nothing, the fallback should not
+be built, and the experiment is designed to say so.
+
+### Named failure modes
+
+- **FM-A, predecessor already dead.** Pane gone; `ReapDead` has marked the
+  session crashed, or `HasPane` reports false. No request is possible.
+  Artifact is `involuntary` if scrollback survives the pane (it does not,
+  once the pane is destroyed, which means the involuntary capture must be
+  taken at the moment of the request, not at drain), else `absent`. Cost:
+  one tick. **This ordering constraint is real and easy to get wrong: the
+  observed content must be captured before anything kills anything.**
+- **FM-B, alive but not listening.** No adapter courier, or the harness is
+  mid-tool-call. No acknowledgement within one tick, so marvel classifies
+  the session `unreachable` and proceeds. This is the mechanism that keeps
+  the common unhealthy case at one tick instead of a full grace, and it is
+  the reason the protocol is ack-then-write rather than a single write.
+- **FM-C, acks then misses the deadline.** `partial` if bytes landed,
+  `absent` otherwise. Costs the full grace. This is the expensive case in
+  the table above.
+- **FM-D, writes something wrong or hostile.** Marvel does not interpret
+  content, so marvel cannot detect this. A predecessor's authored text
+  becomes a successor's read text, which is exactly the agent-to-agent
+  injection hazard finding-016 already records as an ordinary rather than
+  exotic event. The envelope can label content as data; it cannot make a
+  model treat it that way. Recorded as a limit, not solved.
+- **FM-E, shift times out inside the handoff phase.** `abortStuckShift`
+  fires and rolls back. The default `ShiftTimeout` is 10 minutes
+  (MEASURED, `defaultShiftTimeout`), so a grace long enough to trip it
+  would have to be pathological, but the phase must still be handled in
+  the abort path.
+- **FM-F, a headless role that already finished.** finding-015 established
+  that a headless role which completes its job reads as `crashed`. Such a
+  session has no turn to be asked at, and treating its exit as a handoff
+  failure would be wrong. A finished headless job is not a shift's
+  predecessor in any interesting sense; it should be excluded from the
+  handoff phase rather than counted as `absent`.
+
+### The relationship to graceful stop
+
+`question-marvel-graceful-stop` asks for exactly this window under a
+different verb: announce, signal, wait a per-role grace, then destroy. That
+node has been open since 2026-05-13 and is explicit that nothing in marvel
+sends a graceful-shutdown signal or waits out a grace period.
+
+These should be one mechanism with two callers, not two mechanisms. The
+per-role grace field, the ack protocol, and the capability ladder are the
+same in both. If handoff ships its own private drain, graceful stop will
+later ship a second one and they will disagree. Naming this now is cheaper
+than reconciling it later.
+
+## 3. What the successor does with it, and how that becomes measurable
+
+### The read
+
+The successor's adapter reads `MARVEL_HANDOFF_IN` and places `content`
+into the session's opening context. Delivery is per-adapter, same ladder as
+the request: an adapter with a settings or system-prompt surface can do it
+at spawn; the generic fallback cannot, and its sessions get the env var
+pointing at a readable file with nothing that makes the model look at it.
+
+That last clause is a genuine hole and I am not going to paper over it.
+Setting an environment variable makes the path available to the process. It
+does not make the model read the file. Whether the model acts on it is a
+per-adapter prompt question, and marvel's independence requirement means
+the CONTRACT (envelope, location, binding) is harness-agnostic while the
+DELIVERY is graded. That is the same shape as policy projection, where
+marvel's answer for an adapter with no settings surface is to log the
+policy as advisory rather than write into the user's own config.
+
+### The experiment
+
+finding-018 said its measurement could not distinguish "one turn suffices"
+from "fifteen turns needed" because the artifact that would define
+sufficiency did not exist. The metric that closes that gap:
+
+**Turns to recovery (TTR).** Set a task with a pre-declared, machine
+checkable completion predicate. Run a predecessor to a fixed state short of
+the predicate. Shift. Count the successor's turns until it satisfies the
+predicate.
+
+Arms:
+
+| arm | what it is | what it establishes |
+|---|---|---|
+| A0 | shift, no artifact (today) | baseline; the number finding-018 could not obtain |
+| A1 | shift, involuntary artifact (scrollback + event slice) | whether the non-cooperative fallback is worth building |
+| A2 | shift, authored artifact | the cooperative case |
+| A3 | no shift, predecessor continues | control; TTR must be 0, proving the predicate is satisfiable and the task is not the problem |
+| A4 | compaction instead of a shift | the actual comparator, and the arm that settles finding-018's open verdict |
+
+The end-to-end comparison the record calls undetermined is A2 against A4,
+priced in both wall clock and dollars.
+
+Instrumentation is already built. Turn counts and token counts come from
+`agent.turn.completed` in the event ring; wall clock comes from the ring's
+RFC3339 stamps; dollars come from the price classes finding-018 derived.
+The one instrument that is missing is the readiness event finding-018
+already asked for, and the handoff phase makes that worse rather than
+better: it adds three more unobservable instants (requested, acknowledged,
+finalized). The phase should ship with its events from the first commit.
+
+Confounds to pre-register, because the first two can silently produce a
+null result that looks like a finding:
+
+- **The task must have private working state.** If the predecessor's state
+  is recoverable from the filesystem, a coding task with the work on disk,
+  then TTR is near zero in every arm and the experiment measures nothing.
+  The task needs state that lives only in the session: a plan, a
+  ruled-out list, a hypothesis under test, a judgment about which of three
+  approaches is dead. This is the single largest design risk in the
+  experiment.
+- **Authoring quality is a free variable.** The same predecessor prompt
+  must author in every A2 run, and cross-run variance must be reported
+  rather than averaged into a median.
+- **The cache identity trap.** finding-018's three-field rule applies:
+  cold requires `cache_creation > 0` AND `cache_read == 0` AND
+  `is_error == false`. Both-zero is undetermined.
+- **Model identity.** Per finding-016, every number is per-model and a
+  mid-run model change invalidates rather than averages.
+- **Credentials.** finding-018's arm D could not run a real harness under
+  an isolated HOME because the isolated HOME carries no credentials. This
+  experiment needs a real harness under marvel, which is exactly the
+  combination that failed. Solving it is a prerequisite, not a detail, and
+  it is the most likely reason this probe's follow-on does not run as
+  designed.
+
+## 4. How much it may cost
+
+All prices from finding-018's derived classes (claude-haiku-4-5, five
+runs, reproduced to 0.15%): output $5.011/MTok, cache read $0.245/MTok,
+cache write $2.145/MTok, write:read ratio 8.77x. Everything in this section
+is INFERRED arithmetic over those MEASURED prices, and per finding-016 it
+is model-dependent.
+
+**Writing.** Three components, and the one that dominates is the one that
+is easy to miss.
+
+| component | tokens | class | cost |
+|---|---|---|---|
+| predecessor re-reads its context to author | 467,446 (finding-016 p50 occupancy at compaction) | cache read | $0.1145 |
+| predecessor emits the handoff | 2,000 | output | $0.0100 |
+| **write subtotal** | | | **$0.1245** |
+
+The authoring turn's re-read is 92% of the cost of writing a handoff. That
+is not a handoff-specific cost, it is what any turn at that occupancy costs,
+which is the point: **asking for a handoff at the pressure point costs
+approximately one ordinary turn.**
+
+**Reading.** The successor is cold, so the artifact lands in cache-write
+class on its first request.
+
+| handoff size | cache write cost | as % of the measured cold re-warm ($0.1663 for 77.5k) |
+|---|---|---|
+| 2,000 tokens | $0.0043 | 2.6% |
+| 4,000 tokens | $0.0086 | 5.2% |
+| 20,000 tokens | $0.0429 | 25.8% |
+
+**Total for one cooperative handoff at the pressure point: about $0.13.**
+
+**What it has to save to pay for itself.** A successor turn at 95k
+occupancy costs 95,428 * $0.245/MTok = $0.0234 in cache read. So the
+artifact breaks even if it saves roughly five successor turns. At the
+occupancy where shifts actually get triggered, a turn costs $0.1145, and
+the artifact breaks even if it saves **one turn**.
+
+That is the useful shape of the answer, and it holds regardless of where
+the true TTR lands: the cost of the handoff is bounded by roughly one turn
+at the trigger point, so the artifact is cheap exactly in the regime where
+it is needed. HYPOTHESIS, since the saving is the unmeasured quantity the
+section 3 experiment exists to obtain.
+
+**On a ceiling.** A manifest-declared token cap is tempting and I recommend
+against a bespoke one. Truncating is interpreting-adjacent, and refusing an
+over-cap write discards everything the agent just spent a turn producing.
+Marvel should record `content_tokens_estimate` and let a hard ceiling live
+where ceilings already live: `internal/admission` and the declared team
+budget, which is the shipped surface for refusing over-budget work.
+
+## 5. What the stage-rig discipline implies
+
+Orc charter F25 rules that backdrops are AUTHORED and never auto-summarized
+from props, and cites the measured basis: 97.5% recall with verbatim
+artifacts against 19% under recursive summarization (CogCanvas, arXiv
+2601.00821).
+
+**A handoff is exactly a backdrop.** Shape preserved, detail absent,
+written so a successor can orient. Four things follow, and the third and
+fourth are not obvious.
+
+1. **Marvel must never generate the handoff by summarizing the
+   predecessor's context.** This is the strongest constraint in the whole
+   design, and it is what rules out the otherwise attractive option of
+   having marvel read the session stream it already parses and produce a
+   summary with no agent cooperation at all. That option would work in
+   every failure mode, require no bus, and cost nothing at the pressure
+   point. It is ruled out by the project's own measurement, not by taste.
+2. **The departing agent authoring its own handoff IS an authored
+   backdrop.** So the 2026-08-01 ownership ruling and F25 agree, and the
+   ruling is not merely a governance preference: it is the arrangement
+   F25's evidence points at. That is worth stating because it means the
+   design has no live tension with F25 on the cooperative path.
+3. **The involuntary path is props, not a backdrop, and that is correct.**
+   When nobody can author a backdrop, the F25-consistent move is to hand
+   forward the props verbatim rather than have marvel paint one. Pane
+   scrollback and the event slice are verbatim by construction.
+   `content_origin` exists so a successor is never confused about which it
+   holds.
+4. **The open risk F25 does not cover: chained authorship.** Each
+   generation authors its backdrop from a context that already contained
+   the previous backdrop. The CogCanvas figure compares verbatim against
+   summarized once; it says nothing about drift across eight authored
+   generations, where each author is faithful and the chain still walks
+   away from the ground truth. This is a genuinely new sub-question raised
+   by putting F25 and shift mechanics together, and section 7 pre-registers
+   a chained arm to test it.
+
+## 6. Dependencies named, and where I stopped
+
+- **M2 per-team bus.** The general marvel-to-agent request channel. Ruled
+  to be external NATS supervised by marvel; unbuilt. Named and stopped. No
+  transport invented here. Pre-bus, delivery degrades along the adapter
+  capability ladder in section 2.
+- **`question-marvel-graceful-stop`.** Same drain window, different verb.
+  Should be one mechanism with two callers.
+- **The readiness event** (finding-018 consequence 3). Already missing; the
+  handoff phase adds three more unobservable instants. Ship the events with
+  the phase.
+- **Harness credentials under an isolated HOME.** finding-018's arm D could
+  not run for this reason, and section 3's experiment needs the same
+  combination that failed. This is the most likely blocker on the follow-on.
+- **`internal/admission`** for a hard token ceiling, rather than a bespoke
+  limit.
+
+## 7. Pre-registered success signals for the follow-on probe
+
+Written down now so a later run can fail honestly against them. Each is
+stated as a bar, with the reading that follows from missing it.
+
+- **S0 (gate, run first).** Establish whether any adapter's harness exposes
+  a hook that fires at a turn boundary and can run a command. If none does,
+  the cooperative path has no pre-bus delivery at all, and arm A2 must be
+  run by hand-injecting the request, reported as a deviation the way
+  finding-018 reported its arm D.
+- **S1.** TTR(A0) minus TTR(A2) is at least 3 turns on a private-state
+  task. If A0 and A2 land within 1 turn, the authored artifact is
+  decoration for this task class and the probe must report that rather
+  than re-running until it is not.
+- **S2.** A2's end-to-end total (control plane + handoff grace + TTR turns
+  x measured turn duration) beats 154 s for a one-role team. **If it does
+  not, finding-018's headline inverts once the handoff is included, and
+  that inversion is the finding.** This is the pre-registered way for this
+  design to lose.
+- **S3.** A1 beats A0 by at least 1 turn. Below that bar the involuntary
+  fallback is not worth building, and the design should drop to
+  cooperative-or-nothing.
+- **S4.** Authoring completes within 30 s in at least 80% of trials at
+  400k+ occupancy. Missing this bar means the grace default must rise, and
+  section 2's cost table says the design gets materially worse when it
+  does. This is the number that decides whether the whole approach is
+  affordable.
+- **S5 (chained, section 5 item 4).** Across a chain of eight shifts on one
+  task, generation-8 TTR must not exceed generation-1 TTR by more than 2x.
+  If it does, chained authored handoff drifts, and the design needs a
+  props-anchored variant where each generation forwards the original
+  verbatim anchor alongside its own backdrop.
+- **Reporting commitment.** A null or inverted result on any of S1 through
+  S5 is reported as the result. No arm is re-run with a changed task after
+  seeing its number.
+
+## 8. What I could not establish
+
+- **Whether any harness can be asked at all before the bus.** No hook name
+  is asserted here because I did not exercise one. This is S0 and it gates
+  the cooperative path.
+- **Whether the model reads what the env var points at.** Marvel sets pane
+  environment (MEASURED). That the model inside the harness attends to
+  `MARVEL_HANDOFF_IN` is a per-adapter prompt question with no evidence
+  behind it.
+- **The right grace default.** I have no data. Guessing one and shipping it
+  would be exactly the mistake finding-016 recorded, mistaking a configured
+  value for a law.
+- **Replica-indexed binding.** With N replicas per role, whether
+  index-to-index binding is meaningful is unresolved, and `nextIndex` does
+  not gap-fill, so indices are not stable identities across generations.
+- **Whether TTR is the right metric.** It measures speed of recovery, not
+  quality of the successor's first decision. A successor that recovers fast
+  and decides badly scores well. Quality comparison is what critic exists
+  for and it is out of scope here.
+- **Whether an artifact can harm.** An authored backdrop carries the
+  predecessor's mistaken beliefs forward with the same confidence as its
+  correct ones. Unmeasured, and A2-worse-than-A0 is a possible outcome the
+  experiment must be allowed to return.
+- **Prices.** One model, one machine, one day (finding-018). Section 4 is
+  arithmetic over those, and every figure moves with the model.
+
+## 9. Per claim: the alternative the evidence could have excluded
+
+| claim | status | alternative it excludes | could it have come out otherwise |
+|---|---|---|---|
+| no handoff exists anywhere in the repo | MEASURED, grep re-run | that one exists under another name | yes; a single hit refutes it |
+| `shiftDrain` kills with no signal-then-wait | MEASURED, read | that a grace exists somewhere in the path | yes; `instanceTeardownGrace` was checked and bounds marvel's teardown, not the agent's turn |
+| marvel already sets pane env and already takes an in-pane callback | MEASURED, `adapter.go:160`, `ctxforward.go:206` | that a handoff needs new plumbing in both directions | yes; it needs new plumbing in one direction only |
+| marvel does not own pane cwd | MEASURED, no `-c` in the driver | that the workspace directory is a viable artifact location | yes; one `-c` would have made cwd marvel's to choose |
+| the temp-dir location is wrong for a handoff | MEASURED (the code comments the failure it caused for projection) | that reusing `ProjectionDir` is fine | yes; the comment records the adoption bug that argues against it |
+| a handoff phase costs 1 tick plus authoring time | INFERRED from the measured 4-ticks-per-role structure | nothing | no; arithmetic over finding-018's structure |
+| a 60 s grace on three roles loses to compaction | INFERRED | nothing | no; arithmetic, and stated because it is the design's liability |
+| the write costs about one turn at the trigger point | INFERRED from measured prices | that the handoff is expensive relative to a shift | yes; a 10x price ratio the other way would have made it dominant |
+| marvel-side summarization is ruled out | INFERRED from F25 and its cited measurement | that marvel could produce the artifact alone, with no bus and no cooperation | yes; and this is the cheapest option the discipline forbids |
+| the cooperative path serves the context-pressure trigger | HYPOTHESIS | that no trigger is served by a cooperative mechanism | yes; if a full agent cannot author, it fails |
+| an involuntary artifact beats nothing | HYPOTHESIS | nothing yet | yes; S3 is the pre-registered test |
+| an artifact reduces TTR | HYPOTHESIS | nothing yet | yes; S1 is the pre-registered test, and A2-worse-than-A0 is permitted to be the answer |
+
+## 10. Smallest first slice, if this is built
+
+Ordered so each step is independently useful and none needs the bus:
+
+1. Envelope type, location under `paths.Layout`, generation binding, the
+   two env vars. Nothing writes an artifact yet; a hand-placed file proves
+   the read path.
+2. `marvel handoff write` plus the daemon method. Agent-to-marvel only, the
+   `ctx-forward` shape. Now an agent that is told to can write one.
+3. `ShiftHandoff` phase with `Handoff = off` as the default, the three
+   events, and the abort-path handling. Zero behavior change for existing
+   manifests; the phase is observable before it is load-bearing.
+4. The involuntary path: capture scrollback and the event slice at request
+   time, before anything is killed. This is the step that works for every
+   adapter and needs no harness cooperation, which makes it the one worth
+   building before the cooperative path is deliverable.
+5. Per-adapter courier, gated on S0.
+
+Steps 1 through 4 are all buildable today. Step 5 is where the bus
+dependency binds.

--- a/cmd/marvel/ctxforward.go
+++ b/cmd/marvel/ctxforward.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"time"
 
 	"github.com/arcavenae/marvel/internal/daemon"
 	"github.com/spf13/cobra"
@@ -29,6 +30,13 @@ import (
 // only interactive CTX% source marvel has, from reporting a confidently
 // wrong number if the field's meaning ever shifts under it.
 //
+// The same payload also carries the ACCOUNT's rate-limit headroom, which
+// the harness relays from response headers it already received. That
+// figure is captured and shown in the pane but never forwarded, because
+// it belongs to the account rather than to the session whose heartbeat
+// this is; see the rateLimits type for why a per-session column of it
+// would be a category error.
+//
 // Failure posture: this runs on every statusline tick inside an agent's
 // pane, so it never exits nonzero and never prints errors — a broken
 // feed shows as a silent gap in CTX%, diagnosed via `marvel describe
@@ -37,8 +45,17 @@ import (
 // figures into the pane; see renderForward.
 
 // statuslinePayload is the subset of Claude Code's statusline JSON that
-// the forwarder reads. Fields the forwarder does not use are omitted —
-// the harness owns this schema, marvel just picks out context and cost.
+// the forwarder reads. Fields the forwarder does not use are omitted; the
+// harness owns this schema, marvel picks out context, cost, and the
+// account's rate-limit headroom.
+//
+// Omitting a field here is not free, and rate_limits is the demonstration:
+// encoding/json drops unknown keys without complaint, so a field the
+// harness sends and this struct does not declare is discarded in flight
+// with no error, no log line, and nothing to notice. rate_limits arrived
+// on every tick of every statusline-fed session and was thrown away that
+// way until it was declared. Treat any addition to the payload as data
+// this file is silently refusing until proven otherwise.
 //
 // Shape verified against Claude Code 2.1.226 on 2026-08-08, three ways:
 // the payload builder inside the shipped binary, the statusline schema
@@ -55,11 +72,112 @@ type statuslinePayload struct {
 		TotalCostUSD float64 `json:"total_cost_usd"`
 	} `json:"cost"`
 	ContextWindow *contextWindow `json:"context_window"`
+	RateLimits    *rateLimits    `json:"rate_limits"`
 	Tasks         []struct {
 		Status            string `json:"status"`
 		TokenCount        int    `json:"tokenCount"`
 		ContextWindowSize int    `json:"contextWindowSize"`
 	} `json:"tasks"`
+}
+
+// rateLimits is the account's subscription headroom, which the harness
+// relays from the response headers it already received. Reading it here
+// costs nothing: the number arrived on a request the fleet was already
+// making, on a hook marvel already installs.
+//
+// Scope is the point. Occupancy is per-session; headroom is per-ACCOUNT.
+// Every session on one account reports the SAME two windows, so N
+// sessions are N reporters of one quantity rather than N quantities.
+// Summing them, averaging them, or rendering a per-session column of
+// them are all category errors, and the last is the one that looks
+// natural next to the existing CTX% column. That is why this block is
+// captured and displayed but deliberately NOT sent over the heartbeat
+// RPC, whose every field is keyed to a session.
+//
+// Shape verified against Claude Code 2.1.226 (build 2026-08-08, git sha
+// e140b32) three ways: the payload constructor, the statusline schema
+// the same binary documents for statusline authors, and the header
+// parser feeding both. The documented contract is
+// `used_percentage` as a number in 0-100 and `resets_at` as unix epoch
+// seconds, both optional, with the whole block absent until the session
+// has parsed at least one API response.
+//
+// NOT VERIFIED: a populated payload observed in the wild. The captured
+// fixture beside this file is from a session that made no API call and
+// correctly lacks the key, which corroborates the absent case and
+// observes nothing about the present one. Everything here about the
+// populated shape is read out of the binary, not measured from traffic.
+type rateLimits struct {
+	FiveHour *rateLimitWindow `json:"five_hour"`
+	SevenDay *rateLimitWindow `json:"seven_day"`
+}
+
+// rateLimitWindow is one recovering level: it rises with use and falls
+// with time. That makes it a third thing beside the level and the
+// counter internal/usage/doc.go distinguishes, and it is why the reset
+// instant is carried rather than dropped. 94% with four hours to run and
+// 94% with four minutes to run are opposite situations, so a consumer
+// holding only the percentage has a number it cannot act on.
+type rateLimitWindow struct {
+	UsedPercentage *float64     `json:"used_percentage"`
+	ResetsAt       resetInstant `json:"resets_at"`
+}
+
+// resetInstant parses a reset instant from either shape the SAME claude
+// binary emits, because 2.1.226 uses two and they disagree:
+//
+//	statusline payload   resets_at is an INTEGER unix epoch
+//	                     (Math.round(Number(header)))
+//	get_usage response   resets_at is an ISO 8601 STRING
+//	                     (new Date(x*1000).toISOString())
+//
+// The level field diverges the same way and worse: the statusline calls
+// it used_percentage and pre-scales it (utilization*100, from a header
+// carrying a 0-to-1 fraction), while get_usage calls it utilization and
+// documents it as already 0-100. A consumer that reads one channel's
+// documentation and parses the other gets a type error on the instant
+// and a 100x error on the level. Hence both shapes here, and the range
+// check in formatRateLimits for the other half of the trap.
+//
+// UnmarshalJSON never returns an error, which is the load-bearing part.
+// This type sits inside the same struct as the context figure, so a
+// strict parse would let an unfamiliar reset-instant shape fail the
+// WHOLE payload and take the CTX% feed down with it. An unreadable
+// instant is recorded as absent instead, exactly as an unresolved window
+// reports absence rather than a guess.
+type resetInstant struct {
+	Time  time.Time
+	Valid bool
+}
+
+// The always-nil error is the point, not an oversight: json.Unmarshaler
+// fixes this signature, and returning a real error here would reintroduce
+// the whole-payload failure the type exists to prevent.
+//
+//nolint:unparam // json.Unmarshaler mandates the error return; never non-nil by design
+func (r *resetInstant) UnmarshalJSON(b []byte) error {
+	// null must be checked before the number, not after: unmarshalling
+	// null into a float64 succeeds and leaves it zero, so the fallthrough
+	// would silently report 1970 as a valid reset instant. The get_usage
+	// schema declares every window nullable, so this is a shape the
+	// harness family really emits rather than a hypothetical.
+	if string(b) == "null" {
+		return nil
+	}
+	var epoch float64
+	if err := json.Unmarshal(b, &epoch); err == nil {
+		r.Time = time.Unix(int64(epoch), 0).UTC()
+		r.Valid = true
+		return nil
+	}
+	var iso string
+	if err := json.Unmarshal(b, &iso); err == nil {
+		if t, err := time.Parse(time.RFC3339, iso); err == nil {
+			r.Time = t.UTC()
+			r.Valid = true
+		}
+	}
+	return nil
 }
 
 // contextWindow is the harness's own context accounting: the classes it
@@ -116,18 +234,101 @@ func recomputeUsedPercent(w *contextWindow) (pct float64, ok bool) {
 	return math.Min(100, math.Max(0, raw)), true
 }
 
+// formatRateLimits renders the account's headroom for the pane, or "" when
+// the payload carries none. Both windows are labelled `acct` because the
+// figure describes the account rather than the session whose pane it is
+// printed in; every pane on the account shows the same two numbers, and
+// the label is what keeps a reader from taking it for a per-session
+// measurement.
+//
+// The pane is the one destination that cannot commit the attribution
+// error. It is a string a human reads, not a record keyed to a session,
+// so displaying an account-scoped figure there is honest in a way that
+// storing it against a session key would not be.
+//
+// A percentage outside 0-100 is refused rather than printed, in the same
+// posture as the context cross-check above: out of range is the signature
+// of the scaling trap in resetInstant's comment having actually
+// materialized, and a confidently wrong 4100% is worse than a question
+// mark with the raw value beside it.
+func formatRateLimits(rl *rateLimits, now time.Time) string {
+	if rl == nil {
+		return ""
+	}
+	out := ""
+	for _, w := range []struct {
+		label  string
+		window *rateLimitWindow
+	}{
+		{"5h", rl.FiveHour},
+		{"7d", rl.SevenDay},
+	} {
+		if w.window == nil || w.window.UsedPercentage == nil {
+			continue
+		}
+		pct := *w.window.UsedPercentage
+		if out != "" {
+			out += " "
+		}
+		if pct < 0 || pct > 100 {
+			out += fmt.Sprintf("%s ? (raw %.0f)", w.label, pct)
+			continue
+		}
+		out += fmt.Sprintf("%s %.0f%% (%s)", w.label, pct, untilReset(w.window.ResetsAt, now))
+	}
+	if out == "" {
+		return ""
+	}
+	return "acct " + out
+}
+
+// untilReset renders how long the window has left to run, which is the
+// term that makes the level actionable. An instant already past means the
+// window rolled over and no payload has been seen since, so the reading
+// is stale rather than merely old; saying so beats printing a negative
+// duration or silently showing a number that no longer applies.
+func untilReset(r resetInstant, now time.Time) string {
+	if !r.Valid {
+		return "resets ?"
+	}
+	d := r.Time.Sub(now)
+	switch {
+	case d <= 0:
+		return "stale"
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	default:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+}
+
 // renderForward parses one statusline payload and returns the status text
-// to print, the context percentage and model name to forward (send=false
-// when the payload carries no forwardable figure). Pure so it is
+// to print, plus the context percentage, model name, and harness-declared
+// window to forward (send=false when the payload carries no forwardable
+// figure). window is 0 when the payload declares none.
+//
+// Pure apart from the clock formatRateLimits needs, so it stays
 // table-testable.
-func renderForward(raw []byte) (line string, pct float64, model string, send bool) {
+func renderForward(raw []byte) (line string, pct float64, model string, window int, send bool) {
 	var p statuslinePayload
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return "marvel ctx-forward: unreadable payload", 0, "", false
+		return "marvel ctx-forward: unreadable payload", 0, "", 0, false
 	}
 
 	// Subagent shape: summarize the task rows. No RPC — the daemon has
 	// no per-subagent surface yet (tracked in aae-orc-7hzb).
+	// The account's headroom rides every main-shape line. It is appended
+	// rather than woven in so the context half of the line keeps the exact
+	// format it had, including on the cross-check refusal path.
+	withAcct := func(line string) string {
+		if acct := formatRateLimits(p.RateLimits, time.Now().UTC()); acct != "" {
+			return line + " · " + acct
+		}
+		return line
+	}
+
 	if len(p.Tasks) > 0 {
 		running := 0
 		maxPct := 0.0
@@ -141,13 +342,13 @@ func renderForward(raw []byte) (line string, pct float64, model string, send boo
 				}
 			}
 		}
-		return fmt.Sprintf("agents %d/%d running · max CTX %.0f%%", running, len(p.Tasks), maxPct), 0, "", false
+		return fmt.Sprintf("agents %d/%d running · max CTX %.0f%%", running, len(p.Tasks), maxPct), 0, "", 0, false
 	}
 
 	if p.ContextWindow == nil || p.ContextWindow.UsedPercentage == nil {
 		// Session too young to have a measurement. Show something
 		// stable rather than flickering an error.
-		return fmt.Sprintf("%s · CTX –", orUnknown(p.Model.DisplayName)), 0, "", false
+		return withAcct(fmt.Sprintf("%s · CTX –", orUnknown(p.Model.DisplayName))), 0, "", 0, false
 	}
 	pct = *p.ContextWindow.UsedPercentage
 
@@ -169,8 +370,8 @@ func renderForward(raw []byte) (line string, pct float64, model string, send boo
 	// the only place a human will see that the cross-check tripped. A
 	// silent blank would look like an ordinary gap in the feed.
 	if mine, ok := recomputeUsedPercent(p.ContextWindow); ok && math.Abs(mine-pct) > harnessPercentTolerance {
-		return fmt.Sprintf("%s · CTX ? harness %.0f%% vs recomputed %.0f%% · $%.2f",
-			orUnknown(p.Model.DisplayName), pct, mine, p.Cost.TotalCostUSD), 0, "", false
+		return withAcct(fmt.Sprintf("%s · CTX ? harness %.0f%% vs recomputed %.0f%% · $%.2f",
+			orUnknown(p.Model.DisplayName), pct, mine, p.Cost.TotalCostUSD)), 0, "", 0, false
 	}
 	// A payload with no classes to check against is unverified, not
 	// suspect. Older harnesses, and any other producer pointed at this
@@ -178,8 +379,8 @@ func renderForward(raw []byte) (line string, pct float64, model string, send boo
 	// uncorroborated reading would blank the feed for everyone who
 	// predates the classes rather than catch anything.
 
-	line = fmt.Sprintf("%s · CTX %.0f%% · $%.2f", orUnknown(p.Model.DisplayName), pct, p.Cost.TotalCostUSD)
-	return line, pct, p.Model.DisplayName, true
+	line = withAcct(fmt.Sprintf("%s · CTX %.0f%% · $%.2f", orUnknown(p.Model.DisplayName), pct, p.Cost.TotalCostUSD))
+	return line, pct, p.Model.DisplayName, p.ContextWindow.ContextWindowSize, true
 }
 
 func orUnknown(s string) string {
@@ -200,7 +401,7 @@ func newCtxForwardCmd() *cobra.Command {
 				fmt.Println("marvel ctx-forward")
 				return nil
 			}
-			line, pct, model, send := renderForward(raw)
+			line, pct, model, window, send := renderForward(raw)
 			fmt.Println(line)
 
 			socket := os.Getenv("MARVEL_SOCKET")
@@ -209,11 +410,46 @@ func newCtxForwardCmd() *cobra.Command {
 			if !send || socket == "" || workspace == "" || session == "" {
 				return nil
 			}
-			params, _ := json.Marshal(map[string]any{
+			// Deliberately no rate-limit fields here. Every parameter of
+			// this RPC is keyed to one session, and the account's headroom
+			// is not a property of any session; see the rateLimits type.
+			// It reaches the pane and stops there until an account-scoped
+			// home exists to send it to.
+			p := map[string]any{
 				"session_key":     workspace + "/" + session,
 				"context_percent": pct,
 				"model":           model,
-			})
+			}
+			// context_window is the harness's own declared window for this
+			// session. It is emitted as the PRODUCER half of a seam whose
+			// consumer does not exist yet: internal/daemon's heartbeatParams
+			// has no field for it, so today the daemon drops it exactly the
+			// way this file used to drop rate_limits. That is deliberate and
+			// documented rather than accidental, but it is not a shipped
+			// feature, and nothing renders differently because of it.
+			//
+			// Two edits complete it, both outside cmd/marvel and both
+			// deliberately not made here: a window field on
+			// internal/daemon.heartbeatParams, and a window argument on
+			// internal/api.Store.UpdateSessionHeartbeat.
+			//
+			// Whoever makes them should read the comment already standing in
+			// UpdateSessionHeartbeat first. It states that a percentage is
+			// ALL this path produces, "no token count, no window, and no
+			// request count", and that this shape is what tells the two
+			// context producers apart downstream. Adding a window narrows
+			// that discriminator, so it is a contract decision rather than
+			// plumbing, and stamping a limit source without routing both
+			// this window and the session's manifest limit through
+			// usage.Resolve would label a rung of the ladder without
+			// climbing it.
+			//
+			// Zero means the payload declared no window, and an undeclared
+			// window must not arrive as a declared zero.
+			if window > 0 {
+				p["context_window"] = window
+			}
+			params, _ := json.Marshal(p)
 			// Best-effort by design; see the failure posture above.
 			_, _ = daemon.SendRequest(socket, daemon.Request{
 				Method: "heartbeat",

--- a/cmd/marvel/ctxforward_test.go
+++ b/cmd/marvel/ctxforward_test.go
@@ -1,10 +1,249 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestRateLimitsSurviveParsing is the regression this file exists to
+// hold: `rate_limits` used to land on stdin and vanish, because the
+// struct did not declare it and encoding/json drops unknown keys without
+// complaint. The test asserts the block reaches the struct, not that it
+// looks pretty on a line.
+//
+// PROVENANCE, stated because it is weaker than the fixture beside it.
+// statusline-2.1.226-empty.json is a live capture. This one is NOT: it is
+// constructed from the shape Claude Code 2.1.226 documents for statusline
+// authors ("used_percentage: Percentage of limit used (0-100)",
+// "resets_at: Unix epoch seconds when this window resets") and from the
+// payload constructor that builds it. No populated payload has been
+// observed in traffic here, so this fixture pins marvel's reading of a
+// published contract rather than a measurement.
+func TestRateLimitsSurviveParsing(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("testdata/statusline-2.1.226-rate-limits-synthetic.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var p statuslinePayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.RateLimits == nil {
+		t.Fatal("rate_limits is nil: the payload's headroom block was dropped again")
+	}
+	if p.RateLimits.FiveHour == nil || p.RateLimits.SevenDay == nil {
+		t.Fatal("want both windows parsed")
+	}
+	if got := *p.RateLimits.FiveHour.UsedPercentage; got != 41 {
+		t.Errorf("five_hour used_percentage = %v, want 41", got)
+	}
+	if !p.RateLimits.FiveHour.ResetsAt.Valid {
+		t.Fatal("five_hour resets_at did not parse")
+	}
+	if got := p.RateLimits.FiveHour.ResetsAt.Time.Unix(); got != 1786000000 {
+		t.Errorf("five_hour resets_at = %d, want 1786000000", got)
+	}
+
+	// The whole line, so the account block is provably reachable from the
+	// command's output and not merely from the struct.
+	now := time.Unix(1785989200, 0).UTC()
+	if got := formatRateLimits(p.RateLimits, now); got != "acct 5h 41% (3h0m) 7d 63% (4d18h)" {
+		t.Errorf("formatRateLimits = %q", got)
+	}
+	line, _, _, _, send := renderForward(raw)
+	if !send {
+		t.Errorf("send = false, want true: the context reading is sound")
+	}
+	if !strings.Contains(line, "CTX 13%") || !strings.Contains(line, "acct 5h 41%") {
+		t.Errorf("line = %q, want both the session's CTX and the account's headroom", line)
+	}
+}
+
+// TestResetInstantShapes covers the trap measured inside one claude
+// binary: the statusline emits resets_at as an integer epoch and
+// get_usage emits it as an ISO 8601 string. Both are accepted. The last
+// case is the load-bearing one: an unfamiliar shape must degrade to an
+// absent instant, never to an error, because an error here would fail the
+// enclosing payload and take the CTX% feed down with a field it does not
+// depend on.
+func TestResetInstantShapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		raw       string
+		wantValid bool
+		wantUnix  int64
+	}{
+		{"statusline epoch integer", `1786000000`, true, 1786000000},
+		{"get_usage ISO 8601 string", `"2026-08-06T07:06:40Z"`, true, 1786000000},
+		{"ISO 8601 with offset", `"2026-08-06T09:06:40+02:00"`, true, 1786000000},
+		{"null", `null`, false, 0},
+		{"unparseable string", `"whenever"`, false, 0},
+		{"unknown object shape", `{"seconds":1786000000}`, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var r resetInstant
+			if err := json.Unmarshal([]byte(tt.raw), &r); err != nil {
+				t.Fatalf("UnmarshalJSON returned an error, which would fail the whole payload: %v", err)
+			}
+			if r.Valid != tt.wantValid {
+				t.Fatalf("Valid = %v, want %v", r.Valid, tt.wantValid)
+			}
+			if r.Valid && r.Time.Unix() != tt.wantUnix {
+				t.Errorf("Unix = %d, want %d", r.Time.Unix(), tt.wantUnix)
+			}
+		})
+	}
+}
+
+// TestRateLimitsDoNotBreakTheContextFeed pins the containment property
+// directly: a rate_limits block whose reset instant has an unfamiliar
+// shape must leave the context reading intact and forwardable.
+func TestRateLimitsDoNotBreakTheContextFeed(t *testing.T) {
+	t.Parallel()
+	payload := `{"model":{"display_name":"Haiku 4.5"},
+		"cost":{"total_cost_usd":0.5},
+		"context_window":{"used_percentage":17},
+		"rate_limits":{"five_hour":{"used_percentage":41,"resets_at":{"epoch":1786000000}}}}`
+	line, pct, model, window, send := renderForward([]byte(payload))
+	if !send {
+		t.Fatalf("send = false, want true; line = %q", line)
+	}
+	if pct != 17 || model != "Haiku 4.5" {
+		t.Errorf("pct = %v, model = %q, want 17 and Haiku 4.5", pct, model)
+	}
+	if window != 0 {
+		t.Errorf("window = %d, want 0: this payload declares none", window)
+	}
+	if !strings.Contains(line, "acct 5h 41% (resets ?)") {
+		t.Errorf("line = %q, want the level kept and the instant marked absent", line)
+	}
+}
+
+// TestRenderForwardWindow covers the harness-declared window the
+// forwarder returns for the heartbeat params. Zero means undeclared, and
+// the distinction is the whole point: a consumer must be able to tell "no
+// window was declared" from "a window of zero", so an absent
+// context_window_size must never surface as a declared 0.
+func TestRenderForwardWindow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		payload    string
+		wantWindow int
+	}{
+		{
+			name: "declared window is returned",
+			payload: `{"model":{"display_name":"Haiku 4.5"},
+				"context_window":{"context_window_size":200000,"used_percentage":42}}`,
+			wantWindow: 200000,
+		},
+		{
+			name: "undeclared window is zero",
+			payload: `{"model":{"display_name":"Haiku 4.5"},
+				"context_window":{"used_percentage":42}}`,
+			wantWindow: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, _, window, send := renderForward([]byte(tt.payload))
+			if !send {
+				t.Fatal("send = false, want true")
+			}
+			if window != tt.wantWindow {
+				t.Errorf("window = %d, want %d", window, tt.wantWindow)
+			}
+		})
+	}
+}
+
+func TestFormatRateLimits(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1785989200, 0).UTC() // 3h before the 5h window's reset
+	pct := func(f float64) *float64 { return &f }
+	at := func(epoch int64) resetInstant {
+		return resetInstant{Time: time.Unix(epoch, 0).UTC(), Valid: true}
+	}
+	tests := []struct {
+		name string
+		rl   *rateLimits
+		want string
+	}{
+		{"absent block renders nothing", nil, ""},
+		{"empty block renders nothing", &rateLimits{}, ""},
+		{
+			name: "five hour only",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(41), ResetsAt: at(1786000000)}},
+			want: "acct 5h 41% (3h0m)",
+		},
+		{
+			name: "both windows",
+			rl: &rateLimits{
+				FiveHour: &rateLimitWindow{UsedPercentage: pct(41), ResetsAt: at(1786000000)},
+				SevenDay: &rateLimitWindow{UsedPercentage: pct(63), ResetsAt: at(1786400000)},
+			},
+			want: "acct 5h 41% (3h0m) 7d 63% (4d18h)",
+		},
+		{
+			// Under an hour the hours term would read 0h, so minutes carry
+			// the whole remainder.
+			name: "minutes remaining",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(94), ResetsAt: at(1785990400)}},
+			want: "acct 5h 94% (20m)",
+		},
+		{
+			// The window already rolled over and no fresher payload has
+			// arrived, so the level no longer describes anything.
+			name: "reset instant already past",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(94), ResetsAt: at(1785000000)}},
+			want: "acct 5h 94% (stale)",
+		},
+		{
+			// A level with no reset instant is the one thing the triple
+			// discipline refuses to present as complete.
+			name: "level with no reset instant",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(41)}},
+			want: "acct 5h 41% (resets ?)",
+		},
+		{
+			// The 100x scaling trap having materialized: a producer sent
+			// the raw 0-to-1 fraction's scaling on the wrong channel.
+			name: "percentage out of range is refused",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(4100), ResetsAt: at(1786000000)}},
+			want: "acct 5h ? (raw 4100)",
+		},
+		{
+			name: "negative percentage is refused",
+			rl:   &rateLimits{FiveHour: &rateLimitWindow{UsedPercentage: pct(-1), ResetsAt: at(1786000000)}},
+			want: "acct 5h ? (raw -1)",
+		},
+		{
+			// A window present but carrying no level is not a reading.
+			name: "window with no percentage is skipped",
+			rl: &rateLimits{
+				FiveHour: &rateLimitWindow{ResetsAt: at(1786000000)},
+				SevenDay: &rateLimitWindow{UsedPercentage: pct(63), ResetsAt: at(1786400000)},
+			},
+			want: "acct 7d 63% (4d18h)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatRateLimits(tt.rl, now); got != tt.want {
+				t.Errorf("formatRateLimits = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 // TestRenderForwardLiveCapture pins the parser to a payload captured from
 // a real Claude Code 2.1.226 session on 2026-08-08 rather than to one
@@ -20,7 +259,7 @@ func TestRenderForwardLiveCapture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	line, _, _, send := renderForward(raw)
+	line, _, _, _, send := renderForward(raw)
 	if send {
 		t.Errorf("send = true, want false: a null used_percentage is not a reading")
 	}
@@ -180,7 +419,7 @@ func TestRenderForward(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			line, pct, model, send := renderForward([]byte(tt.payload))
+			line, pct, model, _, send := renderForward([]byte(tt.payload))
 			if send != tt.wantSend {
 				t.Fatalf("send = %v, want %v", send, tt.wantSend)
 			}

--- a/cmd/marvel/testdata/statusline-2.1.226-rate-limits-synthetic.json
+++ b/cmd/marvel/testdata/statusline-2.1.226-rate-limits-synthetic.json
@@ -1,0 +1,53 @@
+{
+  "session_id": "00000000-0000-4000-8000-000000000000",
+  "transcript_path": "/tmp/scratch-home/.claude/projects/-tmp-scratch-home-proj/00000000-0000-4000-8000-000000000000.jsonl",
+  "cwd": "/tmp/scratch-home/proj",
+  "model": {
+    "id": "claude-opus-5[1m]",
+    "display_name": "Opus 5 (1M context)"
+  },
+  "workspace": {
+    "current_dir": "/tmp/scratch-home/proj",
+    "project_dir": "/tmp/scratch-home/proj",
+    "added_dirs": []
+  },
+  "version": "2.1.226",
+  "output_style": {
+    "name": "default"
+  },
+  "cost": {
+    "total_cost_usd": 1.25,
+    "total_duration_ms": 91314,
+    "total_api_duration_ms": 40122,
+    "total_lines_added": 12,
+    "total_lines_removed": 3
+  },
+  "context_window": {
+    "total_input_tokens": 134000,
+    "total_output_tokens": 2000,
+    "context_window_size": 1000000,
+    "current_usage": {
+      "input_tokens": 30000,
+      "output_tokens": 2000,
+      "cache_creation_input_tokens": 4000,
+      "cache_read_input_tokens": 100000
+    },
+    "used_percentage": 13,
+    "remaining_percentage": 87
+  },
+  "exceeds_200k_tokens": false,
+  "fast_mode": false,
+  "rate_limits": {
+    "five_hour": {
+      "used_percentage": 41,
+      "resets_at": 1786000000
+    },
+    "seven_day": {
+      "used_percentage": 63,
+      "resets_at": 1786400000
+    }
+  },
+  "thinking": {
+    "enabled": true
+  }
+}

--- a/internal/daemon/testmain_test.go
+++ b/internal/daemon/testmain_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +20,27 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	code := m.Run()
-	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	killTestServer(socket)
 	os.Exit(code)
+}
+
+// killTestServer stops this package's tmux server and unlinks its socket.
+// tmux leaves the socket behind when the server goes away, and the name
+// carries this binary's pid, so without the unlink every run leaks one.
+// See tmux/testmain_test.go for the full rationale and the test that keeps
+// the path derivation honest.
+func killTestServer(socket string) {
+	path := ""
+	if out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{socket_path}").Output(); err == nil {
+		path = strings.TrimSpace(string(out))
+	}
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	if path == "" {
+		dir := os.Getenv("TMUX_TMPDIR")
+		if dir == "" {
+			dir = "/tmp"
+		}
+		path = filepath.Join(dir, fmt.Sprintf("tmux-%d", os.Getuid()), socket)
+	}
+	_ = os.Remove(path)
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -31,8 +31,28 @@ const (
 	KindShiftStarted      Kind = "team.shift-started"
 	KindShiftCompleted    Kind = "team.shift-completed"
 	KindShiftTimedOut     Kind = "team.shift-timed-out"
-	KindRoleSaturated     Kind = "role.saturated"
-	KindRoleRemoved       Kind = "role.removed"
+	// KindShiftRoleReady records the instant the control plane decided a
+	// role's successor generation may take over: allReady returned true and
+	// the shift advanced from launching to draining. It is the boundary
+	// between the two stages of a shift, and the only stage boundary that
+	// will move when real harnesses replace simulators, so it is the stamp
+	// an automatic shift trigger has to reason about.
+	//
+	// The subject is the ROLE's successor generation, not one session,
+	// because allReady is a group gate over every replica. Session is
+	// therefore left empty even for a single-replica role: a field that is
+	// populated only at replicas=1 would let a consumer join by session key
+	// and silently lose the multi-replica rows. The successor keys and the
+	// gate that admitted them ride in Message; Generation carries the
+	// successor generation as data.
+	//
+	// Fires at most once per role per shift: the phase flip that emits it is
+	// also the flip that stops allReady being consulted for that role. See
+	// orc finding-018, which had to poll the session table at 50 Hz to
+	// timestamp this instant because the ring did not carry it.
+	KindShiftRoleReady Kind = "team.shift-role-ready"
+	KindRoleSaturated  Kind = "role.saturated"
+	KindRoleRemoved    Kind = "role.removed"
 	// KindPolicyProjected records that marvel wrote (or rewrote) a
 	// session's projected Claude Code settings file — the observable
 	// signal of a policy landing at spawn and of live re-projection after
@@ -142,6 +162,14 @@ type Event struct {
 	// action one daemon takes against state another daemon may own. See
 	// aae-orc-kvcs.
 	Actor string `json:"actor,omitempty"`
+	// Generation names the team generation the event is about, when the
+	// event is about one. Sessions already carry the generation in their
+	// name (`<team>-<role>-g<gen>-<index>`), but an event whose subject is a
+	// whole generation has nowhere to put it, which is how the shift
+	// stage boundary in KindShiftRoleReady would otherwise have had to
+	// encode its most load-bearing coordinate in prose. Zero means the
+	// event is not generation-scoped.
+	Generation int64 `json:"generation,omitempty"`
 	// Message is a short human-readable description. Keep it one
 	// line — operators scan dozens of these at a time.
 	Message string `json:"message"`

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +23,27 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	code := m.Run()
-	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	killTestServer(socket)
 	os.Exit(code)
+}
+
+// killTestServer stops this package's tmux server and unlinks its socket.
+// tmux leaves the socket behind when the server goes away, and the name
+// carries this binary's pid, so without the unlink every run leaks one.
+// See tmux/testmain_test.go for the full rationale and the test that keeps
+// the path derivation honest.
+func killTestServer(socket string) {
+	path := ""
+	if out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{socket_path}").Output(); err == nil {
+		path = strings.TrimSpace(string(out))
+	}
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	if path == "" {
+		dir := os.Getenv("TMUX_TMPDIR")
+		if dir == "" {
+			dir = "/tmp"
+		}
+		path = filepath.Join(dir, fmt.Sprintf("tmux-%d", os.Getuid()), socket)
+	}
+	_ = os.Remove(path)
 }

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -1016,16 +1016,56 @@ func (c *Controller) shiftLaunch(t *api.Team, role *api.Role) {
 		if c.allReady(newGen, role) {
 			log.Printf("shift: %s/%s role %s — %d new sessions ready, draining old gen %d",
 				t.Workspace, t.Name, role.Name, len(newGen), t.Shift.OldGeneration)
-			_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
+			// Record the phase flip before announcing it. A failed update
+			// leaves the team in launching, so allReady is consulted again
+			// next tick, and an event emitted ahead of the write would then
+			// be a readiness stamp for a transition that did not happen.
+			// Emitting after the write keeps the ring's count of
+			// KindShiftRoleReady equal to the number of transitions.
+			if err := c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
 				live.Shift.Phase = api.ShiftDraining
 				return nil
-			})
+			}); err != nil {
+				log.Printf("shift: %s advance role %s to draining: %v", t.Key(), role.Name, err)
+				return
+			}
 			t.Shift.Phase = api.ShiftDraining
+			events.Emit(c.Events, events.Event{
+				Kind:       events.KindShiftRoleReady,
+				Workspace:  t.Workspace,
+				Team:       t.Name,
+				Role:       role.Name,
+				Generation: t.Generation,
+				Message: fmt.Sprintf("gen %d ready, gate=%s, draining gen %d: %s",
+					t.Generation, readinessGate(role), t.Shift.OldGeneration,
+					strings.Join(sessionKeys(newGen), " ")),
+			})
 		} else {
 			log.Printf("shift: %s/%s role %s — %d sessions launched, waiting for readiness",
 				t.Workspace, t.Name, role.Name, len(newGen))
 		}
 	}
+}
+
+// readinessGate names the rule allReady applied, so a reader of the
+// readiness event can tell a heartbeat-gated successor from one admitted on
+// pane existence alone. The distinction matters for anything reasoning about
+// shift latency: pane-Running fires within about 100 ms of spawn and says
+// nothing about whether the harness inside can work yet.
+func readinessGate(role *api.Role) string {
+	if role.HealthCheck == nil {
+		return "running"
+	}
+	return string(role.HealthCheck.Type)
+}
+
+// sessionKeys returns the session keys in order, for event messages.
+func sessionKeys(sessions []api.Session) []string {
+	keys := make([]string, 0, len(sessions))
+	for i := range sessions {
+		keys = append(keys, sessions[i].Key())
+	}
+	return keys
 }
 
 // allReady returns true if all sessions are ready to take over.

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1673,3 +1673,248 @@ func TestContextReadingIsNotAHeartbeat(t *testing.T) {
 		t.Error("a session with a context reading but no heartbeat was declared shift-ready")
 	}
 }
+
+// TestShiftRoleReadyEventFiresOnceAtTheTransition covers the gap orc
+// finding-018 measured: the instant the control plane decides a successor
+// generation may take over is made inside allReady, between session.created
+// and session.deleted, and until this event nothing was written to the ring
+// for it. The finding had to poll the session table at 50 Hz to timestamp it.
+//
+// The role is heartbeat-gated so the launching phase lasts several ticks
+// with no heartbeat arriving. That separates "not ready yet" from "ready" in
+// time, which a role with no healthcheck cannot do (it is ready on the same
+// tick it is created). Falsification: without the emit in shiftLaunch the
+// ring carries no team.shift-role-ready and the count assertion fails; with
+// an emit placed inside allReady instead of at the phase flip, the count is
+// the number of launching ticks rather than 1.
+func TestShiftRoleReadyEventFiresOnceAtTheTransition(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	ctrl.ShiftTimeout = 1 * time.Hour
+
+	// A one-hour heartbeat timeout keeps every session in HealthUnknown, so
+	// the only thing gating the shift is allReady's first-heartbeat rule.
+	createTeamFixture(t, store, "test-shift-ready", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 2,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Hour, FailureThreshold: 3},
+		},
+	})
+	teamKey := "test-shift-ready/squad"
+
+	readyEvents := func() []events.Event {
+		return ring.Snapshot(events.Filter{Kind: events.KindShiftRoleReady}, 0)
+	}
+
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRoleGeneration("test-shift-ready", "squad", "worker", 1)); got != 2 {
+		t.Fatalf("expected 2 gen-1 sessions, got %d", got)
+	}
+	if got := len(readyEvents()); got != 0 {
+		t.Fatalf("readiness events before any shift = %d, want 0", got)
+	}
+
+	if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+		t.Fatalf("initiate shift: %v", err)
+	}
+
+	// Several ticks in the launching phase with no heartbeat: the successors
+	// exist and are running, but the control plane has not committed to them.
+	for i := 0; i < 4; i++ {
+		ctrl.ReconcileOnce()
+		team, _ := store.GetTeam(teamKey)
+		if team.Shift.Phase != api.ShiftLaunching {
+			t.Fatalf("tick %d: phase = %s, want launching (no heartbeat has arrived)", i, team.Shift.Phase)
+		}
+		if got := len(readyEvents()); got != 0 {
+			t.Fatalf("tick %d: readiness events = %d, want 0 before the successors are ready", i, got)
+		}
+	}
+
+	gen2 := store.ListSessionsByTeamRoleGeneration("test-shift-ready", "squad", "worker", 2)
+	if len(gen2) != 2 {
+		t.Fatalf("expected 2 gen-2 sessions launched, got %d", len(gen2))
+	}
+	wantKeys := make([]string, 0, len(gen2))
+	for _, s := range gen2 {
+		wantKeys = append(wantKeys, s.Key())
+		if err := store.UpdateSession(s.Key(), func(live *api.Session) error {
+			live.LastHeartbeat = time.Now().UTC()
+			return nil
+		}); err != nil {
+			t.Fatalf("set heartbeat on %s: %v", s.Key(), err)
+		}
+	}
+
+	// The tick that observes the heartbeats is the readiness transition.
+	ctrl.ReconcileOnce()
+	team, _ := store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftDraining {
+		t.Fatalf("phase = %s after heartbeats, want draining", team.Shift.Phase)
+	}
+	evs := readyEvents()
+	if len(evs) != 1 {
+		t.Fatalf("readiness events at the transition = %d, want exactly 1", len(evs))
+	}
+
+	ev := evs[0]
+	if ev.Workspace != "test-shift-ready" || ev.Team != "squad" || ev.Role != "worker" {
+		t.Errorf("event scope = %s/%s role %s, want test-shift-ready/squad role worker",
+			ev.Workspace, ev.Team, ev.Role)
+	}
+	if ev.Generation != 2 {
+		t.Errorf("event generation = %d, want 2 (the successor generation)", ev.Generation)
+	}
+	if ev.Severity != events.SeverityInfo {
+		t.Errorf("severity = %s, want %s", ev.Severity, events.SeverityInfo)
+	}
+	for _, key := range wantKeys {
+		if !strings.Contains(ev.Message, key) {
+			t.Errorf("message %q does not name successor session %s", ev.Message, key)
+		}
+	}
+	if !strings.Contains(ev.Message, string(api.HealthCheckHeartbeat)) {
+		t.Errorf("message %q does not name the gate that admitted the successors", ev.Message)
+	}
+
+	// The readiness stamp must precede the first predecessor teardown.
+	// That ordering is the whole point of having it in the ring.
+	for _, d := range ring.Snapshot(events.Filter{Kind: events.KindSessionDeleted}, 0) {
+		if d.Seq < ev.Seq {
+			t.Errorf("session.deleted seq %d precedes readiness seq %d", d.Seq, ev.Seq)
+		}
+	}
+
+	// Drive the shift to completion: the count must stay at 1 across every
+	// remaining tick, including the ones that run after the shift clears.
+	for i := 0; i < 20; i++ {
+		ctrl.ReconcileOnce()
+		team, _ = store.GetTeam(teamKey)
+		if team.Shift.Phase == api.ShiftNone {
+			break
+		}
+	}
+	if team.Shift.Phase != api.ShiftNone {
+		t.Fatalf("shift did not complete, phase %s", team.Shift.Phase)
+	}
+	ctrl.ReconcileOnce()
+	if got := len(readyEvents()); got != 1 {
+		t.Fatalf("readiness events after the shift completed = %d, want exactly 1", got)
+	}
+}
+
+// TestShiftRoleReadyEventAbsentWhenSuccessorNeverReady is the negative half
+// of the bar: a successor generation that never satisfies allReady must never
+// produce a readiness stamp, however many ticks it is given. The shift times
+// out and rolls back instead. Falsification: an emit keyed on session
+// creation or on pane-Running rather than on the allReady verdict would fire
+// here, because these successors do reach Running.
+func TestShiftRoleReadyEventAbsentWhenSuccessorNeverReady(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	clock := newTestClock(time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+	ctrl.ShiftTimeout = 2 * time.Minute
+
+	createTeamFixture(t, store, "test-shift-never-ready", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Hour, FailureThreshold: 3},
+		},
+	})
+	teamKey := "test-shift-never-ready/squad"
+
+	ctrl.ReconcileOnce()
+	if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+		t.Fatalf("initiate shift: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		ctrl.ReconcileOnce()
+	}
+
+	// The successor is Running but has never heartbeat, so it is not ready.
+	gen2 := store.ListSessionsByTeamRoleGeneration("test-shift-never-ready", "squad", "worker", 2)
+	if len(gen2) != 1 {
+		t.Fatalf("expected 1 gen-2 session launched, got %d", len(gen2))
+	}
+	if gen2[0].State != api.SessionRunning {
+		t.Fatalf("successor state = %s, want running (the test needs a live-but-unready pane)", gen2[0].State)
+	}
+
+	clock.Advance(3 * time.Minute)
+	ctrl.ReconcileOnce()
+
+	team, _ := store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftNone {
+		t.Fatalf("phase = %s, want none after the timeout aborted the shift", team.Shift.Phase)
+	}
+	if got := len(ring.Snapshot(events.Filter{Kind: events.KindShiftTimedOut}, 0)); got == 0 {
+		t.Fatal("expected a team.shift-timed-out event")
+	}
+	if got := len(ring.Snapshot(events.Filter{Kind: events.KindShiftRoleReady}, 0)); got != 0 {
+		t.Fatalf("readiness events for a successor that never became ready = %d, want 0", got)
+	}
+}
+
+// TestShiftRoleReadyEventIsPerRole pins the granularity claim: the readiness
+// stamp is per role, not per shift and not per session. A two-role shift
+// crosses the launching-to-draining boundary twice, in shift order, so it
+// must produce two events; a four-replica role crosses it once, so it must
+// produce one. Falsification: an emit per successor session would give 5
+// here rather than 2, and an emit hung off team.shift-completed would give 1.
+func TestShiftRoleReadyEventIsPerRole(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+
+	createTeamFixture(t, store, "test-shift-ready-multi", "squad", []api.Role{
+		{Name: "supervisor", Replicas: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+		{Name: "worker", Replicas: 4, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+	teamKey := "test-shift-ready-multi/squad"
+
+	ctrl.ReconcileOnce()
+	if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+		t.Fatalf("initiate shift: %v", err)
+	}
+	for i := 0; i < 40; i++ {
+		ctrl.ReconcileOnce()
+		team, _ := store.GetTeam(teamKey)
+		if team.Shift.Phase == api.ShiftNone {
+			break
+		}
+	}
+	team, _ := store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftNone {
+		t.Fatalf("shift did not complete, phase %s", team.Shift.Phase)
+	}
+
+	evs := ring.Snapshot(events.Filter{Kind: events.KindShiftRoleReady}, 0)
+	if len(evs) != 2 {
+		t.Fatalf("readiness events for a 2-role shift = %d, want 2 (one per role)", len(evs))
+	}
+	// Snapshot is oldest-first, and shiftOrder puts the supervisor last.
+	if evs[0].Role != "worker" || evs[1].Role != "supervisor" {
+		t.Errorf("readiness roles = [%s %s], want [worker supervisor] (supervisor shifts last)",
+			evs[0].Role, evs[1].Role)
+	}
+	for _, ev := range evs {
+		if ev.Generation != 2 {
+			t.Errorf("role %s: generation = %d, want 2", ev.Role, ev.Generation)
+		}
+		if !strings.Contains(ev.Message, "gate=running") {
+			t.Errorf("role %s: message %q, want gate=running for a role with no healthcheck", ev.Role, ev.Message)
+		}
+	}
+}

--- a/internal/team/testmain_test.go
+++ b/internal/team/testmain_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +20,27 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	code := m.Run()
-	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	killTestServer(socket)
 	os.Exit(code)
+}
+
+// killTestServer stops this package's tmux server and unlinks its socket.
+// tmux leaves the socket behind when the server goes away, and the name
+// carries this binary's pid, so without the unlink every run leaks one.
+// See tmux/testmain_test.go for the full rationale and the test that keeps
+// the path derivation honest.
+func killTestServer(socket string) {
+	path := ""
+	if out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{socket_path}").Output(); err == nil {
+		path = strings.TrimSpace(string(out))
+	}
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	if path == "" {
+		dir := os.Getenv("TMUX_TMPDIR")
+		if dir == "" {
+			dir = "/tmp"
+		}
+		path = filepath.Join(dir, fmt.Sprintf("tmux-%d", os.Getuid()), socket)
+	}
+	_ = os.Remove(path)
 }

--- a/internal/tmux/socketpath_test.go
+++ b/internal/tmux/socketpath_test.go
@@ -1,0 +1,69 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// tmuxSocketPathMatchesTmux guards the socket-path derivation that
+// killTestServer relies on to unlink a dead server's socket.
+//
+// The derivation is a copy of tmux's own layout rule, so it can silently
+// drift from the installed tmux. A wrong path fails safe (nothing is
+// removed) and therefore fails silently: the leak would come back with no
+// test turning red. Asking a live server where its socket is closes that
+// gap.
+func TestTmuxSocketPathMatchesTmux(t *testing.T) {
+	skipIfNoTmux(t)
+
+	// A short TMUX_TMPDIR on purpose. A unix socket path is capped near
+	// 104 bytes, and t.TempDir() under a long working path pushes tmux
+	// past it: every connect then fails with "File name too long", which
+	// looks exactly like a clean run.
+	dir, err := os.MkdirTemp("/tmp", "mxsp")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	t.Setenv("TMUX_TMPDIR", dir)
+
+	socket := "mxsockpath"
+	cmd := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", "probe", "sleep 30")
+	cmd.Env = append(os.Environ(), "TMUX_TMPDIR="+dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("start tmux server: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() })
+
+	query := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{socket_path}")
+	query.Env = append(os.Environ(), "TMUX_TMPDIR="+dir)
+	out, err := query.Output()
+	if err != nil {
+		t.Fatalf("ask tmux for its socket path: %v", err)
+	}
+	reported := strings.TrimSpace(string(out))
+
+	derived := tmuxSocketPath(socket)
+	if !sameFile(t, derived, reported) {
+		t.Errorf("derived socket path %q is not tmux's %q", derived, reported)
+	}
+}
+
+// sameFile compares two paths by identity rather than by string, because
+// macOS reports /private/tmp where the caller passed /tmp.
+func sameFile(t *testing.T, a, b string) bool {
+	t.Helper()
+	fa, err := os.Stat(a)
+	if err != nil {
+		t.Logf("stat %s: %v", a, err)
+		return false
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		t.Logf("stat %s: %v", b, err)
+		return false
+	}
+	return os.SameFile(fa, fb)
+}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +30,42 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	code := m.Run()
-	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	killTestServer(socket)
 	os.Exit(code)
+}
+
+// killTestServer stops the package's dedicated tmux server and unlinks its
+// socket file.
+//
+// tmux never removes the socket when its server goes away, and the socket
+// name carries the test binary's pid, so it is never reused. Every `go test`
+// run therefore left one dead socket per package behind: 695 stale
+// marvel-test-* sockets had accumulated in one dev box's socket directory.
+//
+// The unlink cannot depend on a live server. A tmux server exits on its own
+// once the last session is destroyed, so by the time this runs the server is
+// usually already gone and both display-message and kill-server fail. The
+// derived path is the load-bearing part; the query is only a cross-check for
+// an unusual layout, and tmuxSocketPathMatchesTmux keeps the derivation
+// honest against the installed tmux.
+func killTestServer(socket string) {
+	path := ""
+	if out, err := exec.Command("tmux", "-L", socket, "display-message", "-p", "#{socket_path}").Output(); err == nil {
+		path = strings.TrimSpace(string(out))
+	}
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	if path == "" {
+		path = tmuxSocketPath(socket)
+	}
+	_ = os.Remove(path)
+}
+
+// tmuxSocketPath mirrors tmux's socket layout: TMUX_TMPDIR (defaulting to
+// /tmp), then a tmux-<uid> directory, then the -L name.
+func tmuxSocketPath(socket string) string {
+	dir := os.Getenv("TMUX_TMPDIR")
+	if dir == "" {
+		dir = "/tmp"
+	}
+	return filepath.Join(dir, fmt.Sprintf("tmux-%d", os.Getuid()), socket)
 }

--- a/internal/usage/doc.go
+++ b/internal/usage/doc.go
@@ -43,6 +43,25 @@
 // silently, and an admission gate that reads unresolved as 0% admits
 // everything. There is deliberately no fleet-wide default-window knob.
 //
+// The ladder, most authoritative first, is limitLadder in limits.go:
+// stream, learned, manifest, feed, table, table-alias, then unresolved.
+// LimitSource.Rank is the comparison; do not re-derive precedence by
+// comparing the string values.
+//
+// One rung pair on that ladder will look wrong at first reading. A window
+// the harness declares in its own STREAM sits at rung 1, above the
+// operator's runtime.context_window. The same window declared by the same
+// harness on the statusline FEED sits at rung 4, below it. Transport, not
+// content, is what differs, and it is the difference that matters: the
+// stream is the channel the harness is enforcing compaction against, so
+// overruling it would make marvel's denominator disagree with the one
+// governing the session, whereas the feed is a side channel read
+// opportunistically off a human-facing status hook, with no version
+// handle and no statement of which of the six effective-window axes
+// (finding-016) it reflects. An operator who wrote a window into the
+// manifest outranks a channel that only describes the session. Ruled
+// 2026-08-08; the full reasoning is at limitLadder.
+//
 // # Raw occupancy, not the harness's displayed figure
 //
 // The reported percentage is raw occupancy against the model's context

--- a/internal/usage/ladder_test.go
+++ b/internal/usage/ladder_test.go
@@ -1,0 +1,229 @@
+package usage
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// The resolution ladder is a ruled ordering, not an implementation
+// detail of Resolve's branch sequence. These tests hold three properties
+// that branch order alone cannot state: that the ordering covers every
+// LimitSource that exists, that it is the order the operator ruled, and
+// that Resolve actually obeys it.
+
+// TestLimitLadderIsTotal fails when a LimitSource constant is declared
+// without a place on the ladder.
+//
+// It reads the constants out of limits.go rather than listing them here,
+// because a hand-maintained list in the test is the same omission the
+// test is meant to catch: both the ladder and the list would be updated
+// by the same person in the same edit, or by neither. Parsing the source
+// is the only check that a NEW constant, added by someone who never read
+// this file, fails rather than silently ranking last.
+func TestLimitLadderIsTotal(t *testing.T) {
+	t.Parallel()
+
+	declared := limitSourceConstants(t, "limits.go")
+	if len(declared) == 0 {
+		t.Fatal("parsed no LimitSource constants from limits.go; the test's own premise is broken")
+	}
+
+	ranked := make(map[LimitSource]int, len(limitLadder))
+	for i, s := range limitLadder {
+		if prev, dup := ranked[s]; dup {
+			t.Errorf("%q appears on the ladder twice, at rungs %d and %d", s, prev+1, i+1)
+		}
+		ranked[s] = i
+	}
+
+	for _, name := range declared {
+		if _, ok := ranked[LimitSource(name)]; !ok {
+			t.Errorf("LimitSource %q is declared in limits.go but has no rung on limitLadder; give it one, and put it where its authority belongs rather than at the end", name)
+		}
+	}
+	if len(declared) != len(limitLadder) {
+		t.Errorf("limits.go declares %d LimitSource constants, the ladder has %d rungs", len(declared), len(limitLadder))
+	}
+}
+
+// TestLimitLadderIsTheRuledOrder pins the ordering itself. Changing it is
+// a decision, so this test exists to make the change deliberate: the
+// stream/feed asymmetry in particular reads like a bug and will attract
+// a well-meaning fix.
+func TestLimitLadderIsTheRuledOrder(t *testing.T) {
+	t.Parallel()
+
+	want := []LimitSource{
+		LimitFromStream,
+		LimitLearned,
+		LimitFromManifest,
+		LimitFromFeed,
+		LimitFromTable,
+		LimitFromTableAlias,
+		LimitUnresolved,
+	}
+	if len(limitLadder) != len(want) {
+		t.Fatalf("ladder has %d rungs, want %d", len(limitLadder), len(want))
+	}
+	for i := range want {
+		if limitLadder[i] != want[i] {
+			t.Errorf("rung %d = %q, want %q", i+1, limitLadder[i], want[i])
+		}
+		if got := want[i].Rank(); got != i+1 {
+			t.Errorf("%q.Rank() = %d, want %d", want[i], got, i+1)
+		}
+	}
+	if got := LimitSource("something-a-later-writer-added").Rank(); got <= LimitUnresolved.Rank() {
+		t.Errorf("an undeclared source ranks %d, at or above unresolved (%d); it must rank last, not first", got, LimitUnresolved.Rank())
+	}
+}
+
+// rung is one way to satisfy a ladder position, with a window value
+// unique to it so the winning number names the winner.
+type rung struct {
+	source LimitSource
+	limit  int
+	// apply sets whatever field of the request satisfies this rung.
+	apply func(*Request)
+	// learn, when true, requires the resolver to have learned the
+	// request's model before Resolve is called.
+	learn bool
+	// tableKey is the model id this rung needs. Rungs that do not care
+	// leave it empty.
+	tableKey string
+}
+
+// TestResolveAgreesWithTheLadder is the behavioral half: for every pair
+// of rungs that can be satisfied at once, the higher-ranked one wins.
+//
+// Pairwise rather than a single request satisfying everything, because a
+// single request only proves the top rung and would pass with the rest of
+// the ladder shuffled.
+//
+// The pair order is read from limitLadder, not from a second list written
+// here. An earlier draft did keep its own ordered list, and swapping two
+// rungs in limitLadder left this test green while
+// TestLimitLadderIsTheRuledOrder went red: it was pinning Resolve to the
+// test's opinion rather than to the ladder. Driving it from limitLadder
+// is what makes a ladder edit and a Resolve edit fail together.
+func TestResolveAgreesWithTheLadder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tableModel = "claude-haiku-4-5"
+		aliasModel = "haiku"
+	)
+	table := Table{tableModel: 905_000}
+
+	bySource := map[LimitSource]rung{
+		LimitFromStream:     {source: LimitFromStream, limit: 901_000, apply: func(r *Request) { r.SampleLimit = 901_000 }},
+		LimitLearned:        {source: LimitLearned, limit: 902_000, learn: true},
+		LimitFromManifest:   {source: LimitFromManifest, limit: 903_000, apply: func(r *Request) { r.ManifestLimit = 903_000 }},
+		LimitFromFeed:       {source: LimitFromFeed, limit: 904_000, apply: func(r *Request) { r.FeedLimit = 904_000 }},
+		LimitFromTable:      {source: LimitFromTable, limit: 905_000, tableKey: tableModel},
+		LimitFromTableAlias: {source: LimitFromTableAlias, limit: 905_000, tableKey: aliasModel},
+	}
+
+	// LimitUnresolved is the absence of every rung, so nothing satisfies
+	// it and it takes no part in the pairwise matrix.
+	var rungs []rung
+	for _, s := range limitLadder {
+		if s == LimitUnresolved {
+			continue
+		}
+		r, ok := bySource[s]
+		if !ok {
+			t.Fatalf("ladder rung %q has no way to satisfy it in this test; add one rather than skipping it", s)
+		}
+		rungs = append(rungs, r)
+	}
+
+	for i, hi := range rungs {
+		for j, lo := range rungs {
+			if i >= j {
+				continue
+			}
+			// table and table-alias are structurally exclusive: an alias
+			// is only consulted when the exact key misses, so no request
+			// satisfies both. Their order is fixed by that exclusion
+			// rather than by precedence, and TestResolveLadderPrecedence
+			// covers each singly.
+			if isTableRung(hi.source) && isTableRung(lo.source) {
+				continue
+			}
+
+			model := tableModel
+			if hi.tableKey == aliasModel || lo.tableKey == aliasModel {
+				model = aliasModel
+			}
+
+			req := Request{StreamModel: model}
+			for _, r := range []rung{hi, lo} {
+				if r.apply != nil {
+					r.apply(&req)
+				}
+			}
+
+			res := NewResolver(table)
+			if hi.learn || lo.learn {
+				w := hi.limit
+				if lo.learn {
+					w = lo.limit
+				}
+				res.Learn(model, w)
+			}
+
+			limit, src, _ := res.Resolve(req)
+			if src != hi.source {
+				t.Errorf("%q (rung %d) against %q (rung %d): source = %q, want the higher rung %q",
+					hi.source, hi.source.Rank(), lo.source, lo.source.Rank(), src, hi.source)
+			}
+			if limit != hi.limit {
+				t.Errorf("%q against %q: limit = %d, want %d", hi.source, lo.source, limit, hi.limit)
+			}
+		}
+	}
+}
+
+func isTableRung(s LimitSource) bool {
+	return s == LimitFromTable || s == LimitFromTableAlias
+}
+
+// limitSourceConstants returns the string values of every constant in
+// file declared with the type LimitSource.
+func limitSourceConstants(t *testing.T, file string) []string {
+	t.Helper()
+
+	f, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var out []string
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if id, ok := vs.Type.(*ast.Ident); !ok || id.Name != "LimitSource" {
+				continue
+			}
+			for _, v := range vs.Values {
+				lit, ok := v.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					t.Errorf("LimitSource constant with a non-literal value at %v; this test only understands string literals", vs.Names)
+					continue
+				}
+				out = append(out, lit.Value[1:len(lit.Value)-1])
+			}
+		}
+	}
+	return out
+}

--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -22,6 +22,11 @@ const (
 	LimitLearned LimitSource = "learned"
 	// LimitFromManifest means an operator set runtime.context_window.
 	LimitFromManifest LimitSource = "manifest"
+	// LimitFromFeed means the harness declared the window on a cooperative
+	// side channel rather than in its own stream: today the statusline
+	// feed's context_window.context_window_size. Ranked BELOW the manifest
+	// on purpose; see the asymmetry note below.
+	LimitFromFeed LimitSource = "feed"
 	// LimitFromTable means an exact hit in the shipped model table.
 	LimitFromTable LimitSource = "table"
 	// LimitFromTableAlias means a short alias resolved to a table entry.
@@ -30,6 +35,66 @@ const (
 	// keyed fact.
 	LimitFromTableAlias LimitSource = "table-alias"
 )
+
+// limitLadder is the total ordering of the resolution ladder, most
+// authoritative first. It is the single source of truth for precedence:
+// Rank reads it, Resolve's branch order must agree with it, and
+// TestLimitLadderIsTotal fails if a LimitSource constant is declared
+// without a place on it.
+//
+// # The stream/feed asymmetry, and why it is deliberate
+//
+// The same fact (a window the harness itself declares) sits at rung 1
+// when it arrives in the harness's own stream and at rung 4, below the
+// operator's manifest override, when it arrives on the statusline feed.
+// A reader hitting this for the first time will read it as a bug. It is
+// the operator ruling of 2026-08-08
+// (question-interactive-context-pressure, RESOLUTION LADDER), and the
+// reasoning is that transport carries information the number does not:
+//
+//   - A stream declaration is the harness stating the window it is
+//     currently enforcing compaction against, in the same channel as the
+//     token counts it is stating it about. Overruling it with a manifest
+//     value would make marvel's denominator disagree with the one that
+//     actually governs the session's behavior. The override's job is to
+//     fill absence, not to overrule measurement.
+//   - A feed declaration is a side channel: a cooperative hook the
+//     harness invokes for a human-facing status string, whose payload
+//     marvel reads opportunistically. It is one harness release away from
+//     changing meaning with no version handle on it, and the effective
+//     auto-compact window it reports varies on six axes that the operator
+//     may know about and the payload does not name (finding-016). So an
+//     operator who has written runtime.context_window has stated
+//     something the side channel cannot contradict on its own authority.
+//
+// Put shortly: rung 1 is for the channel that governs the session, and
+// the manifest outranks every channel that merely describes it.
+var limitLadder = []LimitSource{
+	LimitFromStream,
+	LimitLearned,
+	LimitFromManifest,
+	LimitFromFeed,
+	LimitFromTable,
+	LimitFromTableAlias,
+	LimitUnresolved,
+}
+
+// Rank returns the source's position on the resolution ladder, 1 being
+// the most authoritative and LimitUnresolved the least. An undeclared
+// value ranks after every declared one, so a source from a newer writer
+// is treated as least authoritative rather than most.
+//
+// Exported because precedence is a fact consumers need: an admission gate
+// that refuses on low confidence has to compare rungs, and comparing the
+// string values would encode this ordering a second time.
+func (s LimitSource) Rank() int {
+	for i, l := range limitLadder {
+		if l == s {
+			return i + 1
+		}
+	}
+	return len(limitLadder) + 1
+}
 
 // Table maps a normalized model id to its context window in tokens.
 type Table map[string]int
@@ -211,9 +276,21 @@ type Request struct {
 	RuntimeArgs []string
 	// ManifestLimit is runtime.context_window, 0 when unset.
 	ManifestLimit int
-	// SampleLimit is a window declared by the feed alongside the sample,
-	// 0 when the feed carried none.
+	// SampleLimit is a window declared in the harness's own stream
+	// alongside the sample, 0 when the stream carried none. Resolves as
+	// LimitFromStream, the top rung.
+	//
+	// No production call site populates it today: the stream-declared
+	// window reaches the accountant as Sample.DeclaredLimit and is stamped
+	// inside the fold, not through Resolve. The field is the eventual
+	// route for a feed that declares its window with the sample (a codex
+	// per-request record, an OTEL metric), and is exercised by tests.
 	SampleLimit int
+	// FeedLimit is a window declared on a cooperative side channel rather
+	// than in the stream, 0 when none arrived. Resolves as LimitFromFeed,
+	// which ranks BELOW ManifestLimit; SampleLimit ranks above it. That is
+	// the deliberate asymmetry documented at limitLadder.
+	FeedLimit int
 }
 
 // Resolver walks the denominator ladder and caches windows a harness has
@@ -243,11 +320,14 @@ func NewResolver(t Table) *Resolver {
 // A zero window means unresolved; callers must report absence rather than
 // substituting a default.
 //
-// Rung order puts the in-feed declaration above the operator override on
-// purpose: the harness's own belief about the window is what enforces
-// compaction, so it is ground truth for behavior. The override's job is
-// to fill absence, not to overrule measurement. A manifest value later
-// contradicted by an in-feed declaration is logged once, naming both.
+// The branch order below must match limitLadder, which carries the
+// reasoning and is asserted against this function in
+// TestResolveAgreesWithTheLadder. In short: an in-STREAM declaration
+// outranks the operator override because it is what enforces compaction,
+// while a declaration on the statusline FEED ranks under it because a
+// side channel describes the session rather than governing it. Either one
+// contradicting the manifest is logged once, naming both and naming which
+// won.
 func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 	model := req.StreamModel
 	if model == "" {
@@ -272,7 +352,15 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 	}
 
 	if req.ManifestLimit > 0 {
+		if req.FeedLimit > 0 && req.FeedLimit != req.ManifestLimit {
+			r.warnOnce("feed-override:"+model, "context window: %s feed declared %d for %q; the manifest's %d wins, because a side channel does not outrank an operator override",
+				req.Harness, req.FeedLimit, model, req.ManifestLimit)
+		}
 		return req.ManifestLimit, LimitFromManifest, model
+	}
+
+	if req.FeedLimit > 0 {
+		return req.FeedLimit, LimitFromFeed, model
 	}
 
 	if model != "" {

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -115,10 +115,26 @@ func TestResolveLadderPrecedence(t *testing.T) {
 			wantSource: LimitLearned,
 		},
 		{
+			// The asymmetry, stated as a case so it cannot be quietly
+			// flipped: the same fact from the same harness loses to the
+			// manifest here and beats it above, because a side channel
+			// describes the session and the stream governs it.
+			name:       "manifest beats feed",
+			req:        Request{StreamModel: "claude-haiku-4-5", FeedLimit: 444_444, ManifestLimit: 111_111},
+			wantLimit:  111_111,
+			wantSource: LimitFromManifest,
+		},
+		{
 			name:       "manifest beats table",
 			req:        Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
 			wantLimit:  111_111,
 			wantSource: LimitFromManifest,
+		},
+		{
+			name:       "feed beats table",
+			req:        Request{StreamModel: "claude-haiku-4-5", FeedLimit: 444_444},
+			wantLimit:  444_444,
+			wantSource: LimitFromFeed,
 		},
 		{
 			name:       "table exact hit",


### PR DESCRIPTION
Five parallel arms, each of which had to verify its ticket's premise before working it. Three premises came back false or incomplete, and saying so is most of the value here.

## The ladder now has a feed rung, and the feed still is not wired

`aae-orc-38yr` asked which `LimitSource` rung a harness-declared window occupies, and guessed it was "arguably the strongest rung available". The operator ruling put it **below** the manifest override. `LimitFromFeed` now sits between manifest and table.

The same fact from the same harness therefore carries opposite precedence depending on transport: rung 1 in the stream, rung 4 on the feed. That is deliberate (the stream is the channel enforcing compaction; the feed only describes the session) and it reads like a bug, so it is documented at the constant, at `limitLadder`, and in the package doc.

Precedence used to be implicit in `Resolve`'s branch order and is now an explicit total ordering, held by three tests. Worth noting how that was checked: an earlier draft of the pairwise test iterated a *second* hardcoded list, so swapping two rungs left it green. It now derives from the ladder, and the mutation goes red.

**38yr stays open.** It also turned out the feed path does not stamp the wrong source, it stamps *nothing* at all: `ctx-forward` parsed the declared window and dropped it before the heartbeat. The producer half now emits it, `internal/daemon` has no field to receive it, and that gap is documented in place rather than left to look accidental.

## rate_limits was being dropped on every tick

Claude Code has carried a `rate_limits` block on the statusline since 2.1.226, relayed from response headers the fleet already pays for. The payload struct did not declare it, so `encoding/json` discarded it silently. Same class as #141.

Captured and shown in the pane, **deliberately not forwarded**. Headroom is account-scoped: N sessions on one account are N reporters of one quantity, so a per-session column would be a category error, and every field of the heartbeat RPC is keyed to a session.

Parsing is defensive because the same binary emits `resets_at` as an epoch integer on the statusline and an ISO 8601 string on `get_usage`, with `utilization` pre-scaled on one path and 0-100 on the other. A test caught a real bug in the first cut: unmarshalling `null` into a `float64` succeeds and leaves it zero, so a null reset reported itself valid at epoch 1970.

The populated shape is **unverified** and marked so: the evidence is the builder and header parser recovered from the shipped binary plus a cold-state capture, never a populated payload.

## The readiness transition is now in the ring

`allReady` decided a successor could take over and wrote nothing. finding-018 had to poll at 50Hz to timestamp it. `team.shift-role-ready` carries workspace, team, role, successor generation, admitting gate, and session keys.

`Session` is left empty even at `replicas=1`, on purpose: `allReady` is a group gate, so populating it only when the count is one would let a consumer join by session key and silently lose every multi-replica row. The negative test cannot fail before the change, so it was given teeth by implementing the plausible wrong version (emit on launch rather than on the verdict) and confirming both tests go red.

## Sockets: 709 stale, four per run, now zero

`TestMain` killed its tmux server but never unlinked the socket, and the name carries the test binary's pid so it is never reused.

The obvious fix does not work, and that was measured rather than assumed: the tmux server exits on its own once the last session is destroyed, so by cleanup time the server cannot be asked where its socket is, and a query-only patch removed nothing. The path must be derived the way tmux derives it. Since a wrong derivation fails *silently*, a test starts a real server and compares the derived path against `#{socket_path}`.

Four sockets before, **zero after**, measured across a full `go test ./...`.

## Two issues closed as not real

- **#30** (exit codes): built a binary from `b8f1f4b`, the commit the ticket's own environment block names, and ran both reported reproductions. Both exit 1. Had "real then, fixed since" held, that binary would have exited 0.
- **#32** (logbuf dedup): fixed by PR #81 with four regression tests predating the investigation. Its surviving `--log-file` question was split out as #158 rather than closed with it.

## Cost of merge

Additive. `go build`, `go vet`, `go test ./...`, `gofumpt -l`, and `golangci-lint run` at the **CI-pinned 2.10.1** all clean. One `//nolint:unparam` with justification, on an `UnmarshalJSON` whose always-nil error is the point: `json.Unmarshaler` fixes the signature, and a real error there would reintroduce the whole-payload failure the type exists to prevent. Linting at the ambient 2.12.2 instead of the pin hid nothing here, but it did prove #119's defect is easy to re-introduce from a shell.

Refs: aae-orc-38yr, aae-orc-0ptq, aae-orc-7opc, aae-orc-h8lp, #30, #32, #119, #141, #158