### PR TITLE
fix(team): make a stuck shift's abort leave the state it claims

### DIFF
--- a/_kos/findings/finding-010-shift-abort-rollback-defects.md
+++ b/_kos/findings/finding-010-shift-abort-rollback-defects.md
@@ -50,6 +50,10 @@ when `Phase == ShiftLaunching && RoleIndex == 0`; ship together with
 Defect 2's tagging fix or the restore strands undrainable orphans):
 bd aae-orc-d0pt carries the full fixer note.
 
+FIXED 2026-08-09 (see "What the fix established" below). Past the
+first role's drain the abort now says `stopped at gen N with M of K
+roles shifted` instead of claiming a rollback it cannot perform.
+
 ## Defect 2: mid-shift repairs of non-shifting roles mint the new generation
 
 During a shift, `reconcileShift` repairs non-shifting roles via
@@ -61,6 +65,15 @@ replacement is also new-generation. Dates to the original shift probe
 (a762e35). Fix: tag non-shifting-role repairs with
 `Shift.OldGeneration`; the team generation is aspirational until the
 shift completes.
+
+FIXED 2026-08-09, with one correction to that fix shape: tagging
+EVERY non-shifting role with `OldGeneration` is wrong once the shift
+is past its first role. A role at `Shift.Roles[:RoleIndex]` has
+already been carried over and its sessions are the new generation, so
+repairing it at the old one would mint the orphan the fix was meant
+to prevent, in the other direction. The rule is per-role, not
+per-team: already-shifted roles repair at `Team.Generation`,
+everything else at `Shift.OldGeneration`.
 
 ## Defect 3: restart_policy=never bypasses crash accounting (resource leak)
 
@@ -96,12 +109,56 @@ sessions count as launched.
 `TestShiftTimeoutAbortsStuckLaunch` (controller_test.go:1181) asserts
 phase, per-generation counts, and the event, but never
 `team.Generation`, and its fixture is single-role with a one-hour
-heartbeat timeout, so the health path never fires. The runbook's
+heartbeat timeout, so the health path never fires. A single-role
+fixture cannot see Defect 2 at all: with one role there is no
+non-shifting role to repair. The runbook's
 "verified run" for beat 1d used a one-role team, matching the test
 fixture rather than the three-role manifest the beat instructs the
 operator to apply. The general lesson: a runbook beat verified only to
 its event is verified only to its event. Post-state inspection is what
 converted a passing demo into four tickets.
+
+## What the fix established (2026-08-09)
+
+Defects 1 and 2 both still reproduced on `main` at 0886801, eight days
+and roughly forty commits after they were characterized, including
+after Defect 3's fix landed. The premise check was
+`TestShiftAbortStateCoherence` run against unmodified `main`: `team
+generation = 2, want 1` and `role sidecar: session squad-sidecar-g2-0
+at generation 2, want 1`. Each half was then falsified independently
+by reverting the other, so neither test passes on one fix alone.
+
+Three things the original investigation did not name:
+
+**The two defects are one failure with two halves, and the second
+half is the load-bearing one.** Defect 1 alone is a wrong number on a
+`describe team`. What makes it structural is the session key
+`<team>-<role>-g<gen>-<index>`: a leaked generation renames every
+session the team creates afterwards, and `RoleHealth` persists to
+bolt, so the rename survives a daemon restart.
+
+**A mis-tagged repair is silently adopted as its role's new
+generation.** This one needs no abort at all. Repair a role while an
+earlier role is shifting, and the replacement is tagged at the team
+generation. When that role's turn arrives, `shiftLaunch` counts it
+against `ListSessionsByTeamRoleGeneration(role, t.Generation)`, finds
+the replica count already satisfied, and flips straight to draining.
+The role is reported shifted without ever rotating a session, and the
+session carried forward as "new generation" predates the shift.
+Covered by `TestShiftRepairBeforeTurnDoesNotCountAsLaunch`.
+
+**Defect 4 is separable and shift-independent.** The demo's third
+symptom (`restarter` and `capped` absent from `get sessions`) is not
+an abort defect. It reproduces with no shift: `restartSession`
+deletes the row before setting the backoff, so `store.ListSessions`,
+which is all `get sessions` reads, has nothing to show. The repo's
+own `TestHealthRestartBackoff` already asserts the zero-row window.
+Since Defect 3's fix, the two roles fail differently: `failstop`
+freezes with its failed row intact and is visible, while a
+`MaxRestarts`-saturated role's row is deleted first and the freeze
+then makes the absence permanent rather than a 60-second window.
+Fixing it means a new surface (a placeholder row, or `RoleHealth` in
+the listing), which is why it did not ship with the state fix.
 
 ## Method knowledge (isolation)
 
@@ -130,3 +187,10 @@ expected output; the capped-role note misses the one post-backoff
 respawn before saturation; the crashloop-backoff note needs one clause
 saying 1d is where the event becomes observable; the daemon-start
 lines should carry the distinct-socket guidance.
+
+Beat 1d's quote became true with the fix rather than needing a
+rewrite, since the demo aborts at role index 0 where rollback is the
+honest outcome. What it was missing was the post-state check that
+turned this beat into four tickets, now written into the beat. The
+remaining three items stand; the socket guidance belongs to
+aae-orc-t6da.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -237,6 +237,20 @@ after the shift started: `shift stuck in launching past 15s, rolled back to
 gen 1`. The flag wins when set; otherwise the env var is parsed as a Go
 duration; unset leaves the built-in 10-minute default.
 
+Check the state the abort left behind, not just the event. The team must be
+back on the generation the message names, and every session it holds must
+carry that generation:
+
+```sh
+./bin/marvel describe team health/ward    # Generation: 1, no shift in progress
+./bin/marvel get sessions                 # every row a g1 name
+```
+
+An abort that has already drained a role cannot roll back, because that
+role's old generation is gone. It stops where it stands instead and says so:
+`shift stuck in launching past 15s, stopped at gen 2 with 1 of 3 roles
+shifted`. Normal reconciliation converges the roles that never got a turn.
+
 ---
 
 ## Act 2 — Observe

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -437,8 +437,37 @@ func (c *Controller) reconcileOrphanedSessions(t *api.Team) {
 	}
 }
 
+// reconcileRole repairs a role at the team's current generation. Outside a
+// shift that is the only generation in play; reconcileShift calls
+// reconcileRoleAt instead, because mid-shift the team generation is
+// aspirational.
 func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
-	// Normal reconciliation uses all generations — generation scoping is only
+	c.reconcileRoleAt(t, role, t.Generation)
+}
+
+// shiftRepairGeneration returns the generation a mid-shift repair of role
+// should carry. Roles the shift has already carried over belong to the new
+// generation; every other role still belongs to the old one, because the
+// team generation is aspirational until the shift completes and an abort
+// may hand it back. Tagging every repair with the new generation is what
+// left a rolled-back team holding sessions of a generation it no longer
+// claims, undrainable because the abort deletes only the shifting role's.
+// See aae-orc-d0pt, finding-010 defect 2.
+func shiftRepairGeneration(t *api.Team, role string) int64 {
+	shifted := t.Shift.RoleIndex
+	if shifted > len(t.Shift.Roles) {
+		shifted = len(t.Shift.Roles)
+	}
+	for _, r := range t.Shift.Roles[:shifted] {
+		if r == role {
+			return t.Generation
+		}
+	}
+	return t.Shift.OldGeneration
+}
+
+func (c *Controller) reconcileRoleAt(t *api.Team, role *api.Role, generation int64) {
+	// Counting uses all generations — generation scoping is only
 	// for shift logic (shiftLaunch/shiftDrain). This ensures non-shifting roles
 	// aren't disrupted when only one role shifts and the team generation advances.
 	current := c.store.ListSessionsByTeamRole(t.Workspace, t.Name, role.Name)
@@ -505,13 +534,13 @@ func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
 		// and `marvel get sessions` doesn't carry the ghost forward.
 		c.sessMgr.ClearCrashedForRole(t.Workspace, t.Name, role.Name)
 		for i := actual; i < desired; i++ {
-			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, t.Generation, c.nextIndex(t, role, t.Generation))
+			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, generation, c.nextIndex(t, role, generation))
 			sess := &api.Session{
 				Name:       name,
 				Workspace:  t.Workspace,
 				Team:       t.Name,
 				Role:       role.Name,
-				Generation: t.Generation,
+				Generation: generation,
 				Runtime:    role.Runtime,
 			}
 			if err := c.sessMgr.Create(sess); err != nil {
@@ -914,10 +943,11 @@ func (c *Controller) reconcileShift(t *api.Team) {
 
 	shiftingRoleName := t.Shift.Roles[t.Shift.RoleIndex]
 
-	// Reconcile non-shifting roles normally with current generation.
+	// Reconcile non-shifting roles normally, each at the generation it
+	// actually belongs to. See shiftRepairGeneration.
 	for i := range t.Roles {
 		if t.Roles[i].Name != shiftingRoleName {
-			c.reconcileRole(t, &t.Roles[i])
+			c.reconcileRoleAt(t, &t.Roles[i], shiftRepairGeneration(t, t.Roles[i].Name))
 		}
 	}
 
@@ -955,23 +985,42 @@ func (c *Controller) reconcileShift(t *api.Team) {
 // normal reconciliation converges the replica counts. Either way the
 // shift state is cleared, which resumes normal reconciliation and
 // unblocks scale (the daemon refuses scale while a shift is in progress).
-// An operator-visible warning names the phase and the generation rolled
-// back to. Caller holds c.mu. See aae-orc-qkfl.
+// An operator-visible warning names the phase and the state the abort
+// left: the generation rolled back to, or the generation it stopped at
+// and how far it got. Caller holds c.mu. See aae-orc-qkfl, aae-orc-d0pt.
 func (c *Controller) abortStuckShift(t *api.Team) {
 	var role string
 	if t.Shift.RoleIndex < len(t.Shift.Roles) {
 		role = t.Shift.Roles[t.Shift.RoleIndex]
 	}
+	// Rolling the counter back is only honest while nothing has drained.
+	// At the first role's launch the pre-shift state is intact, so the
+	// team goes back to the generation it came from. Once a drain has
+	// happened the old generation's sessions are gone, and handing the
+	// team back to it would name a generation that no longer exists; the
+	// shift stops where it stands instead, and reconciliation converges
+	// the roles that never got their turn. Generation is written in
+	// exactly two places, InitiateShift and here; without this restore a
+	// stuck shift leaked one permanently, and since the session key is
+	// <team>-<role>-g<gen>-<index> the leak renamed every session the
+	// team created afterwards. See aae-orc-d0pt, finding-010 defect 1.
+	rollback := t.Shift.Phase == api.ShiftLaunching && t.Shift.RoleIndex == 0
+	oldGen := t.Shift.OldGeneration
 	elapsed := c.nowUTC().Sub(t.Shift.StartedAt)
-	log.Printf("shift: %s stuck in %s for %s (role %s), aborting and rolling back to gen %d",
-		t.Key(), t.Shift.Phase, elapsed, role, t.Shift.OldGeneration)
+	outcome := fmt.Sprintf("rolled back to gen %d", oldGen)
+	if !rollback {
+		outcome = fmt.Sprintf("stopped at gen %d with %d of %d roles shifted",
+			t.Generation, t.Shift.RoleIndex, len(t.Shift.Roles))
+	}
+	log.Printf("shift: %s stuck in %s for %s (role %s), aborting, %s",
+		t.Key(), t.Shift.Phase, elapsed, role, outcome)
 	events.Emit(c.Events, events.Event{
 		Kind:      events.KindShiftTimedOut,
 		Severity:  events.SeverityWarning,
 		Workspace: t.Workspace,
 		Team:      t.Name,
 		Role:      role,
-		Message:   fmt.Sprintf("shift stuck in %s past %s, rolled back to gen %d", t.Shift.Phase, c.shiftTimeout(), t.Shift.OldGeneration),
+		Message:   fmt.Sprintf("shift stuck in %s past %s, %s", t.Shift.Phase, c.shiftTimeout(), outcome),
 	})
 	if t.Shift.Phase == api.ShiftLaunching && role != "" {
 		for _, sess := range c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role, t.Generation) {
@@ -980,10 +1029,18 @@ func (c *Controller) abortStuckShift(t *api.Team) {
 			}
 		}
 	}
-	_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
+	if err := c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
+		if rollback {
+			live.Generation = oldGen
+		}
 		live.Shift = api.ShiftState{}
 		return nil
-	})
+	}); err != nil {
+		log.Printf("shift: abort clear shift state for %s: %v", t.Key(), err)
+	}
+	if rollback {
+		t.Generation = oldGen
+	}
 	t.Shift = api.ShiftState{}
 }
 

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1918,3 +1918,263 @@ func TestShiftRoleReadyEventIsPerRole(t *testing.T) {
 		}
 	}
 }
+
+// roleGen is one role's post-condition: how many sessions it should have
+// and which generation they should carry.
+type roleGen struct {
+	role       string
+	count      int
+	generation int64
+}
+
+// TestShiftAbortStateCoherence covers aae-orc-d0pt: the state a stuck
+// shift's abort leaves behind must match what the abort event claims. Two
+// cases, because the honest answer differs by how far the shift got.
+//
+// Falsification: without the Generation restore in abortStuckShift the
+// launching case fails on team.Generation (2, want 1); without the
+// old-generation tagging in reconcileShift it fails on the non-shifting
+// role's sessions surviving the abort at generation 2; without the
+// phase/index guard the draining case fails by restoring a generation
+// whose sessions were already drained.
+func TestShiftAbortStateCoherence(t *testing.T) {
+	skipIfNoTmux(t)
+
+	beat := func() *api.HealthCheck {
+		// Generous timeout: the sessions stay HealthUnknown rather than
+		// unhealthy, so the only thing blocking the shift is allReady's
+		// first-heartbeat requirement, which never arrives.
+		return &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 1 * time.Hour, FailureThreshold: 3}
+	}
+	sleeper := api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}
+
+	tests := []struct {
+		name string
+		ws   string
+		// roles in shift order; the stuck one carries the heartbeat gate.
+		roles []api.Role
+		// drive advances the shift to the point the abort should fire.
+		drive func(t *testing.T, store *api.Store, sessMgr *session.Manager, ctrl *Controller, teamKey string)
+		// wantGen is the team generation the abort must leave behind.
+		wantGen int64
+		// wantRoles is the per-role session state after the abort.
+		wantRoles []roleGen
+		wantMsg   string
+	}{
+		{
+			// Nothing has drained, so the pre-shift state is still intact
+			// and rollback is the honest outcome: the generation counter
+			// goes back, and no session anywhere carries the abandoned
+			// generation. The sidecar is deleted mid-shift to force the
+			// repair path that mints replacements while a shift is open.
+			name: "launching first role rolls back",
+			ws:   "test-abort-launching",
+			roles: []api.Role{
+				{Name: "worker", Replicas: 1, Runtime: sleeper, HealthCheck: beat()},
+				{Name: "sidecar", Replicas: 1, Runtime: sleeper},
+			},
+			drive: func(t *testing.T, store *api.Store, sessMgr *session.Manager, ctrl *Controller, teamKey string) {
+				t.Helper()
+				ctrl.ReconcileOnce() // launches the stuck gen-2 worker
+				sides := store.ListSessionsByTeamRole("test-abort-launching", "squad", "sidecar")
+				if len(sides) != 1 {
+					t.Fatalf("sidecar sessions before repair = %d, want 1", len(sides))
+				}
+				if err := sessMgr.Delete(sides[0].Key()); err != nil {
+					t.Fatalf("delete sidecar: %v", err)
+				}
+				ctrl.ReconcileOnce() // repairs the sidecar mid-shift
+			},
+			wantGen: 1,
+			wantRoles: []roleGen{
+				{role: "worker", count: 1, generation: 1},
+				{role: "sidecar", count: 1, generation: 1},
+			},
+			wantMsg: "rolled back to gen 1",
+		},
+		{
+			// alpha has already shifted and its old generation is gone, so
+			// restoring the counter would point the team at a generation
+			// that no longer exists. The shift stops where it stands and
+			// the message says so.
+			name: "draining past first role stops forward",
+			ws:   "test-abort-forward",
+			roles: []api.Role{
+				{Name: "alpha", Replicas: 1, Runtime: sleeper},
+				{Name: "beta", Replicas: 1, Runtime: sleeper, HealthCheck: beat()},
+			},
+			drive: func(t *testing.T, store *api.Store, sessMgr *session.Manager, ctrl *Controller, teamKey string) {
+				t.Helper()
+				// Ticks: alpha launches and goes ready, drains, index
+				// advances, then beta launches and sticks.
+				for i := 0; i < 6; i++ {
+					ctrl.ReconcileOnce()
+				}
+				team, err := store.GetTeam(teamKey)
+				if err != nil {
+					t.Fatalf("get team: %v", err)
+				}
+				if team.Shift.RoleIndex != 1 {
+					t.Fatalf("role index = %d, want 1 (alpha shifted, beta stuck)", team.Shift.RoleIndex)
+				}
+			},
+			wantGen: 2,
+			wantRoles: []roleGen{
+				{role: "alpha", count: 1, generation: 2},
+				{role: "beta", count: 1, generation: 1},
+			},
+			wantMsg: "stopped at gen 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, sessMgr, ctrl, cleanup := setup(t)
+			t.Cleanup(cleanup)
+			ring := events.NewRing(0)
+			ctrl.Events = ring
+			clock := newTestClock(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+			ctrl.now = clock.Now
+			ctrl.ShiftTimeout = 2 * time.Minute
+
+			createTeamFixture(t, store, tc.ws, "squad", tc.roles)
+			teamKey := tc.ws + "/squad"
+
+			ctrl.ReconcileOnce()
+			if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+				t.Fatalf("initiate shift: %v", err)
+			}
+			tc.drive(t, store, sessMgr, ctrl, teamKey)
+
+			clock.Advance(3 * time.Minute)
+			ctrl.ReconcileOnce()
+
+			team, err := store.GetTeam(teamKey)
+			if err != nil {
+				t.Fatalf("get team: %v", err)
+			}
+			if team.Generation != tc.wantGen {
+				t.Errorf("team generation = %d, want %d", team.Generation, tc.wantGen)
+			}
+			if team.Shift.Phase != api.ShiftNone || team.Shift.OldGeneration != 0 ||
+				team.Shift.RoleIndex != 0 || len(team.Shift.Roles) != 0 || !team.Shift.StartedAt.IsZero() {
+				t.Errorf("shift state = %+v, want zero (shift cleared)", team.Shift)
+			}
+			for _, want := range tc.wantRoles {
+				all := store.ListSessionsByTeamRole(tc.ws, "squad", want.role)
+				if len(all) != want.count {
+					t.Errorf("role %s: %d sessions, want %d", want.role, len(all), want.count)
+				}
+				for _, s := range all {
+					if s.Generation != want.generation {
+						t.Errorf("role %s: session %s at generation %d, want %d",
+							want.role, s.Name, s.Generation, want.generation)
+					}
+				}
+			}
+			evs := ring.Snapshot(events.Filter{Kind: events.KindShiftTimedOut}, 0)
+			if len(evs) != 1 {
+				t.Fatalf("shift-timed-out events = %d, want 1", len(evs))
+			}
+			if !strings.Contains(evs[0].Message, tc.wantMsg) {
+				t.Errorf("abort message = %q, want it to contain %q", evs[0].Message, tc.wantMsg)
+			}
+
+			// One more tick: the post-abort state must be a fixed point,
+			// not a state normal reconciliation immediately re-mints out of.
+			ctrl.ReconcileOnce()
+			for _, want := range tc.wantRoles {
+				for _, s := range store.ListSessionsByTeamRole(tc.ws, "squad", want.role) {
+					if s.Generation != want.generation {
+						t.Errorf("after a settling tick, role %s: session %s at generation %d, want %d",
+							want.role, s.Name, s.Generation, want.generation)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestShiftRepairBeforeTurnDoesNotCountAsLaunch covers the healthy-path
+// half of aae-orc-d0pt's tagging defect. A role repaired while an earlier
+// role is shifting must keep the old generation, or shiftLaunch counts the
+// repair as that role's new generation when its turn comes and the role is
+// declared shifted without ever rotating a session.
+//
+// Falsification: with the repair tagged at the team generation, beta's turn
+// finds its replica count already satisfied at generation 2, so no
+// beta-g2 session is created and the session predating the shift is the
+// one carried forward.
+func TestShiftRepairBeforeTurnDoesNotCountAsLaunch(t *testing.T) {
+	skipIfNoTmux(t)
+	store, sessMgr, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	sleeper := api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}
+
+	createTeamFixture(t, store, "test-shift-repair", "squad", []api.Role{
+		{Name: "alpha", Replicas: 1, Runtime: sleeper},
+		{Name: "beta", Replicas: 1, Runtime: sleeper},
+	})
+	teamKey := "test-shift-repair/squad"
+
+	ctrl.ReconcileOnce()
+	if err := ctrl.InitiateShift(teamKey, ""); err != nil {
+		t.Fatalf("initiate shift: %v", err)
+	}
+
+	// Kill beta while alpha holds the shift, then let the reconciler
+	// repair it. beta has not had its turn, so the replacement belongs to
+	// the generation beta is still running.
+	betas := store.ListSessionsByTeamRole("test-shift-repair", "squad", "beta")
+	if len(betas) != 1 {
+		t.Fatalf("beta sessions = %d, want 1", len(betas))
+	}
+	if err := sessMgr.Delete(betas[0].Key()); err != nil {
+		t.Fatalf("delete beta: %v", err)
+	}
+	ctrl.ReconcileOnce()
+
+	repaired := store.ListSessionsByTeamRole("test-shift-repair", "squad", "beta")
+	if len(repaired) != 1 {
+		t.Fatalf("beta sessions after repair = %d, want 1", len(repaired))
+	}
+	if repaired[0].Generation != 1 {
+		t.Fatalf("mid-shift repair of a role awaiting its turn = generation %d, want 1",
+			repaired[0].Generation)
+	}
+	repairedKey := repaired[0].Key()
+
+	// Run the shift out. beta's turn must launch a fresh generation-2
+	// session and drain the repair, not adopt it.
+	for i := 0; i < 40; i++ {
+		ctrl.ReconcileOnce()
+		team, err := store.GetTeam(teamKey)
+		if err != nil {
+			t.Fatalf("get team: %v", err)
+		}
+		if team.Shift.Phase == api.ShiftNone {
+			break
+		}
+	}
+	team, err := store.GetTeam(teamKey)
+	if err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	if team.Shift.Phase != api.ShiftNone {
+		t.Fatalf("shift did not complete, phase %s", team.Shift.Phase)
+	}
+	if _, err := store.GetSession(repairedKey); err == nil {
+		t.Errorf("session %s survived the shift, want it drained with generation 1", repairedKey)
+	}
+	for _, role := range []string{"alpha", "beta"} {
+		sessions := store.ListSessionsByTeamRole("test-shift-repair", "squad", role)
+		if len(sessions) != 1 {
+			t.Errorf("role %s: %d sessions after the shift, want 1", role, len(sessions))
+			continue
+		}
+		if sessions[0].Generation != 2 {
+			t.Errorf("role %s: session %s at generation %d after the shift, want 2",
+				role, sessions[0].Name, sessions[0].Generation)
+		}
+	}
+}


### PR DESCRIPTION
A shift that times out tells the operator it rolled back to the previous generation. It does not. The team keeps the generation it was reaching for, and since a session key is `<team>-<role>-g<gen>-<index>`, that leaked number renames every session the team creates afterwards, across daemon restarts. An operator reading `describe team` after a failed shift sees `Generation: 2` beside `Shift.OldGeneration: 0` and has no way to tell what state the team is actually in.

`Team.Generation` was written in exactly one place, `InitiateShift`. Nothing decremented it, and the abort zeroed `Shift`, erasing the rollback target on the way out.

**The fix is two halves that have to ship together.**

Restore the generation where the claim is honest: launching phase at role index 0, where nothing has drained and the pre-shift state is still intact. Past a drain the old generation's sessions are gone, so rolling the counter back would name a generation that no longer exists. That case now stops where it stands and says so: `stopped at gen 2 with 1 of 3 roles shifted`.

Tag mid-shift repairs per role. `reconcileShift` repaired non-shifting roles at the team generation, which is aspirational until the shift completes. Those replacements are minted before the abort and survive it, because the abort deletes only the shifting role's sessions, so restoring the generation without this leaves orphans the team can never drain. Roles the shift has already carried over repair at the new generation; everything else repairs at `Shift.OldGeneration`.

The tagging half also closes a case that needs no abort at all. Repair a role while an earlier role is shifting and the replacement was tagged forward, so when that role's turn came `shiftLaunch` found its replica count already satisfied and flipped straight to draining. The role was reported shifted without ever rotating a session, and the session carried forward as the new generation predated the shift.

**Verification.** `TestShiftAbortStateCoherence` is table-driven over the two abort shapes and asserts the post-abort state field by field (generation, cleared shift state, per-role session count and generation), plus a settling tick to prove the state is a fixed point rather than something reconciliation re-mints. It fails on `main` at 0886801 with `team generation = 2, want 1` and `role sidecar: session squad-sidecar-g2-0 at generation 2, want 1`. Each half was falsified independently by reverting the other, so neither test passes on one fix alone. `TestShiftRepairBeforeTurnDoesNotCountAsLaunch` covers the healthy-path case.

The existing `TestShiftTimeoutAbortsStuckLaunch` passed throughout because it never asserted `team.Generation` and its single-role fixture has no non-shifting role to repair.

**Cost of merge.** Confined to `internal/team/controller.go`. `reconcileRole` keeps its signature and delegates to `reconcileRoleAt`; the only behavior change outside the abort path is which generation a mid-shift repair carries. Full suite and `-race` green; `golangci-lint` clean.

The third symptom on the ticket, roles absent from `get sessions`, is not an abort defect and is left open. It reproduces with no shift: `restartSession` deletes the row before setting the backoff, so a cooling or saturated role has nothing for `store.ListSessions` to show. Fixing it means a new surface, which is why it is not in here. Detail in the finding.

Refs: aae-orc-d0pt, `_kos/findings/finding-010-shift-abort-rollback-defects.md` (updated in place, including one correction to the fix shape it prescribed: the tagging rule is per-role, not per-team)