### PR TITLE
fix(daemon): bind the heartbeat RPC to the session it claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ What exists today:
   claims; a mismatch is refused and lands on the ring as
   `heartbeat.refused`. Records written before the token existed are
   admitted as `heartbeat.unbound` until those sessions end. See
-  finding-019.
+  finding-022.
 - **`marvel inject`**, operator keystrokes into a pane.
 
 The adopted shape (roadmap M2): an **external NATS bus, supervised by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,9 +236,15 @@ What exists today:
   `internal/runtime/events`; `internal/session/bridge.go` lifts each kind
   into its `agent.*` ring kind. Read it with `marvel events`.
 - **The heartbeat RPC** (`handleHeartbeat` → `UpdateSessionHeartbeat`), a
-  daemon method carrying `session_key` and `context_percent`. Cooperative,
-  and one of the CTX% column's two producers (the other is
-  `internal/usage`, fed by adapter streams).
+  daemon method carrying `session_key`, `session_token`, and
+  `context_percent`. Cooperative, and one of the CTX% column's two
+  producers (the other is `internal/usage`, fed by adapter streams). The
+  token is minted per session at spawn and injected as
+  `MARVEL_HEARTBEAT_TOKEN`, so a heartbeat is bound to the session it
+  claims; a mismatch is refused and lands on the ring as
+  `heartbeat.refused`. Records written before the token existed are
+  admitted as `heartbeat.unbound` until those sessions end. See
+  finding-019.
 - **`marvel inject`**, operator keystrokes into a pane.
 
 The adopted shape (roadmap M2): an **external NATS bus, supervised by

--- a/_kos/findings/finding-019-heartbeat-binding-and-the-store-serialization-seam.md
+++ b/_kos/findings/finding-019-heartbeat-binding-and-the-store-serialization-seam.md
@@ -1,0 +1,117 @@
+# finding-019: a secret on api.Session is published by the same encoder that persists it
+
+**Date:** 2026-08-09
+**Ticket:** `aae-orc-mr5c` (heartbeat RPC unauthenticated and unbound to
+its claimed session)
+**Question:** bears on `question-agent-identity-authority` (M1 identity
+lane) without entering it.
+**Status:** SHIPPED for the narrow fix, with two limits stated below that
+the narrow fix does not reach.
+
+## The result in one line
+
+Binding the heartbeat needed a secret on the session record, and the
+session record is serialized by `encoding/json` twice: once into bbolt,
+once into every `get sessions` response. One tag decides which of those
+two an added field goes to, and the wrong answer would have published the
+secret to exactly the sibling agents it separates.
+
+## The defect, confirmed on `main` before the fix
+
+`handleHeartbeat` unmarshalled `session_key` and `context_percent` off the
+wire and called `UpdateSessionHeartbeat` with them. Nothing tied the
+request to the session it named. Any process that could reach the daemon
+socket could stamp any session's `LastHeartbeat` and write its
+`ContextPercent`.
+
+The second half is what makes this more than a liveness bug. The
+heartbeat RPC is one of the CTX% column's two producers, so an unbound
+key writes a number an operator reads and a shift trigger may act on.
+`LastHeartbeat` alone already feeds the heartbeat healthcheck, the
+restart policy, and `allReady` shift readiness.
+
+The realistic attacker is not a stranger on the host. It is a marvel
+agent: every session gets `MARVEL_SOCKET` by design, sibling session keys
+are `<workspace>/<team>-<role>-g<gen>-<index>` and readable from
+`marvel get sessions`, and an agent can be talked into things by whatever
+it reads.
+
+## The fix
+
+`session.Manager.Create` mints a 256-bit token before the record exists.
+The digest goes on the record; the plaintext rides the caller's pointer
+into `planLaunch`, where the adapter puts it in the pane environment as
+`MARVEL_HEARTBEAT_TOKEN`. `Store.UpdateSessionHeartbeat` takes the token
+as a parameter and checks it under the same lock as the write, so the
+check is in the write's signature rather than in a caller's discipline.
+A mismatch returns `ErrHeartbeatUnauthorized` and the daemon emits
+`heartbeat.refused` on the ring and in the log.
+
+Environment, not a flag: an argv is readable from the process table by
+every agent on the host.
+
+## The durable part: the serialization seam
+
+`api.Session` records reach bbolt through `persistPut` → `json.Marshal`,
+and reach every RPC client through `handleGet` → `ListSessions` →
+`json.Marshal`. Same encoder, same struct tags, two destinations with
+opposite requirements for a secret.
+
+So the field split is not stylistic:
+
+- `HeartbeatToken string \`json:"-"\`` is plaintext: this process's memory
+  and the agent's environment, nowhere else.
+- `HeartbeatTokenHash string` is the digest, persisted and published, which is
+  safe and is what lets an adopted session keep beating across a daemon
+  restart. The agent still holds the plaintext; the rehydrated record
+  still holds the digest to check it against.
+
+Anyone adding a credential, a nonce, or a capability to a store resource
+inherits this seam. `aae-orc-wbqi` (projected policy file must be
+tamper-proof) is in the same family and should read this before choosing
+where its integrity material lives.
+
+There is a test for it (`TestHeartbeatTokenNeverSerializes`) because a
+future field addition, a struct embed, or a switch to a different encoder
+would all break the property silently.
+
+## The one deliberate fail-open, and its drain condition
+
+A session record with an empty hash is admitted, and the daemon emits
+`heartbeat.unbound` each time it happens.
+
+Only records written by a binary that minted no token are in that state.
+Refusing them would have made the upgrade destructive: adopt-on-restart
+brings live agents forward, their heartbeats would be refused, they would
+go stale on the healthcheck, and the restart policy would kill and
+respawn a working fleet. Every session spawned from here on carries a
+hash, so the exemption cannot widen, and it ends when those sessions end.
+
+The event is the price of the exemption. An accepted gap nobody can see
+is not an accepted gap.
+
+## Two limits this does not reach
+
+**Same-uid environment reads.** Marvel's agents run as one user, so an
+agent that goes looking can read a sibling pane's environment and take
+its token. The binding defeats forgery from a guessed key, which is the
+confused-deputy case and the one an injected agent falls into; it does
+not defeat an agent that deliberately hunts. Closing that is enforcement
+locus 3 and curtain, not this ticket.
+
+**Ring pressure.** A process spamming refused heartbeats fills the
+bounded event ring and evicts other events. The refusals are visible,
+which is the property that was missing; rate-limiting them is not built.
+
+Both are scope boundaries rather than oversights: the M1 principal model
+is deliberately on the identity lane, and only the minimal per-session
+spawn token was ruled into the main line.
+
+## Falsification
+
+Removing the comparison in `authenticateHeartbeat` and leaving everything
+else in place fails six subtests across `internal/api` and
+`internal/daemon`: peer-token, no-token, and hash-as-token at both the
+store and the RPC layer, plus the assertion that a refused heartbeat
+leaves `LastHeartbeat` and `ContextPercent` where the last admitted one
+left them. Restoring it passes all of them and the rest of the suite.

--- a/_kos/findings/finding-022-heartbeat-binding-and-the-store-serialization-seam.md
+++ b/_kos/findings/finding-022-heartbeat-binding-and-the-store-serialization-seam.md
@@ -1,4 +1,4 @@
-# finding-019: a secret on api.Session is published by the same encoder that persists it
+# finding-022: a secret on api.Session is published by the same encoder that persists it
 
 **Date:** 2026-08-09
 **Ticket:** `aae-orc-mr5c` (heartbeat RPC unauthenticated and unbound to

--- a/cmd/marvel/ctxforward.go
+++ b/cmd/marvel/ctxforward.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/arcavenae/marvel/internal/api"
 	"github.com/arcavenae/marvel/internal/daemon"
 	"github.com/spf13/cobra"
 )
@@ -419,6 +420,14 @@ func newCtxForwardCmd() *cobra.Command {
 				"session_key":     workspace + "/" + session,
 				"context_percent": pct,
 				"model":           model,
+			}
+			// The token marvel minted for this session at spawn. It is
+			// what lets the daemon tell this session reporting itself
+			// from any other process on the host reporting on its
+			// behalf. Absent (a session spawned before tokens existed)
+			// the daemon admits the beat and says so on the ring.
+			if token := os.Getenv(api.HeartbeatTokenEnv); token != "" {
+				p["session_token"] = token
 			}
 			// context_window is the harness's own declared window for this
 			// session. It is emitted as the PRODUCER half of a seam whose

--- a/cmd/marvel/render_test.go
+++ b/cmd/marvel/render_test.go
@@ -144,7 +144,7 @@ func TestRenderSessionTableWithHeartbeat(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if err := store.UpdateSessionHeartbeat("ws/agent-0", 55.4, ""); err != nil {
+	if _, err := store.UpdateSessionHeartbeat("ws/agent-0", "", 55.4, ""); err != nil {
 		t.Fatalf("heartbeat: %v", err)
 	}
 

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/arcavenae/marvel/internal/api"
 	"github.com/arcavenae/marvel/internal/daemon"
 	marvelotel "github.com/arcavenae/marvel/internal/otel"
 	"github.com/arcavenae/marvel/internal/simulator"
@@ -74,11 +75,19 @@ func main() {
 	// Heartbeat to daemon.
 	if *socket != "" {
 		sessionKey := *workspace + "/" + *name
+		// From the environment rather than a flag: an argv is readable
+		// from the process table by every agent on the host, and the
+		// token is what separates them.
+		token := os.Getenv(api.HeartbeatTokenEnv)
 		engine.OnHeartbeat = func(pct float64) error {
-			params, _ := json.Marshal(map[string]any{
+			p := map[string]any{
 				"session_key":     sessionKey,
 				"context_percent": pct,
-			})
+			}
+			if token != "" {
+				p["session_token"] = token
+			}
+			params, _ := json.Marshal(p)
 			resp, err := daemon.SendRequest(*socket, daemon.Request{
 				Method: "heartbeat",
 				Params: params,

--- a/internal/api/bolt_test.go
+++ b/internal/api/bolt_test.go
@@ -408,7 +408,7 @@ func TestBoltStore_HeartbeatContextReadingSurvivesRehydrate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if err := s1.UpdateSessionHeartbeat("ws/agent-0", 64.0, ""); err != nil {
+	if _, err := s1.UpdateSessionHeartbeat("ws/agent-0", "", 64.0, ""); err != nil {
 		t.Fatalf("heartbeat: %v", err)
 	}
 	if err := s1.CloseBolt(); err != nil {

--- a/internal/api/heartbeat.go
+++ b/internal/api/heartbeat.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// HeartbeatTokenEnv is the environment variable adapters inject the
+// session's heartbeat token into. Environment rather than a command-line
+// flag: an argv is readable from the process table, and every agent on
+// the host can list it.
+const HeartbeatTokenEnv = "MARVEL_HEARTBEAT_TOKEN"
+
+// ErrHeartbeatUnauthorized is returned when a heartbeat presents no token
+// or the wrong one for the session it claims.
+var ErrHeartbeatUnauthorized = errors.New("heartbeat token does not match the session it claims")
+
+// HeartbeatAuth reports how a heartbeat was admitted. The daemon renders
+// it as an event so the unbound case is audible rather than assumed.
+type HeartbeatAuth string
+
+const (
+	// HeartbeatAuthToken is a heartbeat that presented the token minted
+	// for the session it claims.
+	HeartbeatAuthToken HeartbeatAuth = "token"
+	// HeartbeatAuthUnbound is a heartbeat admitted against a session
+	// record carrying no token hash. Only records written before the
+	// token existed are in that state, so the exemption drains as those
+	// sessions end; a session this daemon spawned always carries one.
+	HeartbeatAuthUnbound HeartbeatAuth = "unbound"
+)
+
+// NewHeartbeatToken mints a 256-bit token, hex-encoded, and returns it
+// with its digest. Minted once per session at spawn.
+func NewHeartbeatToken() (token, hash string, err error) {
+	var b [32]byte
+	if _, rerr := rand.Read(b[:]); rerr != nil {
+		return "", "", fmt.Errorf("mint heartbeat token: %w", rerr)
+	}
+	token = hex.EncodeToString(b[:])
+	return token, HashHeartbeatToken(token), nil
+}
+
+// HashHeartbeatToken returns the hex-encoded SHA-256 of a token. The
+// empty token has no hash: an absent secret must not acquire a digest a
+// caller could then match against.
+func HashHeartbeatToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// authenticateHeartbeat checks a presented token against a session's
+// stored hash. Callers hold the store lock.
+func authenticateHeartbeat(sess *Session, token string) (HeartbeatAuth, error) {
+	if sess.HeartbeatTokenHash == "" {
+		// The one deliberate fail-open, and it is bounded rather than a
+		// policy: a record with no hash was written by a binary that
+		// minted no token, so its agent has no token to present and
+		// refusing would restart a live fleet on upgrade. Every session
+		// spawned from here on carries a hash, so the exemption cannot
+		// widen, and the daemon emits heartbeat.unbound each time it
+		// applies.
+		return HeartbeatAuthUnbound, nil
+	}
+	presented := HashHeartbeatToken(token)
+	if subtle.ConstantTimeCompare([]byte(presented), []byte(sess.HeartbeatTokenHash)) != 1 {
+		return "", ErrHeartbeatUnauthorized
+	}
+	return HeartbeatAuthToken, nil
+}

--- a/internal/api/heartbeat_test.go
+++ b/internal/api/heartbeat_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mintedSession is a session as the manager spawns one: token in memory,
+// digest on the record.
+func mintedSession(t *testing.T, s *Store, name string) (key, token string) {
+	t.Helper()
+	tok, hash, err := NewHeartbeatToken()
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	sess := &Session{
+		Name:               name,
+		Workspace:          "ws",
+		Team:               "squad",
+		Role:               "worker",
+		Runtime:            Runtime{Name: "simulator", Command: "simulator"},
+		State:              SessionRunning,
+		CreatedAt:          time.Now().UTC(),
+		HeartbeatToken:     tok,
+		HeartbeatTokenHash: hash,
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session %s: %v", name, err)
+	}
+	return sess.Key(), tok
+}
+
+// TestUpdateSessionHeartbeatAuthenticates is the authority matrix for the
+// heartbeat RPC. The row that matters is peer: a token minted for one
+// session, presented for another. Before the token existed, a heartbeat
+// carried a session key and nothing else, so that row was indistinguishable
+// from the agent reporting itself.
+func TestUpdateSessionHeartbeatAuthenticates(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+	selfKey, selfToken := mintedSession(t, s, "agent-0")
+	peerKey, peerToken := mintedSession(t, s, "agent-1")
+
+	// A record written before tokens existed: no hash to check against.
+	legacy := &Session{
+		Name: "agent-legacy", Workspace: "ws", Team: "squad", Role: "worker",
+		Runtime: Runtime{Name: "simulator", Command: "simulator"},
+		State:   SessionRunning, CreatedAt: time.Now().UTC(),
+	}
+	if err := s.CreateSession(legacy); err != nil {
+		t.Fatalf("create legacy session: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		key      string
+		token    string
+		wantAuth HeartbeatAuth
+		wantErr  error
+	}{
+		{
+			name:     "own token admitted",
+			key:      selfKey,
+			token:    selfToken,
+			wantAuth: HeartbeatAuthToken,
+		},
+		{
+			name:    "peer token refused",
+			key:     selfKey,
+			token:   peerToken,
+			wantErr: ErrHeartbeatUnauthorized,
+		},
+		{
+			name:    "no token refused",
+			key:     selfKey,
+			token:   "",
+			wantErr: ErrHeartbeatUnauthorized,
+		},
+		{
+			name:    "hash of the token is not the token",
+			key:     selfKey,
+			token:   HashHeartbeatToken(selfToken),
+			wantErr: ErrHeartbeatUnauthorized,
+		},
+		{
+			name:    "unknown session refused",
+			key:     "ws/nobody",
+			token:   selfToken,
+			wantErr: ErrNotFound,
+		},
+		{
+			name:     "record with no hash admitted unbound",
+			key:      legacy.Key(),
+			token:    "",
+			wantAuth: HeartbeatAuthUnbound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, _ := s.GetSession(tt.key)
+			auth, err := s.UpdateSessionHeartbeat(tt.key, tt.token, 42.5, "")
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tt.wantErr)
+				}
+				if auth != "" {
+					t.Errorf("auth = %q on a refused heartbeat, want empty", auth)
+				}
+				// A refusal must not move the liveness clock: LastHeartbeat
+				// feeds the healthcheck, the restart policy, and shift
+				// readiness.
+				after, gerr := s.GetSession(tt.key)
+				if gerr != nil {
+					return // unknown-session row has nothing to compare
+				}
+				if !after.LastHeartbeat.Equal(before.LastHeartbeat) {
+					t.Errorf("refused heartbeat moved LastHeartbeat from %v to %v",
+						before.LastHeartbeat, after.LastHeartbeat)
+				}
+				if after.ContextPercent != before.ContextPercent {
+					t.Errorf("refused heartbeat wrote CTX%% %v, want %v",
+						after.ContextPercent, before.ContextPercent)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("UpdateSessionHeartbeat: %v", err)
+			}
+			if auth != tt.wantAuth {
+				t.Fatalf("auth = %q, want %q", auth, tt.wantAuth)
+			}
+			got, _ := s.GetSession(tt.key)
+			if got.ContextPercent != 42.5 {
+				t.Errorf("CTX%% = %v after an admitted heartbeat, want 42.5", got.ContextPercent)
+			}
+			if got.LastHeartbeat.IsZero() {
+				t.Error("an admitted heartbeat left LastHeartbeat zero")
+			}
+		})
+	}
+
+	// The peer's own beat still works: the refusal above is about binding,
+	// not about a session poisoned by someone else's attempt.
+	if _, err := s.UpdateSessionHeartbeat(peerKey, peerToken, 10, ""); err != nil {
+		t.Fatalf("peer heartbeat with its own token: %v", err)
+	}
+}
+
+// TestHeartbeatTokenNeverSerializes guards the property the whole fix
+// rests on. Store records reach bbolt through encoding/json and reach
+// every RPC client the same way, so a serialized plaintext token would be
+// readable by exactly the sibling agents it separates.
+func TestHeartbeatTokenNeverSerializes(t *testing.T) {
+	t.Parallel()
+
+	token, hash, err := NewHeartbeatToken()
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	sess := Session{
+		Name: "agent-0", Workspace: "ws",
+		HeartbeatToken: token, HeartbeatTokenHash: hash,
+	}
+	data, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if strings.Contains(string(data), token) {
+		t.Fatal("the plaintext heartbeat token is serialized on the session record")
+	}
+	if !strings.Contains(string(data), hash) {
+		t.Fatal("the token hash is not serialized, so an adopted session cannot be verified after restart")
+	}
+
+	// Rehydrate is the adoption path: the agent still holds the plaintext
+	// in its environment, and the record must still be able to check it.
+	var back Session
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal session: %v", err)
+	}
+	if back.HeartbeatTokenHash != hash {
+		t.Fatalf("hash did not survive a round trip: %q", back.HeartbeatTokenHash)
+	}
+	if back.HeartbeatToken != "" {
+		t.Fatalf("plaintext token came back from a round trip: %q", back.HeartbeatToken)
+	}
+}
+
+func TestNewHeartbeatTokenIsUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]bool, 64)
+	for range 64 {
+		token, hash, err := NewHeartbeatToken()
+		if err != nil {
+			t.Fatalf("mint token: %v", err)
+		}
+		if len(token) != 64 {
+			t.Fatalf("token length = %d hex chars, want 64 (256 bits)", len(token))
+		}
+		if hash != HashHeartbeatToken(token) {
+			t.Fatal("minted hash does not match the token's digest")
+		}
+		if seen[token] {
+			t.Fatal("NewHeartbeatToken repeated a token")
+		}
+		seen[token] = true
+	}
+
+	if HashHeartbeatToken("") != "" {
+		t.Error("the empty token acquired a digest, which an unbound record could then be matched against")
+	}
+}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -490,9 +490,17 @@ func (s *Store) UpdatePolicy(key string, fn func(*Policy) error) error {
 	return s.persistPut(bucketPolicies, p.Key(), p)
 }
 
-// UpdateSessionHeartbeat updates a session's context pressure and
-// heartbeat timestamp. Kept as a convenience helper; equivalent to
-// UpdateSession with the corresponding closure.
+// UpdateSessionHeartbeat authenticates a heartbeat and, if it holds,
+// updates the session's context pressure and heartbeat timestamp. It
+// returns how the heartbeat was admitted, or ErrHeartbeatUnauthorized
+// when the presented token does not match the session it claims.
+//
+// The token is a parameter of the write rather than a separate check the
+// caller may forget, and the check happens under the same lock as the
+// write. Any future caller of this method has to hold a token to reach
+// the assignment below, which is the point: LastHeartbeat feeds the
+// heartbeat healthcheck, the restart policy, and shift readiness, and
+// ContextPercent is one of the CTX% column's two producers.
 //
 // Note: heartbeat fields are classified ephemeral in finding-050's
 // data-model walk — they're persisted alongside the rest of the
@@ -502,12 +510,16 @@ func (s *Store) UpdatePolicy(key string, fn func(*Policy) error) error {
 // dominant write rate for marvel's bbolt usage; if it surfaces as a
 // performance issue, batch by waiting N heartbeats before persisting
 // (or move heartbeat state into a separate in-memory-only path).
-func (s *Store) UpdateSessionHeartbeat(key string, contextPercent float64, model string) error {
+func (s *Store) UpdateSessionHeartbeat(key, token string, contextPercent float64, model string) (HeartbeatAuth, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	sess, ok := s.sessions[key]
 	if !ok {
-		return fmt.Errorf("session %s: %w", key, ErrNotFound)
+		return "", fmt.Errorf("session %s: %w", key, ErrNotFound)
+	}
+	auth, err := authenticateHeartbeat(sess, token)
+	if err != nil {
+		return "", fmt.Errorf("session %s: %w", key, err)
 	}
 	// A heartbeat is a COMPLETE reading of its own shape, not a partial
 	// update layered over whatever the accountant left behind. Writing
@@ -543,7 +555,10 @@ func (s *Store) UpdateSessionHeartbeat(key string, contextPercent float64, model
 	// downstream (bolt rehydrate keeps this one, the renderer prints it as
 	// a percentage rather than as an unresolved window).
 	sess.ContextAt = sess.LastHeartbeat
-	return s.persistPut(bucketSessions, sess.Key(), sess)
+	if err := s.persistPut(bucketSessions, sess.Key(), sess); err != nil {
+		return "", err
+	}
+	return auth, nil
 }
 
 // UpdateSessionContext records one context-window reading.

--- a/internal/api/store_test.go
+++ b/internal/api/store_test.go
@@ -167,7 +167,7 @@ func TestUpdateSessionHeartbeat(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	if err := s.UpdateSessionHeartbeat("test-ws/agent-0", 42.5, ""); err != nil {
+	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 42.5, ""); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 
@@ -180,7 +180,7 @@ func TestUpdateSessionHeartbeat(t *testing.T) {
 	}
 
 	// Not found case
-	if err := s.UpdateSessionHeartbeat("test-ws/nonexistent", 10, ""); !errors.Is(err, ErrNotFound) {
+	if _, err := s.UpdateSessionHeartbeat("test-ws/nonexistent", "", 10, ""); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -361,7 +361,7 @@ func TestUpdateSessionHeartbeatStampsContextAt(t *testing.T) {
 	if err := s.CreateSession(sess); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if err := s.UpdateSessionHeartbeat("test-ws/agent-0", 42.5, ""); err != nil {
+	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 42.5, ""); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 	got, _ := s.GetSession("test-ws/agent-0")
@@ -472,7 +472,7 @@ func TestHeartbeatAfterUnresolvedAccountantReadingIsNotSuppressed(t *testing.T) 
 	})
 
 	// The agent then reports a percentage it computed itself.
-	if err := s.UpdateSessionHeartbeat("test-ws/agent-0", 61.0, "claude-opus-5"); err != nil {
+	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 61.0, "claude-opus-5"); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -153,8 +153,35 @@ type Session struct {
 	RestartCount    int          `toml:"-"`
 	LastHealthCheck time.Time    `toml:"-"`
 	CreatedAt       time.Time    `toml:"-"`
-	SessionMetrics  `toml:"-"`
-	SessionContext  `toml:"-"`
+	// HeartbeatToken is the secret marvel mints at spawn and injects into
+	// the session's process environment. It binds a heartbeat to the
+	// session that claims it: the RPC takes a session key off the wire,
+	// and without this any process reaching the socket could stamp any
+	// session's liveness and context pressure.
+	//
+	// `json:"-"` is load-bearing twice over. The store's records go to
+	// bbolt through encoding/json, and ListSessions goes to every RPC
+	// client the same way, so a serialized plaintext token would be
+	// readable by exactly the sibling agents it is meant to separate. The
+	// plaintext therefore lives in this process's memory and in the
+	// spawned agent's environment, nowhere else. HeartbeatTokenHash is
+	// what persists.
+	HeartbeatToken string `json:"-" toml:"-"`
+	// HeartbeatTokenHash is the SHA-256 of HeartbeatToken, hex-encoded.
+	// It persists and it travels on the wire, which is safe: a 256-bit
+	// random token is not recoverable from its digest, and verification
+	// only ever needs to recompute it.
+	//
+	// Persisting the hash is what lets an adopted session keep beating
+	// across a daemon restart. The agent still holds the plaintext in its
+	// environment; the rehydrated record still holds the digest to check
+	// it against.
+	//
+	// Empty means the record predates this field, which is the one case
+	// AuthenticateHeartbeat admits unbound. See its comment.
+	HeartbeatTokenHash string `toml:"-"`
+	SessionMetrics     `toml:"-"`
+	SessionContext     `toml:"-"`
 }
 
 // SessionContext is one context-window reading for a session.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1041,7 +1041,13 @@ func (d *Daemon) handleScale(params json.RawMessage) Response {
 
 // Heartbeat params
 type heartbeatParams struct {
-	SessionKey     string  `json:"session_key"`
+	SessionKey string `json:"session_key"`
+	// SessionToken is the secret marvel minted for this session at spawn
+	// and injected into its environment as MARVEL_HEARTBEAT_TOKEN. It is
+	// what binds the reading below to the session named above; the key
+	// alone is public, guessable from `marvel get sessions`, and every
+	// agent on the host can reach this socket.
+	SessionToken   string  `json:"session_token,omitempty"`
 	ContextPercent float64 `json:"context_percent"`
 	// Model is the model as the reporter names it, "" when the
 	// reporter does not know (the simulator). The statusline feed
@@ -1055,12 +1061,45 @@ func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 		return Response{Error: fmt.Sprintf("bad params: %v", err)}
 	}
 
-	if err := d.store.UpdateSessionHeartbeat(p.SessionKey, p.ContextPercent, p.Model); err != nil {
+	auth, err := d.store.UpdateSessionHeartbeat(p.SessionKey, p.SessionToken, p.ContextPercent, p.Model)
+	if err != nil {
+		if errors.Is(err, api.ErrHeartbeatUnauthorized) {
+			d.emitHeartbeatAuth(events.KindHeartbeatRefused, p.SessionKey,
+				"refused: token does not match the session claimed")
+		}
 		return Response{Error: err.Error()}
+	}
+	if auth == api.HeartbeatAuthUnbound {
+		d.emitHeartbeatAuth(events.KindHeartbeatUnbound, p.SessionKey,
+			"admitted unbound: session record carries no token, restart it to bind its heartbeat")
 	}
 
 	result, _ := json.Marshal(map[string]string{"status": "ok"})
 	return Response{Result: result}
+}
+
+// emitHeartbeatAuth records an authentication outcome on the ring and in
+// the daemon log. Both, because the two answer different questions: the
+// ring is what an operator filters when a session's CTX% or liveness
+// looks wrong, and the log is what survives the ring's eviction window.
+//
+// The workspace/team/role coordinates come from the claimed session when
+// it exists, so a refusal can be filtered beside that session's other
+// events rather than only by kind.
+func (d *Daemon) emitHeartbeatAuth(kind events.Kind, sessionKey, message string) {
+	ev := events.Event{
+		Kind:     kind,
+		Severity: events.SeverityWarning,
+		Session:  sessionKey,
+		Message:  message,
+	}
+	if sess, err := d.store.GetSession(sessionKey); err == nil {
+		ev.Workspace = sess.Workspace
+		ev.Team = sess.Team
+		ev.Role = sess.Role
+	}
+	events.Emit(d.events, ev)
+	log.Printf("heartbeat %s for %s: %s", kind, sessionKey, message)
 }
 
 // Run params

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -172,9 +172,20 @@ name = "squad"
 	}
 	if len(sessionsForHB) > 0 {
 		sessionKey := sessionsForHB[0].Workspace + "/" + sessionsForHB[0].Name
+		// The token never crosses the wire in a get response, which is
+		// the point of it, so this in-process test reads it where the
+		// spawned agent reads it from: the record marvel minted it into.
+		spawned, gerr := d.store.GetSession(sessionKey)
+		if gerr != nil {
+			t.Fatalf("get session %s: %v", sessionKey, gerr)
+		}
 		resp, err = SendRequest(sock, Request{
 			Method: "heartbeat",
-			Params: mustMarshal(t, map[string]any{"session_key": sessionKey, "context_percent": 55.5}),
+			Params: mustMarshal(t, map[string]any{
+				"session_key":     sessionKey,
+				"session_token":   spawned.HeartbeatToken,
+				"context_percent": 55.5,
+			}),
 		})
 		if err != nil {
 			t.Fatalf("heartbeat: %v", err)

--- a/internal/daemon/heartbeat_test.go
+++ b/internal/daemon/heartbeat_test.go
@@ -1,0 +1,180 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+)
+
+// registerSession puts a session in the store the way the manager does at
+// spawn: digest on the record, plaintext returned to the caller the way it
+// reaches the agent's environment. No pane, because the heartbeat handler
+// is synchronous store code and never touches tmux.
+func registerSession(t *testing.T, d *Daemon, name string, bind bool) (key, token string) {
+	t.Helper()
+	sess := &api.Session{
+		Name:      name,
+		Workspace: "ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "simulator", Command: "simulator"},
+		State:     api.SessionRunning,
+		CreatedAt: time.Now().UTC(),
+	}
+	if bind {
+		tok, hash, err := api.NewHeartbeatToken()
+		if err != nil {
+			t.Fatalf("mint token: %v", err)
+		}
+		sess.HeartbeatToken = tok
+		sess.HeartbeatTokenHash = hash
+		token = tok
+	}
+	if err := d.store.CreateSession(sess); err != nil {
+		t.Fatalf("create session %s: %v", name, err)
+	}
+	return sess.Key(), token
+}
+
+// TestHandleHeartbeatBindsToItsSession is the RPC-level authority matrix.
+//
+// Falsification: before the token, the handler took a session key off the
+// wire and stamped it. Every row below except the first passed, so any
+// process reaching the socket could hold a dead peer's liveness open and
+// write the CTX% an operator reads.
+func TestHandleHeartbeatBindsToItsSession(t *testing.T) {
+	d := newHandlerDaemon(t)
+
+	selfKey, selfToken := registerSession(t, d, "agent-0", true)
+	_, peerToken := registerSession(t, d, "agent-1", true)
+	legacyKey, _ := registerSession(t, d, "agent-legacy", false)
+
+	tests := []struct {
+		name      string
+		key       string
+		token     string
+		wantErr   string
+		wantEvent events.Kind
+	}{
+		{
+			name: "own token admitted",
+			key:  selfKey, token: selfToken,
+		},
+		{
+			name: "peer token refused",
+			key:  selfKey, token: peerToken,
+			wantErr:   "does not match",
+			wantEvent: events.KindHeartbeatRefused,
+		},
+		{
+			name: "no token refused",
+			key:  selfKey, token: "",
+			wantErr:   "does not match",
+			wantEvent: events.KindHeartbeatRefused,
+		},
+		{
+			name: "unknown session refused",
+			key:  "ws/nobody", token: selfToken,
+			wantErr: "not found",
+		},
+		{
+			name: "record with no hash admitted, and says so",
+			key:  legacyKey, token: "",
+			wantEvent: events.KindHeartbeatUnbound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := len(d.events.Snapshot(events.Filter{Kind: tt.wantEvent}, 0))
+
+			p := heartbeatParams{SessionKey: tt.key, SessionToken: tt.token, ContextPercent: 61}
+			resp := d.handleHeartbeat(mustMarshal(t, p))
+
+			switch {
+			case tt.wantErr == "" && resp.Error != "":
+				t.Fatalf("heartbeat error = %q, want none", resp.Error)
+			case tt.wantErr != "" && !strings.Contains(resp.Error, tt.wantErr):
+				t.Fatalf("heartbeat error = %q, want it to contain %q", resp.Error, tt.wantErr)
+			}
+
+			if tt.wantEvent == "" {
+				return
+			}
+			snap := d.events.Snapshot(events.Filter{Kind: tt.wantEvent}, 0)
+			if len(snap) != before+1 {
+				t.Fatalf("%s events = %d, want %d (the outcome was silent)",
+					tt.wantEvent, len(snap), before+1)
+			}
+			ev := snap[len(snap)-1]
+			if ev.Session != tt.key {
+				t.Errorf("event names session %q, want %q", ev.Session, tt.key)
+			}
+			if ev.Severity != events.SeverityWarning {
+				t.Errorf("event severity = %q, want warning", ev.Severity)
+			}
+		})
+	}
+}
+
+// TestHandleHeartbeatRefusalLeavesLivenessAlone: a refused heartbeat must
+// not be a half-write. LastHeartbeat is what the heartbeat healthcheck,
+// the restart policy, and shift readiness all read.
+func TestHandleHeartbeatRefusalLeavesLivenessAlone(t *testing.T) {
+	d := newHandlerDaemon(t)
+	key, token := registerSession(t, d, "agent-0", true)
+
+	if resp := d.handleHeartbeat(mustMarshal(t, heartbeatParams{
+		SessionKey: key, SessionToken: token, ContextPercent: 40,
+	})); resp.Error != "" {
+		t.Fatalf("first heartbeat: %s", resp.Error)
+	}
+	admitted, err := d.store.GetSession(key)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+
+	if resp := d.handleHeartbeat(mustMarshal(t, heartbeatParams{
+		SessionKey: key, SessionToken: "0000", ContextPercent: 99,
+	})); resp.Error == "" {
+		t.Fatal("a forged heartbeat was admitted")
+	}
+
+	after, err := d.store.GetSession(key)
+	if err != nil {
+		t.Fatalf("get session after refusal: %v", err)
+	}
+	if !after.LastHeartbeat.Equal(admitted.LastHeartbeat) {
+		t.Errorf("refused heartbeat moved LastHeartbeat to %v, want %v",
+			after.LastHeartbeat, admitted.LastHeartbeat)
+	}
+	if after.ContextPercent != 40 {
+		t.Errorf("refused heartbeat wrote CTX%% %v, want the last admitted 40", after.ContextPercent)
+	}
+}
+
+// TestSessionTokenNeverLeavesOverGet: the token binds a heartbeat only
+// while sibling agents cannot read it, and they reach the same socket.
+func TestSessionTokenNeverLeavesOverGet(t *testing.T) {
+	d := newHandlerDaemon(t)
+	_, token := registerSession(t, d, "agent-0", true)
+
+	resp := d.handleGet(mustMarshal(t, getParams{ResourceType: "sessions"}))
+	if resp.Error != "" {
+		t.Fatalf("get sessions: %s", resp.Error)
+	}
+	if strings.Contains(string(resp.Result), token) {
+		t.Fatal("a session's heartbeat token is readable over the get RPC")
+	}
+
+	resp = d.handleDescribe(mustMarshal(t, describeParams{ResourceType: "session", Name: "ws/agent-0"}))
+	if resp.Error != "" {
+		t.Fatalf("describe session: %s", resp.Error)
+	}
+	if strings.Contains(string(resp.Result), token) {
+		t.Fatal("a session's heartbeat token is readable over the describe RPC")
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -92,6 +92,21 @@ const (
 	// killed entity may belong to a second daemon that records nothing
 	// itself.
 	KindReconcileKilled Kind = "reconcile.killed"
+	// KindHeartbeatRefused records that a heartbeat claimed a session it
+	// was not issued for: it presented no token, or the wrong one, for a
+	// session marvel minted a token for. Warning severity, and it names
+	// the claimed session, because the interesting case is not a broken
+	// agent reporting itself but one process reporting on another's
+	// behalf. LastHeartbeat feeds the healthcheck, the restart policy,
+	// and shift readiness, so a forged one keeps a dead peer looking
+	// healthy for as long as it keeps sending.
+	KindHeartbeatRefused Kind = "heartbeat.refused"
+	// KindHeartbeatUnbound records that a heartbeat was admitted against
+	// a session record carrying no token hash: a session spawned before
+	// marvel minted tokens, still beating across the upgrade. Warning
+	// severity: the exemption drains as those sessions end, and an
+	// accepted gap nobody can see is not an accepted gap.
+	KindHeartbeatUnbound Kind = "heartbeat.unbound"
 	// KindReconcileLeft records that a daemon found marvel-* tmux state
 	// it does not own and left it running, which is the default posture
 	// ratified 2026-08-07.

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -164,6 +164,14 @@ func baseEnv(ctx *LaunchContext) map[string]string {
 	}
 	if ctx.SocketPath != "" {
 		env["MARVEL_SOCKET"] = ctx.SocketPath
+		// The socket is what makes a heartbeat possible, so the token
+		// travels with it and a session that cannot reach the daemon
+		// carries no secret. This is enforcement locus 1: marvel
+		// constructs the environment, and what the agent can prove about
+		// itself is what marvel put there.
+		if ctx.Session.HeartbeatToken != "" {
+			env[api.HeartbeatTokenEnv] = ctx.Session.HeartbeatToken
+		}
 	}
 	return env
 }

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -427,3 +427,48 @@ func TestNewStreamParserRejectsUnknownFormat(t *testing.T) {
 		t.Fatal("expected a parser")
 	}
 }
+
+// TestAdaptersInjectHeartbeatToken: the heartbeat token is enforcement
+// locus 1 in practice: marvel constructs the environment, so what an
+// agent can prove about itself is what marvel put there. An adapter that
+// forwards MARVEL_SOCKET without the token hands its agent a channel it
+// cannot authenticate on, and the daemon refuses every beat.
+func TestAdaptersInjectHeartbeatToken(t *testing.T) {
+	t.Parallel()
+
+	const token = "3f1c0d5e" // shape does not matter here, presence does
+
+	for _, a := range []Adapter{&Forestage{}, &Claude{}, &Codex{}, &OpenCode{}, &Simulator{}, &Generic{}} {
+		t.Run(a.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testContext()
+			ctx.Session.Runtime.Name = a.Name()
+			ctx.Session.Runtime.Command = "/usr/local/bin/" + a.Name()
+			ctx.Session.HeartbeatToken = token
+
+			result, err := a.Prepare(ctx)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+			if got := result.Env[api.HeartbeatTokenEnv]; got != token {
+				t.Errorf("%s = %q, want %q", api.HeartbeatTokenEnv, got, token)
+			}
+			// argv is world-readable from the process table; the token
+			// must not be there for every agent on the host to copy.
+			if strings.Contains(result.Command, token) {
+				t.Errorf("token appears in argv: %s", result.Command)
+			}
+
+			// No socket, no heartbeat channel, so no secret in the pane.
+			ctx.SocketPath = ""
+			result, err = a.Prepare(ctx)
+			if err != nil {
+				t.Fatalf("Prepare without socket: %v", err)
+			}
+			if got, ok := result.Env[api.HeartbeatTokenEnv]; ok {
+				t.Errorf("%s = %q on a session with no socket, want absent", api.HeartbeatTokenEnv, got)
+			}
+		})
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -432,6 +432,17 @@ func (m *Manager) Create(sess *api.Session) error {
 	sess.State = api.SessionPending
 	sess.CreatedAt = time.Now().UTC()
 
+	// Mint the heartbeat token before the record exists, so no session is
+	// ever in the store without one. The plaintext rides the caller's
+	// pointer into planLaunch, where the adapter puts it in the pane's
+	// environment; only the digest is stored.
+	token, hash, terr := api.NewHeartbeatToken()
+	if terr != nil {
+		return fmt.Errorf("create session %s: %w", sess.Key(), terr)
+	}
+	sess.HeartbeatToken = token
+	sess.HeartbeatTokenHash = hash
+
 	if err := m.store.CreateSession(sess); err != nil {
 		return fmt.Errorf("create session %s: %w", sess.Key(), err)
 	}
@@ -860,6 +871,9 @@ func (m *Manager) directCommand(sess *api.Session) (string, map[string]string) {
 	}
 	if m.SocketPath != "" {
 		envs["MARVEL_SOCKET"] = m.SocketPath
+		if sess.HeartbeatToken != "" {
+			envs[api.HeartbeatTokenEnv] = sess.HeartbeatToken
+		}
 	}
 	return cmd, envs
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -745,3 +745,53 @@ func TestDaemonTempDirsAreLayoutScoped(t *testing.T) {
 		t.Errorf("projection and stream dirs are both %s, want distinct", alphaProjection)
 	}
 }
+
+// TestCreateMintsHeartbeatToken: no session reaches the store without a
+// token, because the daemon refuses any heartbeat it cannot bind and a
+// session spawned without one would go stale, fail its healthcheck, and
+// restart on a policy that expects it to be beating.
+func TestCreateMintsHeartbeatToken(t *testing.T) {
+	skipIfNoTmux(t)
+
+	store := api.NewStore()
+	driver, err := tmux.NewDriver()
+	if err != nil {
+		t.Fatalf("new driver: %v", err)
+	}
+	mgr := NewManager(store, driver)
+	mgr.SocketPath = "/tmp/marvel-token-test.sock"
+
+	ws := "test-sess-token"
+	t.Cleanup(func() {
+		_ = mgr.CleanupWorkspace(ws)
+	})
+
+	sess := &api.Session{
+		Name:      "agent-0",
+		Workspace: ws,
+		Team:      "agents",
+		Role:      "worker",
+		Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+	}
+	if err := mgr.Create(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if sess.HeartbeatToken == "" {
+		t.Fatal("Create left the session with no heartbeat token to inject")
+	}
+	stored, err := store.GetSession(sess.Key())
+	if err != nil {
+		t.Fatalf("get from store: %v", err)
+	}
+	if stored.HeartbeatTokenHash != api.HashHeartbeatToken(sess.HeartbeatToken) {
+		t.Fatalf("stored hash %q does not verify the minted token", stored.HeartbeatTokenHash)
+	}
+
+	// The ad-hoc path builds its own environment rather than going
+	// through an adapter, so it needs its own assertion.
+	_, env := mgr.directCommand(sess)
+	if got := env[api.HeartbeatTokenEnv]; got != sess.HeartbeatToken {
+		t.Errorf("%s = %q in the ad-hoc environment, want the minted token", api.HeartbeatTokenEnv, got)
+	}
+}


### PR DESCRIPTION
A heartbeat is how marvel knows an agent is alive and how it learns that agent's context pressure, and until this change it accepted both from anyone. `handleHeartbeat` read a session key off the wire and stamped it, so any local process could keep a dead peer looking healthy and write the CTX% an operator reads. The realistic case is not a stranger: every agent gets `MARVEL_SOCKET` by design and can list sibling session keys with `marvel get sessions`.

## The fix

`session.Manager.Create` mints a 256-bit token per session before the record exists. The digest goes on the record; the plaintext reaches the agent only through `MARVEL_HEARTBEAT_TOKEN` in its pane environment. `Store.UpdateSessionHeartbeat` takes the token as a parameter and checks it under the same lock as the write, so a future caller cannot reach the assignment without holding one. A mismatch is refused and lands on the event ring as `heartbeat.refused`, plus a log line.

Two details are load-bearing rather than incidental:

- **The digest persists, the plaintext does not.** `api.Session` is serialized by `encoding/json` into bbolt AND into every `get sessions` response, so a plaintext token on the record would be readable by exactly the sibling agents it separates. Persisting the digest is also what lets an adopted session keep beating across a daemon restart: the agent still holds the plaintext, the rehydrated record still holds the digest.
- **Environment, not a flag.** An argv is readable from the process table by every agent on the host.

## Cost of merge

Additive on the wire (`session_token` is optional; the daemon admits records carrying no hash and says so as `heartbeat.unbound`, which is what keeps an upgrade from restarting a live fleet). One signature change, `Store.UpdateSessionHeartbeat`, with six in-tree call sites updated. No behavior change for a session that beats for itself.

## Scope

This is the minimal per-session spawn token ruled into the main line, not the M1 principal model, which stays on the identity lane. Two limits are stated in the finding rather than papered over: an agent that goes hunting can read a sibling pane's environment (same uid, enforcement locus 3 and curtain), and a process spamming refusals can pressure the bounded event ring.

## Tests

Table-driven, stdlib only. Removing the comparison in `authenticateHeartbeat` fails six subtests across `internal/api` and `internal/daemon` (peer token, no token, hash-as-token, at both layers, plus the assertion that a refusal leaves `LastHeartbeat` and `ContextPercent` where the last admitted heartbeat left them). Restoring it passes those and the rest of the suite. Also asserted: the token never appears in a `get` or `describe` response, never in argv, and never in a marshalled session record.

Finding: `_kos/findings/finding-022-heartbeat-binding-and-the-store-serialization-seam.md`

Refs: aae-orc-mr5c
