### PR TITLE
fix(team): charge one crash per role per reconcile tick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,11 +202,17 @@ Recovery behavior, all shipped:
   `crashloop-backoff` with the pane left alive, so the state is visible
   while the reconciler holds off. Per-role tracking lives in
   `team.RoleHealth`, written through to the bolt `role_health` bucket and
-  rehydrated at daemon start.
+  rehydrated at daemon start. The charge is one crash per role per
+  reconcile tick, not one per lost replica: a role whose replicas go down
+  together (a tmux server dying, a host reboot, a foreign daemon
+  reclaiming the prefix) is one event, and marvel cannot see which of
+  those it was. See finding-019.
 - **`Role.MaxRestarts`** caps restarts per replica slot; on saturation the
   session is left `failed` rather than respawned. Zero means unlimited.
+  The count never decays, and clearing it means deleting the team.
 - **`crashed`** is the transition state `ReapDead` sets when a pane is
-  gone, distinguishing a dead process from a drained one.
+  gone, distinguishing a dead process from a drained one. It carries
+  `health=unhealthy`: the pane's absence is the process-alive verdict.
 - **Adopt-on-restart.** A restarted daemon rehydrates the store and runs
   `AdoptOrLeave` against the live panes; agents survive the daemon. Panes
   it has no record of are left running and reported (`reconcile.left`),

--- a/_kos/findings/finding-019-one-loss-event-charged-per-replica.md
+++ b/_kos/findings/finding-019-one-loss-event-charged-per-replica.md
@@ -1,0 +1,120 @@
+# finding-019: one loss event was charged once per replica, and marvel cannot see that it was external
+
+Date: 2026-08-09
+Observed on: `internal/team` and `internal/session` at `0886801`, reproduced
+in the package test rig (per-package tmux server, simulator-grade `sleep`
+runtimes, no model tokens)
+Bears on: `question-daemon-isolation-boundary` (the residual it names),
+`question-healthchecks`
+Work item: `aae-orc-4bz2`
+
+## What was seen
+
+A three-replica role whose whole tmux session is destroyed out of band, the
+shape a foreign daemon's reclaim produced on 2026-08-06, is charged three
+crashes in the tick that notices:
+
+```
+reap: session repro/squad-worker-g1-0 crashed (role repro/squad/worker restart #1, next backoff=59.9s)
+reap: session repro/squad-worker-g1-1 crashed (role repro/squad/worker restart #2, next backoff=2m0s)
+reap: session repro/squad-worker-g1-2 crashed (role repro/squad/worker restart #3, next backoff=4m0s)
+role health: restarts=3 backoff_until=... (in 3m59.9s)
+```
+
+`RoleHealth` is keyed by `workspace/team/role`, so a per-replica charge
+scales one event by the replica count. Two consequences follow, and the
+second is the one the ticket calls suppressed recovery.
+
+1. **The backoff exponent tracks replica count, not crash history.** One
+   event moved the window from 30s to 4m.
+2. **The restart budget is spent in a single event.** With
+   `max_restarts = 3`, the same three-replica role has nothing left; the
+   next loss saturates, `noteCrashAndBackoff` freezes `BackoffUntil` at the
+   year-9999 sentinel, and the only documented recovery is deleting the
+   team and re-applying, which destroys whatever else it still runs.
+
+All three sessions also reported `state=crashed` alongside
+`health=healthy`. `ReapDead` recorded the state transition and left the
+health reading taken while the pane was alive.
+
+## Why the obvious fix is not available
+
+The ticket asks what distinguishes an external kill from an application
+crash at the point `ReapDead` runs. Nothing marvel can see does.
+
+Both present identically: a pane ID tmux no longer lists. The tempting
+discriminator, "the whole tmux session is gone, so something external took
+it", does not survive a check. A single-pane session collapses the server
+when its process exits:
+
+```
+$ tmux -L repro-3dc644b1 new-session -d -s marvel-solo 'sleep 300'
+$ tmux -L repro-3dc644b1 list-sessions
+marvel-solo: 1 windows (created Sun Aug  9 00:55:12 2026)
+$ tmux -L repro-3dc644b1 kill-pane -t %0
+$ tmux -L repro-3dc644b1 list-sessions
+no server running on /private/tmp/tmux-501/repro-3dc644b1
+```
+
+A harness that finishes and exits leaves the same evidence a reclaim
+leaves. Any classifier built on that signal would have to choose which way
+to be wrong, and being wrong toward "external" reopens marvel#11: the
+respawn-instantly-forever loop that crash-loop backoff exists to stop.
+
+So the fix is cause-agnostic. Marvel does not guess why the panes went; it
+stops letting the blast radius of one event scale with the replica count.
+
+## What changed
+
+- `Controller.ReconcileOnce` carries a per-tick `charged` set into
+  `noteReapedCrash`. A tick that finds k panes of one role gone records one
+  crash for that role. Roles are charged independently, per-session
+  handling (including the `restart_policy=never` verdict) is unchanged, and
+  flapping still escalates because flapping repeats across ticks.
+- `Manager.ReapDead` sets `HealthState = unhealthy` when it marks a session
+  crashed. The pane's absence is the process-alive verdict; the health path
+  already defers to the reap path for that check
+  (`controller.go`, `evaluateHealth`).
+
+Tests: `TestReapChargesOneCrashPerRolePerTick` (table: one replica, three
+replicas of one role, two roles losing together),
+`TestExternalLossDoesNotExhaustMaxRestarts` (budget intact, backoff holds
+the tick, all three replicas back when the window elapses),
+`TestReapDeadClearsStaleHealthReading` (table over the prior reading).
+
+## Direction (a) is untouched and still live
+
+The ticket's forward direction, a daemon respawning agents from stale
+desired state, is unchanged by this and by everything shipped for
+`aae-orc-kvcs`. Checked directly: a store opened against a bolt file
+holding only a team record spawns processes on the first tick.
+
+```
+rehydrated teams=1 sessions=0 resource_version=2
+spawned: repro-forward/squad-worker-g1-1 state=running pane=%2 cmd=sleep
+spawned: repro-forward/squad-worker-g1-0 state=running pane=%1 cmd=sleep
+```
+
+`sleep` costs nothing. A `claude` or `codex` runtime in the same manifest
+is live model spend against whatever workspace the record still names, and
+`marvel daemon` is the whole trigger. The 2026-08-07 posture ("err on
+accumulation rather than destruction") governs panes marvel finds; it says
+nothing about desired state marvel rehydrates. Ticket items 3 and 4 are
+scoped to assess rather than implement, so this is recorded, not fixed.
+
+## Left open
+
+- **`RestartCount` never decays.** There is no success-based reset, so a
+  role that loses a pane once a month walks to saturation and freezes. K8s
+  resets after a container stays up; marvel has no equivalent. This is a
+  pre-existing property of `MaxRestarts`, not something an external kill
+  introduces, but it is the reason saturation is terminal.
+- **No recovery verb short of `marvel delete team`.** `ClearRoleHealthForTeam`
+  is reachable only through the delete cascade, which destroys sessions to
+  clear a counter.
+- **The crashed-marker cap does not hold within a tick.**
+  `clearStaleCrashed` reads the snapshot taken before the loop, where the
+  sessions about to be marked still read `running`, so a mass loss leaves
+  one marker per replica rather than the documented one per role. Cosmetic
+  while the markers clear on the next spawn.
+- **The victim daemon still records nothing** (`aae-orc-tt5e`).

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -943,6 +943,13 @@ func (m *Manager) ReapDead() []ReapedSession {
 			if err := m.store.UpdateSession(sess.Key(), func(live *api.Session) error {
 				live.State = api.SessionCrashed
 				live.PaneID = ""
+				// The absence of the pane IS the process-alive verdict
+				// (the health path defers to this one for that check), so
+				// the last reading taken while the pane was alive must
+				// not survive the transition. Without this a session
+				// killed out of band reported state=crashed alongside
+				// health=healthy. See aae-orc-4bz2.
+				live.HealthState = api.HealthUnhealthy
 				return nil
 			}); err != nil {
 				log.Printf("warning: mark crashed %s: %v", sess.Key(), err)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -490,6 +490,83 @@ func TestReapDead(t *testing.T) {
 	}
 }
 
+// TestReapDeadClearsStaleHealthReading: a session marked Crashed must not
+// keep publishing the health reading it carried while its pane was alive.
+// After an external kill, `marvel get sessions` reported state=crashed
+// alongside health=healthy: the pane's absence is the process-alive
+// verdict, and ReapDead was recording the state transition without it.
+// See aae-orc-4bz2.
+func TestReapDeadClearsStaleHealthReading(t *testing.T) {
+	skipIfNoTmux(t)
+
+	cases := []struct {
+		name  string
+		prior api.HealthState
+	}{
+		{name: "healthy", prior: api.HealthHealthy},
+		{name: "unknown", prior: api.HealthUnknown},
+		{name: "already unhealthy", prior: api.HealthUnhealthy},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := api.NewStore()
+			driver, err := tmux.NewDriver()
+			if err != nil {
+				t.Fatalf("new driver: %v", err)
+			}
+			mgr := NewManager(store, driver)
+
+			ws := "test-reap-health-" + tc.name
+			t.Cleanup(func() {
+				_ = mgr.CleanupWorkspace(ws)
+			})
+
+			sess := &api.Session{
+				Name:      "dying-0",
+				Workspace: ws,
+				Team:      "agents",
+				Role:      "worker",
+				Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			}
+			if err := mgr.Create(sess); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if err := store.UpdateSession(sess.Key(), func(live *api.Session) error {
+				live.HealthState = tc.prior
+				return nil
+			}); err != nil {
+				t.Fatalf("seed health state: %v", err)
+			}
+
+			if err := driver.KillPane(sess.PaneID); err != nil {
+				t.Fatalf("kill pane %s: %v", sess.PaneID, err)
+			}
+			deadline := time.Now().Add(2 * time.Second)
+			for driver.HasPane(sess.PaneID) && time.Now().Before(deadline) {
+				time.Sleep(20 * time.Millisecond)
+			}
+			if driver.HasPane(sess.PaneID) {
+				t.Fatalf("tmux still reports pane %s alive after kill-pane", sess.PaneID)
+			}
+
+			if reaped := mgr.ReapDead(); len(reaped) != 1 {
+				t.Fatalf("expected 1 reaped session, got %d", len(reaped))
+			}
+			got, err := store.GetSession(sess.Key())
+			if err != nil {
+				t.Fatalf("get crashed marker: %v", err)
+			}
+			if got.State != api.SessionCrashed {
+				t.Fatalf("expected state=%s, got %s", api.SessionCrashed, got.State)
+			}
+			if got.HealthState != api.HealthUnhealthy {
+				t.Errorf("expected health=%s on a crashed session, got %s", api.HealthUnhealthy, got.HealthState)
+			}
+		})
+	}
+}
+
 // TestReapDeadCapsCrashedMarkers verifies the store keeps at most one
 // Crashed session per role — a saturated role's many crashes must not
 // accumulate ghosts. See ArcavenAE/marvel#10, aae-orc-8ci.

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -265,8 +265,12 @@ func (c *Controller) ReconcileOnce() {
 	// respawned instantly forever (ArcavenAE/marvel#11). We defer the
 	// spawn decision to reconcileRole, which already honors BackoffUntil
 	// and (now) MaxRestarts saturation.
+	//
+	// The charge is per role per tick, not per lost replica: see
+	// noteReapedCrash.
+	charged := make(map[string]bool)
 	for _, r := range c.sessMgr.ReapDead() {
-		c.noteReapedCrash(r)
+		c.noteReapedCrash(r, charged)
 	}
 	c.evaluateHealth()
 
@@ -280,7 +284,22 @@ func (c *Controller) ReconcileOnce() {
 // crash in the role's health. If the team or role has vanished (e.g.,
 // workspace delete cascade in progress), the crash is untracked — the
 // reconciler won't try to recreate those sessions anyway.
-func (c *Controller) noteReapedCrash(r session.ReapedSession) {
+//
+// charged tracks which roles this tick has already charged, so a tick
+// that finds k panes of one role gone records ONE crash rather than k.
+// RoleHealth is per-role state, so charging it per lost replica scaled a
+// single event by the replica count: three replicas taken down together
+// by a tmux server dying, a foreign daemon reclaiming the marvel-* prefix,
+// or a host reboot moved the role from restart count 0 to 3 and from a
+// 30s backoff to a 4m one, and a role with max_restarts=3 spent its whole
+// budget so the next loss froze it permanently. Marvel cannot tell an
+// external kill from an application exit at this point — both present as
+// a pane ID tmux no longer lists, and a harness exiting from the last
+// pane collapses its tmux session exactly as a kill does — so the fix is
+// cause-agnostic: bound the blast radius of one event instead of guessing
+// at its cause. Flapping still escalates, because flapping repeats across
+// ticks. See aae-orc-4bz2.
+func (c *Controller) noteReapedCrash(r session.ReapedSession, charged map[string]bool) {
 	t, err := c.store.GetTeam(r.Workspace + "/" + r.Team)
 	if err != nil {
 		return
@@ -320,6 +339,12 @@ func (c *Controller) noteReapedCrash(r session.ReapedSession) {
 		})
 		return
 	}
+	if charged[roleKey] {
+		log.Printf("reap: session %s crashed with the rest of role %s in one tick; already charged",
+			r.Key, roleKey)
+		return
+	}
+	charged[roleKey] = true
 	if c.noteCrashAndBackoff(r.Workspace, r.Team, r.Role, role.MaxRestarts) {
 		rh := c.roleHealth[roleKey]
 		log.Printf("reap: session %s crashed (role %s restart #%d, next backoff=%s)",

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1051,24 +1051,187 @@ func (c *testClock) Advance(d time.Duration)  { c.t = c.t.Add(d) }
 // scoped to their per-package tmux server.
 func killPaneAndWait(t *testing.T, paneID string) {
 	t.Helper()
-	tmuxCmd := func(args ...string) *exec.Cmd {
-		if socket := os.Getenv("MARVEL_TMUX_SOCKET"); socket != "" {
-			return exec.Command("tmux", append([]string{"-L", socket}, args...)...)
-		}
-		return exec.Command("tmux", args...)
-	}
-	if err := tmuxCmd("kill-pane", "-t", paneID).Run(); err != nil {
+	if err := tmuxTestCmd("kill-pane", "-t", paneID).Run(); err != nil {
 		t.Fatalf("tmux kill-pane %s: %v", paneID, err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		out, err := tmuxCmd("list-panes", "-a", "-F", "#{pane_id}").CombinedOutput()
+		out, err := tmuxTestCmd("list-panes", "-a", "-F", "#{pane_id}").CombinedOutput()
 		if err != nil || !strings.Contains(string(out), paneID) {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("tmux still reports pane %s alive after kill-pane", paneID)
+}
+
+// tmuxTestCmd builds a tmux invocation against the per-package test
+// server TestMain created, so an out-of-band kill in a test never
+// reaches the operator's own tmux.
+func tmuxTestCmd(args ...string) *exec.Cmd {
+	if socket := os.Getenv(tmux.SocketEnv); socket != "" {
+		return exec.Command("tmux", append([]string{"-L", socket}, args...)...)
+	}
+	return exec.Command("tmux", args...)
+}
+
+// killWorkspaceAndWait destroys a workspace's whole tmux session out of
+// band: the shape of an external event that takes every replica of a role
+// down together, such as a foreign daemon reclaiming the marvel-* prefix
+// or a `tmux kill-server`. Waits until tmux confirms the session is gone
+// so the next reconcile tick observes the loss.
+func killWorkspaceAndWait(t *testing.T, workspace string) {
+	t.Helper()
+	target := "marvel-" + workspace
+	if out, err := tmuxTestCmd("kill-session", "-t", target).CombinedOutput(); err != nil {
+		t.Fatalf("tmux kill-session %s: %v (%s)", target, err, out)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := tmuxTestCmd("list-sessions", "-F", "#{session_name}").CombinedOutput()
+		if err != nil || !strings.Contains(string(out), target) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("tmux still reports session %s alive after kill-session", target)
+}
+
+// TestReapChargesOneCrashPerRolePerTick: a reconcile tick that finds k
+// panes of one role gone records ONE crash against that role, not k.
+// RoleHealth is per-role state, so charging it per lost replica scaled a
+// single event by the replica count — a three-replica role went from
+// restart count 0 to 3 and from a 30s backoff to a 4m one on a single
+// external kill. See aae-orc-4bz2.
+func TestReapChargesOneCrashPerRolePerTick(t *testing.T) {
+	skipIfNoTmux(t)
+
+	runtime := api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}
+	cases := []struct {
+		name      string
+		workspace string
+		roles     []api.Role
+	}{
+		{
+			name:      "one replica lost",
+			workspace: "test-charge-one",
+			roles: []api.Role{
+				{Name: "worker", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: runtime},
+			},
+		},
+		{
+			name:      "three replicas of one role lost together",
+			workspace: "test-charge-three",
+			roles: []api.Role{
+				{Name: "worker", Replicas: 3, RestartPolicy: api.RestartAlways, Runtime: runtime},
+			},
+		},
+		{
+			name:      "two roles lost together are charged separately",
+			workspace: "test-charge-two-roles",
+			roles: []api.Role{
+				{Name: "worker", Replicas: 3, RestartPolicy: api.RestartAlways, Runtime: runtime},
+				{Name: "supervisor", Replicas: 2, RestartPolicy: api.RestartAlways, Runtime: runtime},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, _, ctrl, cleanup := setup(t)
+			t.Cleanup(cleanup)
+
+			clock := newTestClock(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+			ctrl.now = clock.Now
+
+			createTeamFixture(t, store, tc.workspace, "squad", tc.roles)
+			ctrl.ReconcileOnce()
+			for _, role := range tc.roles {
+				if got := len(store.ListSessionsByTeamRole(tc.workspace, "squad", role.Name)); got != role.Replicas {
+					t.Fatalf("role %s: expected %d sessions, got %d", role.Name, role.Replicas, got)
+				}
+			}
+
+			killWorkspaceAndWait(t, tc.workspace)
+			ctrl.ReconcileOnce()
+
+			for _, role := range tc.roles {
+				rh, ok := ctrl.RoleHealthSnapshot(tc.workspace, "squad", role.Name)
+				if !ok {
+					t.Fatalf("role %s: expected crash-loop state after the loss", role.Name)
+				}
+				if rh.RestartCount != 1 {
+					t.Errorf("role %s: expected 1 crash for the tick, got %d", role.Name, rh.RestartCount)
+				}
+				if want := clock.Now().Add(computeBackoff(2)); !rh.BackoffUntil.Equal(want) {
+					t.Errorf("role %s: expected backoff until %s, got %s", role.Name, want, rh.BackoffUntil)
+				}
+			}
+		})
+	}
+}
+
+// TestExternalLossDoesNotExhaustMaxRestarts: losing every replica at once
+// must leave the role's restart budget intact and let the reconciler
+// repair the team when the backoff window elapses. Before the per-tick
+// charge, a three-replica role with max_restarts=3 spent its whole budget
+// on one event, and the next loss froze the role at the saturation
+// sentinel where the only recovery is deleting the team.
+func TestExternalLossDoesNotExhaustMaxRestarts(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	clock := newTestClock(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	ws := "test-external-loss"
+	createTeamFixture(t, store, ws, "squad", []api.Role{{
+		Name: "worker", Replicas: 3, MaxRestarts: 3,
+		RestartPolicy: api.RestartAlways,
+		Runtime:       api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}})
+
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRole(ws, "squad", "worker")); got != 3 {
+		t.Fatalf("expected 3 sessions, got %d", got)
+	}
+
+	killWorkspaceAndWait(t, ws)
+	ctrl.ReconcileOnce()
+
+	rh, ok := ctrl.RoleHealthSnapshot(ws, "squad", "worker")
+	if !ok {
+		t.Fatal("expected crash-loop state after the loss")
+	}
+	if rh.RestartCount != 1 {
+		t.Fatalf("expected 1 of 3 restarts spent, got %d", rh.RestartCount)
+	}
+	if rh.BackoffUntil.Equal(saturationFreezeUntil) {
+		t.Fatal("role frozen at the saturation sentinel after a single loss")
+	}
+	if alive := aliveCount(store, ws, "squad", "worker"); alive != 0 {
+		t.Fatalf("expected the backoff window to hold replacements, got %d alive", alive)
+	}
+
+	clock.Advance(2 * time.Minute)
+	ctrl.ReconcileOnce()
+
+	if alive := aliveCount(store, ws, "squad", "worker"); alive != 3 {
+		t.Fatalf("expected 3 replicas back after the backoff window, got %d", alive)
+	}
+}
+
+// aliveCount reports how many of a role's sessions count toward its
+// replica total, which is what the reconciler repairs against.
+func aliveCount(store *api.Store, workspace, team, role string) int {
+	n := 0
+	for _, sess := range store.ListSessionsByTeamRole(workspace, team, role) {
+		if sess.State.CountsAsAlive() {
+			n++
+		}
+	}
+	return n
 }
 
 func TestShiftSessionNaming(t *testing.T) {


### PR DESCRIPTION
Losing a role's replicas together should cost that role one restart, not
one per replica. Today it costs one per replica, so a single event that
takes a whole role down burns the restart budget it was supposed to
survive: a three-replica role with `max_restarts = 3` has nothing left
after one loss, and the next one freezes it at the saturation sentinel
where the only recovery is deleting the team.

Measured on a three-replica role whose tmux session is destroyed out of
band, which is the shape a foreign daemon's reclaim produced on
2026-08-06:

```
reap: ... restart #1, next backoff=59.9s
reap: ... restart #2, next backoff=2m0s
reap: ... restart #3, next backoff=4m0s
role health: restarts=3 backoff_until=... (in 3m59.9s)
```

`RoleHealth` is keyed by `workspace/team/role`, so charging it per lost
replica scales one event by the replica count in both the backoff
exponent and the `MaxRestarts` budget.

## The fix is cause-agnostic on purpose

Marvel cannot tell an external kill from an application exit at the point
`ReapDead` runs. Both present as a pane ID tmux no longer lists, and the
tempting discriminator (the whole tmux session is gone, so something
external took it) does not survive a check: a single-pane session
collapses the server when its own process exits. A classifier on that
signal would have to pick which way to be wrong, and being wrong toward
"external" reopens marvel#11, the respawn-forever loop backoff exists to
stop.

So `ReconcileOnce` carries a per-tick `charged` set into
`noteReapedCrash`: a tick that finds k panes of one role gone records one
crash for that role. Roles are charged independently, per-session
handling including the `restart_policy=never` verdict is unchanged, and
flapping still escalates because flapping repeats across ticks.

## Also in this PR

`ReapDead` sets `health=unhealthy` when it marks a session crashed. The
pane's absence is the process-alive verdict and the health path already
defers to the reap path for that check, so leaving the last live reading
in place published `state=crashed` alongside `health=healthy`, reported
in the same 2026-08-06 run.

## Cost of merge

Behavior change is confined to the reap path's bookkeeping and one health
field on an already-terminal marker. Nothing keys control flow off a
crashed session's `HealthState` (`evaluateHealth` visits running sessions
only), so that half is reporting. Full suite green, lint clean.

Tests, table-driven: `TestReapChargesOneCrashPerRolePerTick` (one
replica, three replicas of one role, two roles losing together),
`TestExternalLossDoesNotExhaustMaxRestarts` (budget intact, backoff holds
the tick, all three replicas back when the window elapses),
`TestReapDeadClearsStaleHealthReading` (table over the prior reading).
All three fail on `main`.

## Not fixed here, recorded in the finding

The ticket's forward direction is untouched and still live: a store
opened against a bolt file holding only a team record spawns processes on
the first tick, so `marvel daemon` alone can respawn agents from stale
desired state at real model spend. Ticket items 3 and 4 are scoped to
assess rather than implement. Also open: `RestartCount` never decays,
there is no recovery verb short of `marvel delete team`, and the
crashed-marker cap does not hold within a single tick.

Refs: aae-orc-4bz2, `_kos/findings/finding-019-one-loss-event-charged-per-replica.md`