### PR TITLE
Harvest: the codex correction, the rework negative, and the handoff cost model

### DIFF
--- a/_kos/nodes/frontier/question-interactive-context-pressure.yaml
+++ b/_kos/nodes/frontier/question-interactive-context-pressure.yaml
@@ -143,6 +143,55 @@ content: |
   aae-orc-k2mi (Crush), aae-orc-9jvb (opencode). The plumbing that
   gated all three shipped in marvel#153 and #154.
 
+  CODEX DONE 2026-08-08 (finding-017, marvel#156 and #159), and it did not
+  land the way this order anticipated. The probe did not add a codex
+  occupancy channel; it REMOVED one that was never real. `turn.completed`
+  is a running session total rather than a per-request level, so the exec
+  stream yields no occupancy at all and codex CTX% now renders absent
+  rather than a wrong number. Full correction and its four supporting
+  measurements: question-stream-attachment correction (iii). Crush
+  (k2mi) and opencode (9jvb) remain, and remain serialized, because all
+  three land in `internal/usage`.
+
+  THE LADDER IS BUILT, THE FEED IS NOT WIRED TO IT (marvel#159,
+  aae-orc-38yr still open). `LimitFromFeed` exists at the ruled rung, and
+  precedence is now an explicit total ordering with a test that parses the
+  constants out of `limits.go` so a rung-less `LimitSource` fails. But the
+  statusline feed does not stamp the WRONG source, it stamps NOTHING:
+  `ctx-forward` parsed the declared window, used it for a local
+  cross-check, and dropped it before the heartbeat. The producer half now
+  emits it; `internal/daemon` has no field to receive it and `internal/api`
+  leaves `ContextLimit` at zero.
+
+  Two traps recorded on 38yr for whoever finishes it. Stamping "feed" in
+  the store would implement the LABEL without the LADDER, because the
+  ruling only bites if the heartbeat path calls `Resolve` with both the
+  feed limit and the manifest limit. And `UpdateSessionHeartbeat`'s
+  percentage-only shape is the DISCRIMINATOR telling the two CTX%
+  producers apart downstream, including in bolt rehydrate and the
+  renderer, so adding a window narrows it: a contract decision, not
+  plumbing.
+
+  THE CONSENT CATALOG NAMED THE WRONG CODEX FIELD. This node's CONCEDED
+  grade cites codex's `agent_transcript_path`. All eleven hook input
+  schemas embedded in the binary require `transcript_path`;
+  `agent_transcript_path` appears in exactly one, `subagent-stop`, and is a
+  subagent's file. The consent GRADE is unchanged and the channel works;
+  the field name was wrong, and a design built on it would have found it
+  absent everywhere it mattered.
+
+  HEADROOM IS A SEPARATE QUANTITY WITH A SEPARATE ATTRIBUTION RULE
+  (`probe-rate-limit-headroom-channel-catalog.md`, aae-orc-reif). Claude's
+  statusline already carries `rate_limits` with five-hour and seven-day
+  windows, sourced from response headers, and `ctx-forward` was discarding
+  it because its struct omitted the field. Captured in marvel#159.
+  Deliberately NOT forwarded over the heartbeat: headroom is
+  account-scoped, so N sessions on one account are N reporters of ONE
+  quantity, and a per-session column of it would be a category error
+  rather than merely a hard problem. Also corrects finding-007 on codex:
+  the path is `payload.rate_limits`, a sibling of `payload.info`, not
+  inside it. opencode and Crush have no headroom channel at all.
+
   Tracked: bd aae-orc-dc1j. Related: aae-orc-7hzb (statusline probe;
   its "other harnesses" remainder is absorbed by the sweep brief),
   aae-orc-w5su (headless CTX%; scope it headless-only so nobody

--- a/_kos/nodes/frontier/question-marvel-otel-architecture.yaml
+++ b/_kos/nodes/frontier/question-marvel-otel-architecture.yaml
@@ -157,6 +157,36 @@ content: |
   Gap 1 has an instrument nobody had noticed. Worth its own check
   before it is designed around.
 
+  THE FIRST CONCRETE OTEL PRODUCER MARVEL MIGHT CONSUME IS NOT A HARNESS
+  (`study-router-and-backend-layering.md`, aae-orc-eooi, 2026-08-08). A
+  router in the path (liteLLM is the instance studied) ships an `otel`
+  callback emitting GenAI-semconv spans with model, provider, token usage,
+  and cost, plus an opt-in v2 mode producing one trace per request
+  covering auth, guardrails, the LLM call, and DB writes. Every sub-question
+  on this node is posed in terms of harnesses as the emitters. If the
+  richest emitter is a piece of infrastructure the operator already runs,
+  sub-question A (topology) and sub-question E (advertisement) both change
+  shape, because a router does not need marvel to advertise an endpoint to
+  it and is not something marvel supervises.
+
+  This does NOT reopen the occupancy ruling above. A router's spans carry
+  the same cumulative token counters, so the type mismatch stands. It bears
+  on the affirmative inventory instead: the resource-matrix rows that are
+  correctly cumulative (dollars, tokens billed, tools invoked, seconds) may
+  be better served from one router than from N harnesses, and cost in
+  particular is a quantity the router computes rather than infers.
+
+  Carried as documentary INFERENCE, not measurement: the study could not run
+  liteLLM (not installed on this host; the operator's instance was left
+  untouched by direction), so every liteLLM claim is read from vendor
+  documentation rather than executed. It also surfaced two cautions worth
+  keeping beside any adoption decision: a router can rewrite the response
+  `model` field to the client-facing alias (liteLLM issue #22709), which
+  would corrupt any per-model attribution marvel derived downstream, and
+  liteLLM shipped a credential-stealing supply-chain compromise in two
+  releases, which is a live consideration for a component that would sit in
+  the credential path.
+
   Tracked: aae-orc-e06y (the affirmative inventory), aae-orc-24oy /
   aae-orc-fkvv / aae-orc-tpda (the deferred OTEL studies, which still
   carry the superseded framing and should be updated from the

--- a/_kos/nodes/frontier/question-shift-triggers.yaml
+++ b/_kos/nodes/frontier/question-shift-triggers.yaml
@@ -80,6 +80,80 @@ content: |
   region must not be built into a default. Next attempt is rework
   detection (aae-orc-tzzn).
 
+  REWORK DETECTION RAN AND THE KNEE IS UNDECIDABLE FROM THIS CORPUS
+  (`probe-rework-detection-result.md`, aae-orc-tzzn, 2026-08-08). A
+  pre-registered failure signal fired, so it lands as a probe result and
+  NOT as a finding. 255,071 transcript lines parsed, 0 parse failures.
+  Rework does not separate across occupancy bands, in the same shape SP1's
+  error rate did not: pooled repeated-invocation runs 0.23 to 1.59 percent
+  below 600k and 1.24 percent (95 percent CI 0.68 to 2.27) above it, an
+  interval that CONTAINS the below-600k rate.
+
+  The verdict is "undecidable", deliberately not "invisible", because
+  "invisible" would claim the measurement had power to see an effect and
+  saw none. It did not have that power, and the probe can now say exactly
+  where the power went. Three structural reasons, only the first
+  anticipated by the brief:
+
+  1. THE PRIMARY ANALYSIS CANNOT REACH THE KNEE. 67 of 78 compaction
+     boundaries fire at a `preTokens` median of 467,446 and none between
+     500k and 900k, so the natural experiment's intervention sits BELOW the
+     question. The auto-compact threshold is roughly 467k; the reported
+     knee is roughly 600k.
+  2. MODEL MIX IS NOT CONSTANT ACROSS BANDS, and within-model trends
+     disagree in DIRECTION. One model steps up across 300k to 400k while
+     another falls, both with non-overlapping intervals. A flat pooled
+     series is what two opposing series produce. This applies retroactively
+     to SP1's pooled table.
+  3. THE CENSORING HAZARD IS NOT COMPUTABLE as specified: 0 of 415
+     main-thread transcripts carry a terminal `result` record.
+
+  Survivorship is also worse than the brief predicted, and for a reason the
+  brief did not have: the high-occupancy population is selected on
+  CONFIGURATION, not only on outcome, since a session only passes 500k if
+  it did not auto-compact at 467k. That is a change of population, not a
+  bias of degree. So flat-or-falling rework above 600k is NOT evidence
+  against the knee, and the dominated region still must not be built into
+  a default. Also ruled out along the way: `file-history-delta` is not a
+  revert oracle (no content digest, 7 percent file coverage).
+
+  THE HANDOFF ARTIFACT IS NOW DESIGNED, AND THE COST MATH ARGUES FOR IT
+  (`probe-shift-handoff-artifact.md`, aae-orc-7opc). Writing a handoff at
+  the p50 pressure point costs about $0.125, of which 92 percent is the
+  predecessor re-reading its own context, so asking for one costs roughly
+  one ordinary turn. Reading a 2k-token artifact is 2.6 percent of the
+  measured cold re-warm. Break-even is five successor turns at 95k
+  occupancy and ONE turn at the occupancy where shifts actually fire.
+
+  The liability is the grace window, not the tokens: three roles each
+  burning a 60s grace costs 210s, which loses to the 154s compaction by an
+  order. So handoff defaults off, and an unresponsive predecessor
+  short-circuits at one tick rather than waiting out the grace. Gate S0
+  (does any harness expose an event at which a departing agent can be
+  ASKED, and acknowledge, before its pane dies) is unanswered and blocks
+  the whole arc; a "no" across all four harnesses is a real result that
+  forces the involuntary path.
+
+  Two results from that probe bear on this node directly. The stage-rig
+  discipline RULES OUT the cheapest option: marvel already parses the
+  session stream and could summarize it with no cooperation, no bus, and
+  no cost at the pressure point, which F25 forbids on its own cited
+  measurement. And `question-marvel-graceful-stop` asks for the same
+  window under a different verb, so that should be one mechanism with two
+  callers rather than two mechanisms.
+
+  THE READINESS INSTANT IS NOW IN THE RING (marvel#159).
+  `team.shift-role-ready` fires at the `allReady` verdict carrying
+  workspace, team, role, successor generation, and the admitting gate, so
+  the 50Hz poll finding-018 needed is no longer required to price
+  launch-to-ready. Two limits an automatic trigger must respect: it stamps
+  the control plane's OBSERVATION of readiness rather than the instant the
+  successor became capable, so with a 2s ticker it is up to one tick late
+  and finding-018's 1.09s first-heartbeat column stays unobservable from
+  the ring; and `allReady` has exactly one caller, so scale-up and restart
+  still produce no readiness signal at all (aae-orc-h8lp). Anything
+  pricing time-to-useful today sees a shift-biased sample.
+
   SHIFTING IS NOT OBVIOUSLY THE CHEAP SIDE. Compaction is measured at
   154s median, up to 275s (finding-016). Standby tiers trade money for
   latency and marvel already owns the machinery (a hot standby is a

--- a/_kos/nodes/frontier/question-stream-attachment.yaml
+++ b/_kos/nodes/frontier/question-stream-attachment.yaml
@@ -118,7 +118,7 @@ content: |
   normalized to a configurable threshold plus a reserved buffer and reads
   higher than raw occupancy.
 
-  TWO CORRECTIONS TO THE PARAGRAPH ABOVE, 2026-08-08.
+  THREE CORRECTIONS TO THE PARAGRAPH ABOVE, 2026-08-08.
 
   (i) THE OPENCODE SHAPE IS WRONG AS WRITTEN. "step_finish.part.tokens.input
   (+cache)" came from finding-007's SP1, whose supporting row had both cache
@@ -141,6 +141,55 @@ content: |
   varies on six independent axes (harness release, user settings, model,
   backend service, entitlement, model slot), so it must be learned and
   invalidated per tuple rather than assigned once. Tracked: aae-orc-sj34.
+
+  (iii) THE CODEX SHAPE IS WRONG IN THE LOAD-BEARING WAY, AND THE CONSEQUENCE
+  IS THAT THE EXEC STREAM CANNOT PRODUCE CODEX OCCUPANCY AT ALL (finding-017,
+  aae-orc-pt8k). `codex exec --json` `turn.completed` reports a RUNNING SESSION
+  TOTAL, not a per-request level. The repo's own `tool_call.jsonl` fixture
+  reports 28110 for a thread whose rollout shows two requests with prompts
+  14005 then 14105 and `total_token_usage` 14005 then 28110; the exec stream
+  matches `total_token_usage` field for field. marvel was reading 28110 as
+  occupancy where the truth was 14105. This is the same class of defect
+  correction (i) records for opencode and that finding-007 measured when a
+  cumulative total was read as a level, now for the third time in this arc.
+  So the rollout behind the hook pointer is not one option among several, it
+  is the ONLY source. Fixed in marvel#159: `fold` honors `Cumulation` (a field
+  previously set and never read), codex is `CumulationSession`, and codex CTX%
+  renders absent rather than a wrong number.
+
+  Four supporting corrections from the same probe:
+
+  - `LayoutSubsumptive` for codex STANDS, but the evidence the code cited
+    could not discriminate it. `input_tokens` 13992 with `cached` 11008 is
+    equally what an additive harness shows on a large new prompt. The
+    discriminator is the window bound over 2081 records against the 258400
+    codex declares beside them: `In` alone peaks at 93.8 percent and never
+    exceeds the window, while `In + cached + cache_write` exceeds it on 801
+    records and reaches 186.6 percent.
+  - REASONING IS A SUBSET OF OUTPUT. Over 1665 nonzero-reasoning records,
+    `total == in + out` holds on all 1665 and `total == in + out + reasoning`
+    on none. `TotalMismatch` sums `In + Out + ReasoningOut`, so publishing a
+    codex Total would report a phantom mismatch on every thinking turn.
+  - THE HOOK POINTER FIELD IS `transcript_path`, NOT `agent_transcript_path`.
+    All eleven hook input schemas embedded in the codex binary list
+    `transcript_path` as required; `agent_transcript_path` appears in exactly
+    one, `subagent-stop`, where it is a SUBAGENT's file. A design built on the
+    name the consent catalog carried would have found it absent everywhere it
+    mattered.
+  - A SECOND DENOMINATOR SOURCE EXISTS that this node's "table keyed on the
+    launch -m arg" sentence does not mention:
+    `event_msg/task_started.model_context_window`, present at the start of
+    every turn (369 records), which fired even in an unauthenticated probe
+    that never received a model response.
+
+  Still open on codex, and stated rather than glossed: whether the accumulator
+  resets per turn or per session is unestablished (it needs an authenticated
+  multi-turn `codex exec resume`, declined on credential cost). And the
+  denominator CANNOT be keyed to a model from this corpus, because all three
+  models observed and all eight in the shipped table report the identical
+  258400, so "keyed by model" and "one number per account or plan" predict the
+  same data. That is the finding-007 failure shape exactly, and it was
+  reported as indeterminate rather than shipped as a table line.
 
   A related correction to the capture-pane ruling this node carries above: the
   disqualifier is not that a TUI is uncooperative, it is that there is no


### PR DESCRIPTION
Four nodes updated from two findings and four probes merged in #156 and #159. Nodes only, no charter prose, per `charter-light-touch.md`.

The load-bearing one is a correction. `question-stream-attachment` has said since 2026-08-01 that codex occupancy is `turn.completed.usage.input_tokens`. That value is a running **session total**, not a per-request level: the repo's own fixture reports 28110 for a thread whose rollout shows two requests with prompts 14005 then 14105, and `total_token_usage` 14005 then 28110. So the exec stream cannot produce codex occupancy at all, and the rollout behind the hook pointer is the only source rather than one option among several.

That is the **third time in this arc** a cumulative total was read as a level (finding-007 for claude, correction (i) for opencode, now codex). Worth noting the pattern rather than just the instance.

Four supporting corrections land with it: the `LayoutSubsumptive` evidence the code cited could not discriminate (the window bound over 2081 records can, and does, at 186.6% versus a never-exceeded 93.8%); reasoning is a subset of output, so publishing a codex Total would report a phantom mismatch on every thinking turn; the hook pointer is `transcript_path`, not the `agent_transcript_path` the consent catalog named, which appears in 1 of 11 schemas and is a *subagent's* file; and `task_started.model_context_window` is a second denominator source the node never mentioned.

Two things recorded as unestablished rather than glossed: whether the codex accumulator resets per turn or per session, and whether the window varies by model at all — every model observed reports an identical 258400, so the corpus cannot discriminate "keyed by model" from "one number per account". That is the same shape as the finding-007 failure, and it was reported as indeterminate instead of shipped as a table line.

## The rework probe as a negative

`question-shift-triggers` said the next attempt at the reliability knee was rework detection. It ran, and the knee is **undecidable** from this corpus, with a pre-registered failure signal fired. Deliberately not "invisible", which would claim the measurement had power to see an effect and saw none.

Three structural reasons, only the first anticipated: 67 of 78 compaction boundaries fire at a `preTokens` median of 467,446, putting the intervention *below* the question; model mix is not constant across bands and within-model trends disagree in direction, so a flat pooled series is what two opposing series produce (this applies retroactively to SP1's table); and no main-thread transcript carries a terminal `result` record, so the censoring hazard is not computable.

Survivorship is worse than the brief predicted, for a reason the brief did not have: the high-occupancy population is selected on **configuration**, not only outcome, since a session only passes 500k if it did not auto-compact at 467k. So flat rework above 600k is not evidence against the knee, and the dominated region still must not become a default.

## The rest

`question-interactive-context-pressure` records that codex is done and did not land as the order anticipated (the probe *removed* a channel that was never real), that the ladder is built while the feed is still unwired, and that headroom is account-scoped so a per-session column would be a category error.

`question-marvel-otel-architecture` records that the first concrete OTEL producer marvel might consume is not a harness at all. Every sub-question there is posed with harnesses as emitters. This does not reopen the occupancy ruling, since a router's spans carry the same cumulative counters, and it is carried as documentary inference with the model-rewrite and supply-chain cautions kept beside it.

## Coverage

Every finding on disk now has a node back-reference except `finding-015`, which was already orphaned before this session and is untouched here. All four YAML files parse.

Refs: aae-orc-pt8k, aae-orc-tzzn, aae-orc-reif, aae-orc-eooi, aae-orc-38yr, aae-orc-7opc, aae-orc-h8lp