### PR TITLE
test: the reap tests could not tell the shipped fence from the rejected one

### DIFF
--- a/_kos/findings/finding-014-reap-destroyed-panes-marvel-did-not-create.md
+++ b/_kos/findings/finding-014-reap-destroyed-panes-marvel-did-not-create.md
@@ -119,3 +119,48 @@ was therefore checked by breaking the code, not by watching it pass.
   live foreign daemon (`aae-orc-2cms`). That question is now narrower:
   per-HOME tmux servers mean a foreign daemon's panes are not visible at
   all.
+
+## Addendum, 2026-08-09: re-verified live, and one test added
+
+`aae-orc-reya` was filed against this defect about thirty minutes before
+PR #132 merged, so it outlived its own fix. Re-checking it produced two
+things worth keeping.
+
+**The fix holds under a live rig.** Isolated `HOME` and tmux server, a
+two-replica generic fleet, ground truth read straight from tmux: the base
+pane is present and unmarked (`%0`, `marker=`), both replicas carry
+`marker=1`, `marvel reap` says "Nothing to reap", and `reap --confirm`
+leaves every pane id in place.
+
+**Marvel is not sensitive to `base-index` or `pane-base-index`.** With
+`base-index 3` and `pane-base-index 7` set in the rig's `.tmux.conf`, the
+panes come back as `pane_index=7 window_index=3,4,5` and reap still
+reports clean. Nothing in the driver targets a pane by index; every
+`-t` argument is a `%id`.
+
+**The reason to reject the `%0` guard is sharper than "base-index is
+configurable".** Pane ids are allocated per server in creation order and
+are unaffected by either index option, so `%0` stays `%0` no matter how a
+user configures tmux. What actually breaks an id guard is a second
+workspace: two workspaces of two replicas each put the base panes at `%0`
+and `%3`, and only the first of those is `%0`. The original text is right
+that the number is not a fact, for a reason it does not name.
+
+**Which exposed a gap in the tests above.** Every test in this finding
+uses one workspace, so every one of them also passes against the guard
+this finding rejects. I confirmed that by replacing the `!p.Created`
+fence with `p.ID == "%0"` and running them:
+`TestReapReportsNothingOnAHealthyFleet` and
+`TestUnrecordedTmuxStateIgnoresPanesMarvelDidNotCreate` both PASS. The
+suite proved the defect was gone without proving the fix had the shape
+that keeps it gone.
+
+`TestReapReportsNothingWhenTheBasePaneIsNotPaneZero` closes that. It
+builds two workspaces, asserts its own preconditions (the later workspace
+has an unmarked base pane, and its id is not `%0`, so an id guard and a
+provenance guard genuinely disagree), and then asserts reap reports
+nothing. Against the `%0` fence it fails with `1 reap candidate(s), want
+0: [pane %3 in workspace test-basepane-second]`.
+
+Same lesson as the section above, one level up. The earlier check
+confirmed the behavior was right; this one confirms the mechanism is.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -745,3 +745,80 @@ func TestDaemonTempDirsAreLayoutScoped(t *testing.T) {
 		t.Errorf("projection and stream dirs are both %s, want distinct", alphaProjection)
 	}
 }
+
+// A second workspace's base pane is not %0, and that is what separates
+// the fence marvel shipped from the one it rejected.
+//
+// tmux allocates pane ids per server in creation order, so the base pane
+// of the first workspace is %0 and the base pane of the next is whatever
+// comes after that workspace's replicas. Every other test in this file
+// uses one workspace, so each of them would also pass against a guard
+// that simply skipped %0 — the shape finding-014 ruled out. Measured on a
+// live rig: two workspaces of two replicas each gave base panes at %0 and
+// %3.
+//
+// The test therefore asserts on the SECOND workspace, where an id guard
+// and a provenance guard disagree, and it fails loudly if the ids come
+// out such that they would agree.
+func TestReapReportsNothingWhenTheBasePaneIsNotPaneZero(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+
+	workspaces := []string{"test-basepane-first", "test-basepane-second"}
+	for _, ws := range workspaces {
+		if err := store.CreateWorkspace(&api.Workspace{Name: ws}); err != nil {
+			t.Fatalf("create workspace %s: %v", ws, err)
+		}
+		t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+		for i := range 2 {
+			sess := &api.Session{
+				Name:      fmt.Sprintf("t-r-g1-%d", i),
+				Workspace: ws,
+				Team:      "t",
+				Role:      "r",
+				Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			}
+			if err := mgr.Create(sess); err != nil {
+				t.Fatalf("create session %s/%s: %v", ws, sess.Name, err)
+			}
+		}
+	}
+
+	// Precondition: the later workspace really does carry an unmarked
+	// base pane whose id is not %0. Without it this test would pass
+	// against the id guard too, and prove nothing.
+	second := "marvel-" + workspaces[1]
+	panes, err := driver.ListPanes(second)
+	if err != nil {
+		t.Fatalf("list panes %s: %v", second, err)
+	}
+	var unmarked []string
+	for _, p := range panes {
+		if !p.Created {
+			unmarked = append(unmarked, p.ID)
+		}
+	}
+	if len(unmarked) == 0 {
+		t.Fatalf("%s has no unmarked base pane, so this test cannot tell the two fences apart (panes=%d)",
+			second, len(panes))
+	}
+	for _, id := range unmarked {
+		if id == "%0" {
+			t.Fatalf("%s base pane is %%0, so an id guard would agree here and the test proves nothing", second)
+		}
+	}
+
+	found, err := mgr.UnrecordedTmuxState()
+	if err != nil {
+		t.Fatalf("UnrecordedTmuxState: %v", err)
+	}
+	if len(found) != 0 {
+		t.Fatalf("healthy two-workspace fleet reports %d reap candidate(s), want 0: %v", len(found), found)
+	}
+}


### PR DESCRIPTION
The tests guarding marvel's most destructive path pass against the wrong fix. Every one of them uses a single workspace, where the base pane is always `%0`, so all of them also go green against the "skip `%0`" guard finding-014 explicitly rejected. Anyone simplifying `!p.Created` into an id check would get a clean suite and reintroduce #129 the moment a second workspace exists.

Measured rather than argued. With the fence in `UnrecordedTmuxState` replaced by `p.ID == "%0"`:

```
--- PASS: TestReapReportsNothingOnAHealthyFleet (0.15s)
--- PASS: TestUnrecordedTmuxStateIgnoresPanesMarvelDidNotCreate (0.07s)
--- FAIL: TestReapReportsNothingWhenTheBasePaneIsNotPaneZero (0.31s)
    healthy two-workspace fleet reports 1 reap candidate(s), want 0:
    [pane %3 in workspace test-basepane-second]
```

Only the new test separates them. tmux allocates pane ids per server in creation order, so two workspaces of two replicas each put the base panes at `%0` and `%3`. The test asserts on the second one and checks its own preconditions first: it fails loudly if that workspace has no unmarked base pane, or if its id comes out as `%0`, either of which would make an id guard and a provenance guard agree and leave the test proving nothing.

This also sharpens why the id guard is wrong. finding-014 says `base-index` is configurable so the number is not a fact. Measured on a live rig with `base-index 3` and `pane-base-index 7`, panes report `pane_index=7 window_index=3,4,5` and `%0` is still `%0`: neither option moves a pane id. The multi-workspace case is what actually breaks the guard.

The reason I was in here at all is that `aae-orc-reya` was filed about thirty minutes before #132 merged and read as still open. Its premise is false, and I re-verified that live rather than from source: on an isolated `HOME` and tmux server, `marvel reap` and `marvel reap --confirm` both report "Nothing to reap" on a healthy fleet and the pane set is byte-identical before and after. That verification is recorded as an addendum on finding-014 alongside the test gap.

Cost of merge: additive only. No production code changes, one test added, one finding appended. `go test ./...` and `golangci-lint run ./...` both clean.

Refs: aae-orc-reya, #129, #132