### PR TITLE
harvest: question-router-and-backend-layering — no new primitive yet, and the trigger that would change that

### DIFF
--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -155,6 +155,71 @@ content: |
   a per-team virtual key is management, and it is the one management
   act that buys fleet-wide spend attribution obtainable no other way.
 
+  THE PROVIDER IS A WINDOW KEY, MEASURED 2026-08-09 (third pass). Crush's
+  on-disk catalog `~/.local/share/crush/providers.json` is keyed provider
+  first, model second, and carries a `context_window` per entry. Read-only
+  over the static file, no server started: 40 providers, 948 distinct model
+  ids, 249 offered by more than one provider, and 141 of those 249 DISAGREE
+  on the window, 52 of them by 1.5x or more. `claude-sonnet-4-6` is 200000
+  at anthropic and 1000000 at vertexai.
+
+  ALL SEVEN model ids in marvel's shipped table are provider-variable at
+  exact spelling. The cleanest collision: marvel's table returns 1000000 for
+  `claude-opus-5` and a copilot-served model of that exact id is catalogued
+  at 264000, so marvel would resolve `LimitFromTable`, the most confident
+  non-measured rung, and be wrong by 3.8x with no signal.
+
+  A hypothesis formed and REFUTED in the same pass: copilot's uniform cost 0
+  suggested the finding-017 codex pattern (a per-account plan limit wearing a
+  model name). It is not. Copilot's 30 models carry nine distinct windows,
+  264000 on 11 of them, so copilot CLAMPS a subset below native and leaves
+  the rest. Price is the uniform thing at copilot, not the window.
+
+  HELD LOOSELY, deliberately. This is a third party's curation of 40 vendors,
+  not a measurement of any vendor's served window, and nothing here checks it
+  against a live API. Crush and marvel also DISAGREE about which axis carries
+  the 1M: marvel puts it in the model name (`claude-opus-4-8` 200000 beside
+  `claude-opus-4-8[1m]` 1000000, finding-016 axis 5, entitlement), Crush puts
+  it in the provider row (anthropic's `claude-opus-4-8` is 1000000). At least
+  one models the axis wrong and marvel cannot tell which. Provider and
+  entitlement are entangled, so keying the table by provider would relocate
+  the entanglement rather than resolve it. What the measurement DOES
+  establish: the one shipping harness here that fronts many providers, and
+  that maintains a 1405-model catalog precisely to answer "what is this
+  model's window", found it necessary to key by (provider, model).
+
+  THE CONSEQUENCE, sharper than the first pass had it. finding-016 argued the
+  table is last resort because its MISS rate is structural. The table's HIT
+  can also be wrong: for all seven keys marvel ships, a correct-looking exact
+  match returns a number whose truth depends on a provider marvel does not
+  record, does not read, and has no field for. A miss renders `?`, which is
+  designed. A wrong hit renders a confident number, which is the failure
+  internal/usage exists to prevent. Two fixes, both inside internal/usage and
+  neither a new type: (1) the KNOW step above stops being a nice provenance
+  record and becomes load-bearing, since the table is unsound without it;
+  (2) a provider-sensitivity guard, resolving `?` where an id's window varies
+  by provider and the provider is unknown. That is the `?`-rather-than-guess
+  discipline applied one level up: today it fires on an unknown model, and it
+  should also fire on a known model whose answer depends on something
+  unknown.
+
+  RULING UNCHANGED BY THE THIRD PASS. The provider is a real key and it is
+  not a marvel primitive. Crush naming provider and model as different things
+  at the same distance weakens Position A further, and requires no type: it
+  requires a field marvel already has to be keyed on one more thing, plus a
+  guard that refuses a lookup it cannot key. On cost, the opposite of what
+  Crush's provider-priced column suggests at a glance: marvel NEVER prices.
+  There is no price table in internal/usage; `Sample.CostUSD` is a *float64
+  copied from the harness's own figure. Provider is load-bearing for the
+  WINDOW and not for SPEND.
+
+  BOTH CONSEQUENCES NOW POINT AT ONE NEAR-TERM EVENT: the Crush adapter
+  (`aae-orc-k2mi`, in progress 2026-08-09). This repo's own sweep tiers Crush
+  FEED-N (occupancy on the SSE session frame; `model.context_window` from a
+  separate REST call to /v1/workspaces/{id}/agent, so "FEED-N plus a one-shot
+  lookup rather than a FEED-2"), and Crush is the harness whose catalog
+  demonstrates provider-keyed windows. Whoever ships that adapter meets both.
+
   ONE CONCRETE SITE, if backend ever becomes a key. `NormalizeModel` in
   `internal/usage/limits.go` strips `us.`, `eu.`, `apac.` and a leading
   `anthropic.` before a window lookup, justified as regional ("Pricing
@@ -175,6 +240,14 @@ content: |
   table. Whether claude's `message.model` is server-attested or
   client-echoed, which is open in the DIRECT case and which a router
   converts from a possibility into a likelihood.
+
+  STILL NOT ESTABLISHED AFTER THE THIRD PASS: whether Crush's catalog matches
+  any vendor's served window (no live API was called); whether Crush stores
+  provider as its own column or parses a namespaced string, and whether one
+  Crush session can hold rows with two providers (asked of the k2mi rig,
+  unanswered at time of writing, so the stats-surface observation stays
+  relayed rather than observed); and which of marvel or Crush models the
+  1M-entitlement axis correctly.
 edges:
   - target: question-interactive-context-pressure
     type: derives

--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -241,13 +241,63 @@ content: |
   client-echoed, which is open in the DIRECT case and which a router
   converts from a possibility into a likelihood.
 
-  STILL NOT ESTABLISHED AFTER THE THIRD PASS: whether Crush's catalog matches
-  any vendor's served window (no live API was called); whether Crush stores
-  provider as its own column or parses a namespaced string, and whether one
-  Crush session can hold rows with two providers (asked of the k2mi rig,
-  unanswered at time of writing, so the stats-surface observation stays
-  relayed rather than observed); and which of marvel or Crush models the
-  1M-entitlement axis correctly.
+  FOURTH PASS 2026-08-09: the k2mi rig answered the schema questions by
+  measurement (crush v0.88.1, isolated rig,
+  CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1, zero host drift; finding-019,
+  marvel#166). Three open items close, one framing corrects.
+
+  - The hedge RESOLVES IN FAVOR of the design-vote argument. `provider` is
+    its own nullable TEXT column on `messages`, beside `model`, live rows
+    reading provider='ollama' and model='qwen3:0.6b' separately. Not
+    liteLLM's model_group shape. Crush keys by provider in the CATALOG and
+    records provider per message in the DATABASE.
+  - Per-message and unconstrained: `sessions` carries no provider or model
+    column, so nothing structurally prevents one session holding two
+    providers. Not observed (every assistant row read ollama).
+  - NO WINDOW IN THE DATABASE. Zero hits for context/window/max_token across
+    all five tables. The harmful case is confirmed in its strongest form, and
+    the rig's formulation beats mine: the DB has per-message model
+    attribution and no window, the REST route has the window and no history,
+    neither surface joins them. Separate SURFACES, not merely separate
+    records, and the REST route reports the workspace's CURRENT agent model
+    so it cannot answer what window applied to a past message in principle.
+
+  THE NEGATIVE, which CORRECTS the framing above rather than confirming it. A
+  per-message provider column is NOT a complete routing record. Crush has two
+  model slots (models.large, models.small); with them configured to different
+  models, a TUI session's title generation ran on the small model and NO ROW
+  APPEARED (output landed in sessions.title). Summarization is the same
+  class. So messages.provider/model records the model that served each
+  persisted CONVERSATIONAL TURN, not every model call, and carries no marker
+  distinguishing the two. Crush is therefore a FOURTH internal-router
+  instance (with claude, codex, gemini) and the first to show a distinct
+  failure: the harness's own routing record is silently PARTIAL. Same shape
+  as finding-016 axis 6 (claude's three model slots) in a different vendor.
+  Consequence is a caution, not a new recommendation: a marvel that reads a
+  harness's provider field to answer "what served this session" gets a true
+  answer about a subset and no signal about the remainder.
+
+  NOT RELIED ON: the `crush stats` page that prompted the thread. Its
+  usage_by_model entries carry {model, provider, message_count} and NO token
+  fields, and its totals sum sessions.prompt_tokens, a per-request LEVEL
+  rather than a running total (measured: a three-turn session issuing 28672 /
+  28712 / 28782 contributed only 28782, undercounting ~3x). The
+  provider/model split it displays is real and stored; the token aggregation
+  beside it is not a quantity to price off. Cost is stored per SESSION
+  (sessions.cost REAL), not per message; 0.0 for ollama is a stored literal
+  from catalog pricing.
+
+  RULING AND TRIGGER UNCHANGED BY THE FOURTH PASS. Nothing here argues for a
+  primitive, and two of the named fixes absorb it: the spawn-time environment
+  record is what tells marvel which provider a session was pointed at when
+  the harness's own record is silent, and the provider-sensitivity guard is
+  unaffected. What is new is a BOUND on how much a harness-read can ever
+  deliver, which belongs in whatever design aae-orc-k2mi produces.
+
+  STILL NOT ESTABLISHED: whether Crush's catalog matches any vendor's served
+  window (no live API was called); which of marvel or Crush models the
+  1M-entitlement axis correctly; and whether a Crush session in practice ever
+  holds two providers, which the schema permits and the rig did not exhibit.
 edges:
   - target: question-interactive-context-pressure
     type: derives

--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -1,0 +1,192 @@
+id: question-router-and-backend-layering
+type: question
+confidence: frontier
+title: "Router and backend as layers below the harness: are they marvel primitives, and is the served model knowable?"
+tags:
+  - marvel
+  - observability
+  - harness
+  - resource-matrix
+content: |
+  Marvel's model of what serves an agent has one rung, the harness.
+  Reality has more: a harness talks to a ROUTER or directly to a
+  BACKEND, which may fan out further, and the router may choose per
+  request. The operator runs both shapes on the same fleet
+  (`local-ai-mac`: local and cloud are backends only, hybrid puts
+  liteLLM in front), so any model marvel adopts must describe both
+  without special-casing one.
+
+  Urgent rather than merely absent because finding-016 established that
+  CTX% needs a denominator varying on six axes, one of which is backend
+  service. A router does not add a seventh axis. It can make that axis
+  unobservable, and a model-to-window table keyed on a model marvel
+  believes is in use returns a confident wrong number when something
+  else was served. That is the silent-wrong failure this arc keeps
+  ruling against.
+
+  Studied twice: `_kos/probes/study-router-and-backend-layering.md`
+  (first pass 2026-08-08, five questions, three left unresolved on
+  purpose; addendum 2026-08-09). Source idea:
+  `_kos/ideas/router-and-backend-as-first-class-concepts.md`.
+
+  RULING 2026-08-09: NO NEW PRIMITIVE IS WARRANTED YET.
+
+  Not a B14 term. B14 composes Agent = Persona + Identity + Role(s) +
+  LLM + Tools, and its five terms are library items selected when an
+  agent is composed. A backend is resolved at REQUEST time, sometimes
+  by a party that is neither operator nor marvel. It does not belong in
+  a list of design choices.
+
+  Not a runtime property. `elem-runtime-names-harness` is bedrock and
+  holds. The reason is stronger than "a router is a third thing": the
+  internal router (below) is the harness's own behavior, so a field
+  describing it would describe the adapter rather than the deployment.
+
+  Not a resource-matrix row. Cache locality and token spend are already
+  rows. A router changes their values and their attribution; it adds no
+  resource.
+
+  What IS warranted are two fields on structs that already exist, both
+  local to `internal/usage`: a PROVENANCE GRADE on a reading's model
+  identity, ranked as `LimitSource` is ranked (server-attested vs
+  client-echoed vs launch-flag-derived), and possibly a same-record
+  axis on `profile` (below). Neither claims marvel owns a router.
+
+  The failure mode being avoided is on the record: Pack, Vault, Volume,
+  Schedule, Gateway and Readycheck survive as model-only prose with no
+  type and no code. A Router resource today would be the seventh.
+
+  THERE ARE TWO ROUTERS, AND THE FIRST PASS MODELLED ONE.
+
+  - EXTERNAL router: a separate process over the network, addressed by
+    environment, observable in principle over HTTP. liteLLM publishes
+    the distinction itself, per request, in `x-litellm-model-group`
+    (what was asked for), `x-litellm-model-id` (which deployment
+    served), and `x-litellm-model-api-base`. Marvel can read none of
+    it: the harness owns the HTTP connection and marvel reads its
+    stdout.
+  - INTERNAL router: a model-selection decision inside the harness
+    process. Claude runs up to three model slots per session
+    (`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`,
+    `CLAUDE_CODE_SUBAGENT_MODEL`); codex emits
+    `codex.compaction.model_fallback` with a `model_downshift` reason;
+    gemini routes on `model_routing` (finding-016).
+
+  Marvel already names the internal router in code and already solves
+  it. `internal/usage/sample.go:104` records that a terminal sample's
+  window must be indexed by the session's primary model because "a
+  session routing across models carries several entries with windows
+  differing by 5x, and Go map iteration is randomized." Measured in
+  this repo's own fixtures: `hello.ndjson` and `tool_call.ndjson` each
+  carry `claude-haiku-4-5-20251001` at contextWindow 200000 beside
+  `claude-fable-5[1m]` at 1000000, one session, one terminal record.
+
+  Consequence for any manifest surface, including `aae-orc-2lfg`: a
+  `backend:` field beside `runtime:` describes the external router and
+  cannot describe the internal one. It handles liteLLM and misses the
+  case that already perturbs a shipped adapter.
+
+  IS THE SERVED MODEL KNOWABLE? The question is the wrong one, and
+  marvel's own type system already separates the two facts it conflates.
+  `internal/usage/profiles.go` carries `modelFromStream` and
+  `limitInStream` as independent booleans.
+
+  - codex: names its model (turn_context.model, ten of eleven hook
+    payloads) and naming it KEYS NOTHING, because every model on the
+    host reports 258400 against a catalog giving all eight models
+    identical values. A table entry would be a per-account plan limit
+    wearing a model name (finding-017).
+  - gemini: routes usefully often and publishes NO window anywhere; the
+    denominator lives in a static table in its source (documentary,
+    `aae-orc-6c2r`).
+
+  So: marvel needs the DENOMINATOR. It needs the model only to know
+  when to INVALIDATE a learned denominator. The two are independent and
+  only one is load-bearing.
+
+  The refinement, sharper than "does the harness name its model":
+  claude routes too and it costs marvel nothing, because
+  `message.model` rides the same record as the counts it describes.
+  Gemini splits them (numerator on `AfterModel`, identity on
+  `model_routing`), so a consumer must join two streams and every gap
+  in the join attributes a count to the wrong denominator, silently.
+  The harmful property is the MODEL IDENTITY AND THE TOKEN COUNT
+  ARRIVING ON SEPARATE RECORDS. That restates the FEED-2 versus FEED-N
+  split: a FEED-2 channel carries both terms and the router is
+  harmless; a FEED-N channel carries the numerator only and marvel must
+  supply a denominator keyed on a model the router may change. A router
+  only hurts on FEED-N.
+
+  THE TRIGGER that would warrant a primitive, stated so it can be
+  recognized without judgment:
+
+    Marvel adopts a harness that routes between models AND publishes no
+    per-model window on the record carrying the token count.
+
+  Gemini is that harness. Marvel ships six adapters (claude, codex,
+  opencode, forestage, simulator, generic); gemini is not among them
+  and appears twice in the Go tree, both in a doc.go comment recording
+  it as out of scope and unavailable to measure. The trigger has not
+  fired.
+
+  SECOND TRIGGER, cheap and unrun: one curl loop of N identical
+  requests against the operator's hybrid endpoint reading
+  `x-litellm-model-id` on each. Constant id means a spawn-time record
+  answers the external case entirely. Varying id means routing is
+  per-request, "the backend of this session" has no referent, and the
+  external layer is real. This is the single most decision-relevant
+  unknown and it touches the operator's running router, so it is the
+  operator's to run.
+
+  KNOW / PRESENT / MANAGE, from the first pass and unchanged. KNOW yes,
+  and the cheapest step needs no router: record the ambient
+  backend-selecting environment observed at spawn, which also fixes the
+  DIRECT case, since marvel is equally blind there. That record is an
+  ASSIGNMENT, not an observation, and finding-016's open-loop ruling
+  applies verbatim. PRESENT yes, graded, never a synthesized guess.
+  MANAGE no, on three arguments that are not the reflexive one: SOUL
+  section 3 (a router holds live provider credentials for every backend
+  it fronts), supply chain (liteLLM's PyPI package shipped a credential
+  stealer in 1.82.7 and 1.82.8 on 2026-03-24, and marvel installing a
+  router would put marvel inside that blast radius against the
+  platform's own frozen-composition rule), and vision value 10 (a
+  router is capacity; marvel should own the record of what routed
+  where, not the routing). Boundary case left to the operator: minting
+  a per-team virtual key is management, and it is the one management
+  act that buys fleet-wide spend attribution obtainable no other way.
+
+  ONE CONCRETE SITE, if backend ever becomes a key. `NormalizeModel` in
+  `internal/usage/limits.go` strips `us.`, `eu.`, `apac.` and a leading
+  `anthropic.` before a window lookup, justified as regional ("Pricing
+  differs by region; the window does not"). The rule is stated about
+  regions and also erases the PROVIDER, since `us.anthropic.<id>` is a
+  Bedrock id and the bare form is not. finding-016 axis 4 says provider
+  can change the window and axis 5 says the 1M window is a beta gated
+  per account per backend. Not claimed wrong here: no measurement
+  compares a Bedrock window against a direct one for the same id. It is
+  the site, and it is narrow enough to settle with one measurement.
+
+  NOT ESTABLISHED. Anything about gemini by measurement (all gemini
+  claims are documentary). Anything about liteLLM by execution (the
+  whole external-router section is documentary; no instance was
+  contacted). Whether the same-record property is the right third
+  profile axis or a special case of something general. Whether a
+  Bedrock window differs from a direct one for any id in marvel's
+  table. Whether claude's `message.model` is server-attested or
+  client-echoed, which is open in the DIRECT case and which a router
+  converts from a possibility into a likelihood.
+edges:
+  - target: question-interactive-context-pressure
+    type: derives
+    note: "the layer below the harness is where finding-016's backend-service axis lives; this question asks whether marvel can read it"
+  - target: elem-runtime-names-harness
+    type: supports
+    note: "the ruling upholds it: router and backend are a third thing, and the internal router is adapter behavior rather than deployment configuration"
+  - target: elem-agentic-resource-matrix
+    type: supports
+    note: "a router changes the values and attribution of the cache-locality and token-spend rows without adding a row"
+provenance:
+  created_by: agent
+  session: marvel-eooi-router-backend-2026-08-09
+  created_at: "2026-08-09"
+  discovered_from: study-router-and-backend-layering

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -566,3 +566,227 @@ written. No liteLLM instance was contacted.
 - [LiteLLM: Security Update, Suspected Supply Chain Incident (March 2026)](https://docs.litellm.ai/blog/security-update-march-2026)
 - [LM Studio: REST API v0 endpoints](https://lmstudio.ai/docs/developer/rest/endpoints)
 
+---
+
+# Addendum, second pass, 2026-08-09
+
+Written against the same ticket after a premise check. The first pass stands
+unedited above; this pass adds what it did not reach and rules on the two
+questions it left unasked. Same three evidence grades, same standing rule.
+
+**Premise check.** The five questions the ticket names are answered above, and
+the structural claims re-verify at HEAD `0886801`: the word "backend" occurs
+once in the Go tree, in `internal/api/store.go` about bolt persistence, and
+"router" occurs nowhere. So the concepts are still absent and the first pass
+is still accurate. What was missing was a graph node, a ruling on where these
+concepts sit in the committed vocabulary, and one case.
+
+**The case.** `gemini` appears zero times in the study and zero times in the
+source idea file. It is the sharpest instance of the question, and
+`finding-016` already carried it: "router-initiated switch. gemini routes
+between models mid-session and announces it only on a separate
+`model_routing` event."
+
+## 10. There are two routers, and the first pass modelled one
+
+The study treats a router as a network hop between the harness and a backend,
+addressed by an environment variable and observable, in principle, over HTTP.
+That is one of two.
+
+- **External router.** liteLLM. A separate process reached over the network.
+  Sections 2 through 5 above are about this one.
+- **Internal router.** A model-selection decision made inside the harness
+  process, over a policy marvel never sees, published only in whatever the
+  harness chooses to emit.
+
+The internal router is not hypothetical and not confined to one vendor.
+`finding-016` lists three mechanisms: claude runs up to three model slots in
+one session (`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`,
+`CLAUDE_CODE_SUBAGENT_MODEL`), codex emits
+`codex.compaction.model_fallback` with a `model_downshift` reason, and gemini
+routes on `model_routing`.
+
+**MEASURED (this repo, HEAD).** Marvel's own code already names the internal
+router, and solves it. `internal/usage/sample.go:104` documents why a terminal
+sample's window must be indexed by the session's primary model:
+
+> Selecting that entry by anything else (first key, max, a range) is wrong: a
+> session routing across models carries several entries with windows differing
+> by 5x, and Go map iteration is randomized.
+
+**MEASURED (fixtures).** The 5x is real and it is in two of this repo's own
+claude fixtures. `hello.ndjson` and `tool_call.ndjson` each carry a terminal
+`modelUsage` map with two entries: `claude-haiku-4-5-20251001` at
+`contextWindow` 200000, and `claude-fable-5[1m]` at 1000000. One session, one
+terminal record, two denominators five times apart.
+
+So "the session's context window" is not one number in the simplest shipped
+fixture, and the reason is a router inside the harness. Marvel handles it by
+keying on `primaryRaw`.
+
+**The consequence for any manifest surface.** A `backend:` field beside
+`runtime:` describes the external router and cannot describe the internal one,
+because the internal one is not configuration marvel supplies. It is harness
+behavior. A design that adds the field handles liteLLM and misses the case
+that already perturbs a shipped adapter.
+
+## 11. Model identity and denominator identity are independent
+
+The first pass framed section 3 as "can marvel learn the served model", and
+treated that as the thing a router threatens. Two of marvel's own harnesses
+say the question is the wrong one, and marvel's type system already separates
+them: `internal/usage/profiles.go` carries `modelFromStream` and
+`limitInStream` as independent booleans on the `profile` struct.
+
+**MEASURED (this repo).** The occupied cells, with the fourth from documentary
+research rather than code:
+
+| harness | names its model | declares its window | consequence |
+|---|---|---|---|
+| claude | yes, per request | yes, per model, on the terminal line | router is announced on the same record as the count |
+| codex | no, not in the exec stream | no, not in the exec stream (the rollout declares it twice) | model name would key nothing |
+| opencode | no | no | neither term |
+| gemini | on a separate event (INFERRED) | nowhere (INFERRED) | the two terms must be joined |
+
+Codex is the case that breaks the intuition, and `finding-017` settled it:
+the model name IS captured, in `turn_context.model` and on ten of eleven hook
+payloads, and naming it keys nothing, because every model on the host reports
+258400 against a catalog giving all eight models identical values. "The window
+is keyed by model" and "the window is one number for this account and plan"
+predict identical data, so a table entry would be a per-account plan limit
+wearing a model name.
+
+Read the two together and the ruling falls out. **Marvel needs the
+denominator. It needs the model only to know when to invalidate a learned
+denominator.** Codex shows the denominator can be sound while the model key is
+worthless. Gemini would show the converse: a model key that changes usefully
+often, against no denominator at all.
+
+**The refinement, and it is sharper than "does the harness name its model".**
+Claude also routes between models, and it costs marvel nothing, because
+`message.model` rides the same record as the token counts it describes. Gemini
+splits them: the numerator arrives on `AfterModel`, the model identity on
+`model_routing`. A consumer must join two event streams, and every gap in that
+join attributes a count to the wrong denominator, silently.
+
+So the harmful property is not the router and not the missing name. It is
+**the model identity and the token count arriving on separate records**. That
+is a third profile axis the struct does not have, and it is the one worth
+adding when a harness forces it.
+
+This is the FEED-2 versus FEED-N split stated in the terms this study was
+asked about. A FEED-2 channel carries both terms, so the router is harmless
+whether it is internal or external. A FEED-N channel carries the numerator
+only, so marvel supplies the denominator from a table keyed on a model the
+router is free to change. **A router only hurts on FEED-N.**
+
+## 12. Ruling: no new primitive, and specifically not three of them
+
+The ticket asks whether router and backend are new primitives, refinements of
+B14's LLM term, or properties of the runtime. None of the three.
+
+**Not a B14 term.** B14's composition is `Agent = Persona + Identity + Role(s)
++ LLM + Tools`. Its five terms are library items selected when an agent is
+composed. A backend is not selected at composition time; it is resolved at
+request time, sometimes by a party that is neither the operator nor marvel.
+Adding it to a composition of authored artifacts would put a runtime outcome
+in a list of design choices.
+
+**Not a runtime property.** `elem-runtime-names-harness` is bedrock and
+`runtime` names the harness. The first pass is right that a router is a third
+thing. Section 10 adds the reason it cannot be folded in anyway: the internal
+router is the harness's own behavior, so a field describing it would describe
+the adapter, not the deployment.
+
+**Not a resource-matrix row.** Cache locality and token spend are already rows
+of the seventeen. A router changes their values and their attribution. It does
+not add a resource.
+
+**What is warranted instead** is the thing the first pass already named from
+the other direction, and it is a field on a struct that exists rather than a
+type that does not: a **provenance grade on the reading's model identity**,
+ranked the way `LimitSource` is ranked, distinguishing server-attested from
+client-echoed from launch-flag-derived. Section 11 adds a second candidate,
+the same-record axis on `profile`. Both are cheap, both are local to
+`internal/usage`, and neither claims marvel owns a router.
+
+The failure mode this avoids is on the record in this repo's own CLAUDE.md:
+`Pack`, `Vault`, `Volume`, `Schedule`, `Gateway` and `Readycheck` survive as
+model-only prose with no type and no code. A `Router` resource today would be
+the seventh.
+
+## 13. The one place marvel has already decided the backend does not matter
+
+Abstract questions about modelling a backend have one concrete site.
+
+**MEASURED (this repo).** `NormalizeModel` in `internal/usage/limits.go`
+strips `us.`, `eu.`, `apac.` and a leading `anthropic.` before a window
+lookup. Its documented reason is regional: "Pricing differs by region; the
+window does not." The rule is stated about regions and also erases the
+provider, because `us.anthropic.claude-sonnet-4-6` is a Bedrock model id and
+the bare form is not. Both collapse to one key.
+
+`finding-016` axis 4 says the same model id through a different provider can
+carry a different window, and axis 5 says the 1M window is gated by a beta
+header per account per backend rather than being intrinsic to the model.
+
+I am not claiming the strip is wrong: no measurement here compares a Bedrock
+window against a direct one for the same id, and the regional half of the
+justification looks sound. I am claiming this is the site. If "backend" ever
+has to become a key in marvel, it becomes one here first, and the question is
+narrow enough to settle with one measurement rather than a design.
+
+## 14. The trigger
+
+The honest answer to the ticket is that no new primitive is warranted **yet**,
+and the trigger is specific enough to recognize without judgment:
+
+> **Marvel adopts a harness that routes between models AND publishes no
+> per-model window on the record carrying the token count.**
+
+Gemini is that harness. Marvel ships six adapters (claude, codex, opencode,
+forestage, simulator, generic) and gemini is not among them; the string
+appears twice in the Go tree, both in a `doc.go` comment saying it was out of
+scope and unavailable to measure. So the trigger has not fired.
+
+A second trigger, cheaper and named in section 2 above: the operator's `curl`
+loop against the hybrid endpoint reading `x-litellm-model-id` on N identical
+requests. If the id varies, Position A is unsound and the external layer is
+real. If it is constant, a spawn-time record answers the external case
+entirely.
+
+Either one firing moves this from a concept marvel declines to carry into one
+with a measured reason to exist.
+
+## 15. What this pass did not establish
+
+- **Anything about gemini by measurement.** Every gemini claim here is
+  documentary, from the channel research recorded on `aae-orc-6c2r` (itself
+  labelled desk measurement, not a probe run) and from `finding-016`. I did
+  not run gemini, read its source, or see a `model_routing` event.
+- **Whether the same-record property is the right third profile axis** or a
+  special case of something more general. One harness suggests it; one harness
+  is not a taxonomy.
+- **Whether a Bedrock window differs from a direct window for any id marvel's
+  table carries.** Section 13 names the site, not the answer.
+- **Whether claude's `message.model` is server-attested or client-echoed.**
+  Unchanged from the first pass: two hypotheses, no discriminating evidence.
+- **Everything the first pass listed in section 7.** None of it was retested.
+
+## Addendum provenance
+
+Written 2026-08-09 against `aae-orc-eooi`, in an isolated clone at marvel HEAD
+`0886801`. Method: reading this repository and its fixtures, plus the graph
+artifacts cited. Zero model calls, zero network reads, no harness started, no
+liteLLM instance contacted, nothing outside the clone touched.
+
+## Addendum sources
+
+All in-tree: `internal/usage/sample.go`, `internal/usage/profiles.go`,
+`internal/usage/limits.go`, `internal/runtime/claudecode/testdata/hello.ndjson`
+and `tool_call.ndjson`, `internal/usage/doc.go`,
+`_kos/findings/finding-016-effective-autocompact-window-is-the-predictive-denominator.md`,
+`_kos/findings/finding-017-codex-context-pressure-channel.md`,
+`_kos/nodes/bedrock/elem-runtime-names-harness.yaml`. Gemini and Crush channel
+detail from bd `aae-orc-6c2r` notes (2026-08-08).
+

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -939,6 +939,75 @@ event: the Crush adapter (`aae-orc-k2mi`, in progress). Crush is FEED-N by
 this repo's own tiering, and Crush is the harness whose catalog demonstrates
 provider-keyed windows. Whoever ships that adapter meets both.
 
+## 21. Fourth pass: the schema answers, and one negative I did not predict
+
+The `k2mi` rig answered the four schema questions by measurement (crush
+v0.88.1, isolated rig, `CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1` to avoid the
+global-cache refresh, zero host drift). Full detail in
+`finding-019-crush-context-pressure-channel.md`, marvel#166. Three of my open
+items close and one framing of mine needs correcting.
+
+**The hedge resolves in favor of the argument.** `provider` is its own
+nullable `TEXT` column on `messages`, beside `model`, both added by later
+migration; live rows read `provider='ollama'` and `model='qwen3:0.6b'`
+separately. It is not liteLLM's `model_group` shape. Section 18's design-vote
+reading stands at the stored level, not just the catalog level: Crush keys by
+provider in the catalog AND records provider per message in the database.
+
+**Per-message, and unconstrained.** `sessions` carries no provider or model
+column at all, so nothing structurally prevents one session from holding rows
+with two providers. Not observed on the rig, where every assistant row read
+`ollama`.
+
+**No window in the database.** Zero hits for `context`, `window` or
+`max_token` across all five tables. My section 11 harmful case is confirmed in
+the strongest available form, and the rig's own formulation is sharper than
+mine: the DB has per-message model attribution and no window, the REST route
+has the window and no history, and neither surface joins them. Worse than
+separate records, they are separate surfaces, and the REST route reports the
+workspace's CURRENT agent model, so it cannot answer what window applied to a
+past message even in principle.
+
+**The negative, and it corrects section 10 rather than confirming it.** I have
+been treating a per-message provider column as a routing record. It is not a
+complete one. Crush has two model slots, `models.large` and `models.small`.
+With the slots configured to different models, a TUI session's title
+generation ran on the small model and **no row appeared**; the output landed
+in `sessions.title`. Summarization is the same class. So
+`messages.provider/model` records the model that served each persisted
+conversational turn, not every model call the session made, **and carries no
+marker distinguishing the two**.
+
+That makes Crush a fourth instance of the internal router alongside claude,
+codex and gemini, and the first to demonstrate a distinct failure: the
+harness's own routing record is silently partial. It is the same shape as
+finding-016 axis 6 (claude's three model slots), arriving in a different
+vendor with a different persistence story.
+
+The design consequence is a caution rather than a new recommendation. A marvel
+that reads a harness's provider field to answer "what served this session"
+gets a true answer about a subset and no signal about the remainder. Reading
+the harness's own record is better than guessing and is still not a
+measurement of every call.
+
+**Not relied on here:** the `crush stats` page that prompted this thread. Its
+`usage_by_model` entries carry `{model, provider, message_count}` and no token
+fields, and its totals sum `sessions.prompt_tokens`, which is a per-request
+LEVEL rather than a running total. Measured on the rig: a three-turn session
+issuing 28672 / 28712 / 28782 contributed only 28782, undercounting by about
+3x. The provider/model split it displays is real and stored; the token
+aggregation beside it is not a quantity to price anything off. Cost is stored
+per session (`sessions.cost REAL`), not per message, and the 0.0 for ollama is
+a stored literal from catalog pricing rather than a render-time derivation.
+
+**The ruling is unchanged by the fourth pass, and the trigger is unchanged.**
+Nothing here argues for a primitive. Two of the three fixes already named
+absorb it: the spawn-time environment record is what tells marvel which
+provider a session was pointed at when the harness's own record is silent, and
+the provider-sensitivity guard is unaffected. What is new is a bound on how
+much a harness-read can ever deliver, which belongs in whatever design
+`aae-orc-k2mi` produces.
+
 ## Third-pass provenance
 
 Written 2026-08-09 against `aae-orc-eooi`. Method: read-only `jq` over

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -780,6 +780,175 @@ Written 2026-08-09 against `aae-orc-eooi`, in an isolated clone at marvel HEAD
 artifacts cited. Zero model calls, zero network reads, no harness started, no
 liteLLM instance contacted, nothing outside the clone touched.
 
+---
+
+# Third pass, 2026-08-09: the provider is a window key, measured
+
+Prompted by a Crush data point relayed from the `k2mi` rig: `crush stats`
+reports Messages by Provider and Usage by Model as separate breakdowns, and
+prices per day by provider ($0.00 for a local model). The question that makes
+that evidence rather than decoration is whether the split is real in the data
+or produced by the renderer, so I went looking for the stored form.
+
+I did not start a Crush server. Starting one refreshes host-global
+`providers.json` and `hyper.json`, because `--data-dir` scopes only the
+project database.
+
+## 16. What marvel's own research already settled
+
+Two of the four questions were already answered in this repo, in
+`probe-interactive-ctx-remainder-sweep.md` round 3, measured against Crush
+v0.88.0:
+
+- **Crush is already tiered FEED-N here.** Occupancy rides the server SSE
+  session frame; `model.context_window` comes from a separate REST call to
+  `/v1/workspaces/{id}/agent`. The brief's own words: this "splits Crush's
+  feed into FEED-N plus a one-shot lookup rather than a FEED-2." So Crush sits
+  on the side of the section 11 split where a router hurts, and it is the next
+  adapter in the queue (`aae-orc-k2mi`, in progress today).
+- **The denominator source is a catalog, not a per-message field.**
+  `~/.local/share/crush/providers.json`, 40 providers, and every model
+  carries a `context_window`.
+
+## 17. The measurement: 141 of 249 shared model ids disagree on the window
+
+**MEASURED (kinu, 2026-08-09, read-only `jq` over a static file; no server
+started, no request issued).** Crush's catalog is keyed provider first, model
+second, and each model entry carries both `context_window` and per-provider
+pricing.
+
+| quantity | value |
+|---|---|
+| providers | 40 |
+| distinct model ids | 948 |
+| model ids offered by more than one provider | 249 |
+| of those, ids whose `context_window` DISAGREES across providers | **141** |
+| of those, disagreeing by 1.5x or more | **52** |
+
+Some disagreement is cosmetic (1000000 against 1048576 is decimal against
+binary). The 52 are not: `claude-sonnet-4-6` is 200000 at `anthropic` and
+1000000 at `vertexai`; `grok-4.5` spans 328000, 500000 and 1000000.
+
+**Every model id in marvel's shipped table is provider-variable, at exact
+spelling.** All seven keys, ignoring the `[1m]` suffixed forms:
+
+| marvel table key | marvel's value | catalog spread across providers |
+|---|---|---|
+| `claude-haiku-4-5` | 200000 | 200000, 204800 |
+| `claude-fable-5` (as `[1m]`) | 1000000 | 264000 (copilot), 1000000 |
+| `claude-sonnet-4-6` | 200000 | 200000 (anthropic), 1000000 (vertexai and three others) |
+| `claude-sonnet-5` | 1000000 | 264000 (copilot), 1000000 |
+| `claude-opus-4-7` | 200000 | 200000 (aihubmix), 1000000 (anthropic) |
+| `claude-opus-4-8` | 200000 | 200000 (aihubmix), 1000000 (anthropic) |
+| `claude-opus-5` | 1000000 | 264000 (copilot), 1000000 (anthropic) |
+
+`claude-opus-5` is the cleanest collision: marvel's table returns 1000000, and
+a copilot-served model of that exact id is catalogued at 264000. Marvel would
+resolve `LimitFromTable`, the most confident non-measured rung, and be wrong
+by 3.8x with no signal.
+
+**A hypothesis I formed and the data refuted.** Copilot's rows show cost 0 for
+every model, which looked like the codex pattern from finding-017: a
+per-account plan limit wearing a model name. It is not. Copilot's 30 models
+carry nine distinct windows (16384 through 1048576), with 264000 on 11 of
+them. So copilot CLAMPS a subset of models below their native window and
+leaves the rest alone, which is a third pattern beside "keyed by model" and
+"one number per account". The uniform thing at copilot is the price, not the
+window, and price and window turn out to be provider effects of different
+shapes.
+
+## 18. What this does not establish, and it matters
+
+This is **Crush's catalog**, a third party's curation of 40 vendors. It is not
+a measurement of any vendor's served window. Two reasons to hold it loosely:
+
+- A catalog can be stale or wrong, and nothing here checks one against a live
+  API.
+- **Crush and marvel disagree about which axis carries the 1M window.** Marvel
+  puts it in the model name (`claude-opus-4-8` 200000 beside
+  `claude-opus-4-8[1m]` 1000000, the entitlement axis, finding-016 axis 5).
+  Crush puts it in the provider row (anthropic's `claude-opus-4-8` is
+  1000000). At least one of them is modelling the axis wrong, and marvel
+  cannot tell which from here. Provider and entitlement are entangled, so
+  "key the table by provider" would not resolve the entanglement. It would
+  relocate it.
+
+What the measurement DOES establish is narrower and still decisive: **the one
+shipping harness in this survey that fronts many providers, and that maintains
+a 1405-model catalog precisely to answer "what is this model's window", found
+it necessary to key that catalog by (provider, model) rather than by model.**
+That is an independent design vote on the exact question of section 13, cast
+by someone who had to ship an answer.
+
+## 19. The consequence, which is sharper than the first pass had it
+
+finding-016 argued the table is the rung of last resort because its **miss**
+rate is structural. This adds the worse half: **the table's HIT can be wrong.**
+For all seven keys marvel ships, a correct-looking exact match returns a
+number whose truth depends on a provider marvel does not record, does not
+read, and has no field for. A miss renders `?`, which is the designed
+behavior. A wrong hit renders a confident number, which is the failure
+`internal/usage` exists to prevent.
+
+Two fixes, both inside `internal/usage`, neither a new type:
+
+1. **Strengthen the KNOW step the first pass already recommended.** Recording
+   the ambient provider-selecting environment at spawn stops being a nice
+   provenance record and becomes the input to (2). Section 6 argued for it on
+   the grounds that it fixes the direct case; this argues for it on the
+   grounds that the table is unsound without it.
+2. **A provider-sensitivity guard on the table.** Where an id's window varies
+   by provider and the provider is unknown, resolve `?` rather than the
+   default. That is the `?`-rather-than-guess discipline applied one level up:
+   today it fires on an unknown model, and it should also fire on a known
+   model whose answer depends on something unknown.
+
+`NormalizeModel` is where this lands, and section 13's framing needs
+correcting. I called the `anthropic.` strip "the site, not the answer" and
+said no measurement compared a Bedrock window against a direct one. The
+comparison above is not that measurement either, but it is close enough to
+retire the idea that the question is speculative. The strip's stated
+justification ("Pricing differs by region; the window does not") is sound
+about regions and silent about providers, and providers are where the 5x
+lives.
+
+## 20. The ruling is unchanged, and here is why the new evidence does not move it
+
+The provider is a real key. It is not a marvel primitive.
+
+Crush separating provider from model is a stronger version of the same
+observation the first pass made about liteLLM's model-group/deployment split:
+the layer below the harness is genuinely two-level, and Position A ("the
+router IS the backend") is weakened further, since a shipping harness names
+provider and model as different things at the same distance. None of that
+requires marvel to grow a type. It requires a field marvel already has
+somewhere to be keyed on one more thing, and a guard that refuses a lookup it
+cannot key.
+
+On the cost half of the data point: **marvel never prices.** There is no
+price table anywhere in `internal/usage`; `Sample.CostUSD` is a `*float64`
+copied from whatever the harness reported (`sample.go:134` and `:148`), and
+opencode's fixtures report `"cost":0`. Crush's provider-priced cost column is
+Crush doing a job marvel deliberately does not do. So provider is load-bearing
+for the WINDOW and not load-bearing for SPEND, which is the opposite of what
+the cost column suggests at a glance.
+
+The trigger from section 14 stands unchanged. This adds a second, independent
+consequence on a different axis, and both now point at the same near-term
+event: the Crush adapter (`aae-orc-k2mi`, in progress). Crush is FEED-N by
+this repo's own tiering, and Crush is the harness whose catalog demonstrates
+provider-keyed windows. Whoever ships that adapter meets both.
+
+## Third-pass provenance
+
+Written 2026-08-09 against `aae-orc-eooi`. Method: read-only `jq` over
+`~/.local/share/crush/providers.json` (436KB, mtime 2026-08-09 00:52, refreshed
+by another agent's rig rather than by me), plus this repo's
+`probe-interactive-ctx-remainder-sweep.md` and `internal/usage`. No Crush
+server started, no socket opened, no request issued, no file written outside
+the clone. The Crush stats-surface observation is relayed rather than
+observed; the catalog numbers are mine.
+
 ## Addendum sources
 
 All in-tree: `internal/usage/sample.go`, `internal/usage/profiles.go`,


### PR DESCRIPTION
Marvel is about to grow a manifest surface for per-agent model and provider selection (`aae-orc-2lfg`), and the obvious shape for it, a `backend:` field beside `runtime:`, is the wrong one. It describes an external router like liteLLM and cannot describe the router that already perturbs a shipped adapter, which sits inside the harness. This files the ruling and the trigger so the field is not added on reflex.

## What was already done

The study for `aae-orc-eooi` exists and stands: `_kos/probes/study-router-and-backend-layering.md`, committed `5b2ac43` on 2026-08-08, answering all five of the ticket's questions with MEASURED / INFERRED / HYPOTHESIS grades. Its structural claims re-verify at HEAD: "backend" occurs once in the Go tree, in `internal/api/store.go` about bolt persistence, and "router" occurs nowhere.

Missing were a graph node, a ruling on where these concepts sit in the committed vocabulary, and one case. `gemini` appears zero times in the study and zero times in the source idea file, while `finding-016` already names it routing between models mid-session on a separate `model_routing` event.

## The ruling

**No new primitive is warranted yet.** Not a B14 term: its five terms are library items selected when an agent is composed, and a backend is resolved at request time. Not a runtime property: `elem-runtime-names-harness` holds, and the internal router is adapter behavior rather than deployment configuration. Not a resource-matrix row: a router changes the values and attribution of cache locality and token spend without adding a resource.

What is warranted are two fields on structs that already exist, both local to `internal/usage`: a provenance grade on a reading's model identity, ranked as `LimitSource` is ranked, and possibly a same-record axis on `profile`.

`Pack`, `Vault`, `Volume`, `Schedule`, `Gateway` and `Readycheck` are already model-only prose with no type and no code. A `Router` today would be the seventh.

## The two results behind it

**There are two routers.** The external one is a network hop. The internal one is a model-selection decision inside the harness: claude's three model slots, codex's `model_fallback`, gemini's `model_routing`. Marvel already names the internal router in code and solves it, at `internal/usage/sample.go:104`, and the 5x window spread that comment cites is measurable in this repo's own fixtures: `hello.ndjson` and `tool_call.ndjson` each carry `claude-haiku-4-5-20251001` at 200000 beside `claude-fable-5[1m]` at 1000000, one session, one terminal record.

**Model identity and denominator identity are independent,** and `profile` already separates them as `modelFromStream` and `limitInStream`. Codex names its model and naming it keys nothing, because every model on the host reports 258400 (`finding-017`). Marvel needs the denominator; it needs the model only to know when to invalidate a learned one. The refinement is that claude routes too and it costs nothing, because `message.model` rides the same record as the counts it describes. The harmful property is the model identity and the token count arriving on **separate records**, which is the FEED-2 versus FEED-N split restated: a router only hurts on FEED-N.

## The trigger

> Marvel adopts a harness that routes between models AND publishes no per-model window on the record carrying the token count.

Gemini is that harness. Marvel ships six adapters and gemini is not among them, so the trigger has not fired. A second, cheaper trigger is named and unrun: one curl loop reading `x-litellm-model-id` on N identical requests decides whether routing is per-session or per-request, and it touches the operator's own router, so it is the operator's to run.

## Scope and cost

Documentation only: one new frontier node and an addendum to the existing study. No code, no behavior change, no test change. `kos validate` passes on the new node (33 nodes, 0 failed).

Every gemini claim is documentary, from the channel research on `aae-orc-6c2r` and from `finding-016`. Every liteLLM claim is documentary. No harness was started, no instance contacted, zero model calls, nothing outside an isolated clone touched. What the evidence could not decide is listed in the addendum's section 15 rather than resolved by preference.

Refs: aae-orc-eooi

---

## Update: third pass, the provider is a window key (measured)

A Crush data point (its `stats` surface reports Messages by Provider and Usage by Model as separate breakdowns) prompted checking whether that split is real in the data or produced by the renderer. Chasing the stored form found something stronger.

**MEASURED**, read-only `jq` over the static `~/.local/share/crush/providers.json`. No Crush server was started, since starting one refreshes host-global caches.

Crush's catalog is keyed provider first, model second, with a `context_window` per entry: 40 providers, 948 distinct model ids, 249 offered by more than one provider, and **141 of those 249 disagree on the window**, 52 of them by 1.5x or more. `claude-sonnet-4-6` is 200000 at anthropic and 1000000 at vertexai.

**All seven model ids in marvel's shipped table are provider-variable at exact spelling.** The cleanest collision: the table returns 1000000 for `claude-opus-5`, and a copilot-served model of that exact id is catalogued at 264000. Marvel would resolve `LimitFromTable`, the most confident non-measured rung, and be wrong by 3.8x with no signal.

One hypothesis was formed and refuted in the same pass: copilot's uniform cost 0 suggested `finding-017`'s codex pattern (a plan limit wearing a model name). It is not. Copilot's 30 models carry nine distinct windows, so it clamps a subset below native and leaves the rest.

**The consequence, which is sharper than the first pass had it.** `finding-016` argued the table is the rung of last resort because its *miss* rate is structural. The table's **hit** can also be wrong: a correct-looking exact match returns a number whose truth depends on a provider marvel does not record, does not read, and has no field for. A miss renders `?`, which is designed. A wrong hit renders a confident number, which is the failure `internal/usage` exists to prevent. Two fixes, both inside `internal/usage` and neither a new type: the spawn-time environment record becomes load-bearing rather than a nice provenance record, and a provider-sensitivity guard resolves `?` where an id's window varies by provider and the provider is unknown.

**Held loosely, deliberately.** This is a third party's curation of 40 vendors, not a measurement of any vendor's served window. Marvel and Crush also disagree about which axis carries the 1M (marvel puts it in the model name as the entitlement axis, Crush puts it in the provider row), so at least one models it wrong and marvel cannot tell which from here. Keying the table by provider would relocate that entanglement rather than resolve it.

**The ruling is unchanged.** The provider is a real key and it is not a marvel primitive. On the cost half, the opposite of what a provider-priced column suggests at a glance: marvel never prices, and `Sample.CostUSD` is a `*float64` copied from the harness's own figure, so provider is load-bearing for the window and not for spend.

Both consequences now point at one near-term event, the Crush adapter (`aae-orc-k2mi`, in progress). This repo's own sweep already tiers Crush as FEED-N plus a one-shot denominator lookup, and Crush is the harness whose catalog demonstrates provider-keyed windows. Whoever ships that adapter meets both.


---

## Update: fourth pass, the schema answers (measured by the k2mi rig)

The `k2mi` rig measured the four Crush schema questions this study had asked and left open (crush v0.88.1, isolated rig, `CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1`, zero host drift). Detail in `finding-019` / #166. Three open items close and one framing of mine corrects.

**The hedge resolves in favor of the argument.** `provider` is its own nullable `TEXT` column on `messages`, beside `model`, with live rows reading `provider='ollama'` and `model='qwen3:0.6b'` separately. Not liteLLM's `model_group` shape. So the design-vote reading holds at the stored level and not only in the catalog.

**No window anywhere in the database:** zero hits for `context`, `window` or `max_token` across all five tables. The harmful case is confirmed in its strongest form, and the rig's formulation beats mine. The DB has per-message model attribution and no window; the REST route has the window and no history; neither surface joins them. They are separate *surfaces* rather than separate records, and the REST route reports the workspace's *current* agent model, so it cannot answer what window applied to a past message even in principle.

**The negative corrects rather than confirms.** A per-message provider column is not a complete routing record. Crush has two model slots; with them configured to different models, a session's title generation ran on the small model and **no row appeared** (the output landed in `sessions.title`). Summarization is the same class. So `messages.provider/model` records the model that served each persisted conversational turn, not every model call, with no marker distinguishing the two. That makes Crush a fourth internal-router instance beside claude, codex and gemini, and the first to show that a harness's own routing record can be silently partial.

**Not relied on:** the `crush stats` page that prompted the thread. Its `usage_by_model` entries carry no token fields, and its totals sum `sessions.prompt_tokens`, a per-request level rather than a running total, undercounting a measured three-turn session by about 3x. The provider/model split it displays is real and stored; the token aggregation beside it is not a quantity to price anything off.

**Ruling and trigger unchanged.** Two of the named fixes absorb the negative: the spawn-time environment record is what tells marvel which provider a session was pointed at when the harness's own record is silent, and the provider-sensitivity guard is unaffected. What is new is a bound on how much a harness-read can ever deliver, which belongs in whatever design `aae-orc-k2mi` produces.
