### PR TITLE
finding-024: the compaction detector holds, and three other things report low pressure at high

### DIFF
--- a/_kos/findings/finding-023-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-023-compaction-corpus-and-the-shipped-detector.md
@@ -1,0 +1,360 @@
+# finding-023: the shipped compaction detector survives 63 labelled events, and three other things in the same corpus report LOW pressure at HIGH pressure
+
+- **Date:** 2026-08-09
+- **Status:** measured. SP1 and SP4 answered; SP5 answered for gemini and
+  opencode; two claims in the probe brief refuted.
+- **Probe:** `_kos/probes/probe-compaction-ground-truth-mining.md`, SP1,
+  SP4, SP5. SP2 and SP3 were answered by finding-016 and are not
+  recomputed.
+- **Medium:** mining local artifacts on kinu. Zero model calls, no harness
+  started, no daemon.
+- **Question:** `question-interactive-context-pressure`; bears on
+  `question-shift-triggers`.
+- **bd:** aae-orc-0tnf. Adjacent: aae-orc-sj34, aae-orc-hpeu, aae-orc-mob4.
+- **Scripts:** `scripts/mine_claude_compactions.py` (SP1, SP4),
+  `scripts/mine_other_harness_compactions.py` (SP5). Fixture:
+  `internal/usage/testdata/compaction_series_claudecode.json`.
+
+## Summary
+
+The measurement SP4 exists for came out in the detector's favor, and it is
+the smallest result here. Over 63 labelled Claude Code compactions with an
+occupancy sample on each side, `internal/usage/accountant.go`'s reasoned
+hysteresis fired on **63 of 63** with **zero false negatives**, and the
+tightest event cleared the guard by **4.03x**. The comment at
+accountant.go:14-31 says the bound was "chosen to be un-fireable by
+ordinary variation rather than calibrated"; against this corpus that
+choice is now measured rather than reasoned, and the n-of-1 geometry it
+cites can be retired.
+
+The corpus then produced three separate ways for marvel to report LOW
+pressure while a session is at HIGH pressure, which is the direction that
+silently disables shift rotation:
+
+1. **19 of 82 boundaries produce no post-boundary sample at all** in
+   marvel's series, so the detector cannot fire on them. Two have no usage
+   record after them; the other 17 have records marvel's own guards route
+   away.
+2. **The primary-model latch freezes CTX% permanently.** 19 sessions
+   switch model and never switch back. `fold` latches the first model it
+   sees and never re-latches, so 3,563 later samples go to spend, the sink
+   is never written again, and the stored level stays at its pre-switch
+   value. Worst case froze at 79,246 tokens while the session went on to
+   reach 751,169.
+3. **Zero-occupancy records exist on Claude too.** 68 non-sidechain
+   assistant records carry all three prompt classes at zero. 57 are kept
+   out of the series by the non-primary-model guard, which was written for
+   a different purpose; the exclusion is incidental, not designed.
+
+Two claims in the probe brief are refuted. Subagent context IS minable
+(1,186 subagent transcript files exist, and two of the 82 boundaries are
+inside them), and transcript file order is NOT chronological.
+
+## Method, and the counting the brief asked for
+
+Snapshot taken 2026-08-09T06:12:36Z, `~/.claude/projects`, walked
+recursively. Records are selected by PARSING each line and testing
+`type == "assistant"` with a `message.usage` object, or
+`subtype == "compact_boundary"`. Never by matching a raw string: the brief
+already records why, and this document is itself now in the corpus.
+
+```
+1,609  transcript files          423 session files, 1,186 subagent files
+   82  compact_boundary records  73 auto, 9 manual; 82 of 82 carry compactMetadata
+77,711 non-sidechain usage lines
+       -> 42,244 dropped by the shipped consecutive-message.id dedupe
+       ->  4,884 routed away as non-primary model
+       -> 30,583 samples in the occupancy series
+   23  distinct Claude Code versions, 2.1.220 the plurality
+```
+
+The corpus is live and grew during the work: three runs an hour apart
+gave 1,608 / 1,608 / 1,609 files and 30,547 / 30,563 / 30,583 series
+samples, with the boundary count stable at 82 throughout. The script
+stats every file before and after reading it and reports any that changed
+size (one did, on the final run). Every figure below is from the final
+run; re-running will not reproduce them exactly, and that is a property
+of the corpus rather than of the method.
+
+Only token counts, timestamps, model names, message ids and compaction
+metadata were read. Paths appear in artifacts only as a salted digest.
+
+## SP4: would the shipped detector have caught these?
+
+The replay ports `Accountant.fold` exactly: occupancy is
+`input + cache_read + cache_creation` per assistant message, deduped
+against the immediately preceding `message.id` (which is what
+`parser.go` does, comparing against `lastRequestID` rather than a set),
+non-primary models routed out, and a compaction booked when
+`prev - occ > max(2048, 0.10 * prev)`.
+
+```
+82  labelled boundaries
+63  with a series sample on both sides   -> 63 detected, 0 false negatives
+19  with no series sample after them     -> the detector cannot fire
+ 2  with no series sample before them
+
+drop at the boundary        min  59,305   p50 368,272   max 459,472
+guard at that level         min  12,049   p50  46,540   max  53,452
+drop / guard                min    4.03   p50    8.09   max   10.0
+```
+
+No event came within 4x of the guard, so the detector is not close to a
+miss anywhere in this corpus. The margin is structural rather than lucky:
+compaction takes a session from roughly 467k to roughly 25k, and a 10%
+fractional guard cannot be near that.
+
+**False positives: 5 in file order, 3 in timestamp order**, across 30,583
+samples. They are not one phenomenon:
+
+- **Two are ordering artifacts** (see below) and disappear when the series
+  is sorted by each record's own timestamp.
+- **Two are real context drops with no compaction record anywhere in the
+  file**: 572,515 -> 481,858 and 257,006 -> 206,151, roughly 16% and 20%.
+  Both sit immediately after an `away_summary` system record. Whatever
+  produces them, "the level fell" and "a compaction happened" are separate
+  claims, and marvel's `Compactions` counter currently conflates them.
+- **One is a drop to a zero-occupancy record**, covered below.
+
+**The 19 undetectable boundaries are the result that matters more than the
+63.** Two of them have no usage record after them at all, which is a
+session that ended at the boundary. The other 17 have raw usage records
+that marvel's guards route out of the series. In the clearest case a
+single session carries eight boundaries: the last sample naming its
+latched primary model sits at line 3,110 of 5,283, and the six
+compactions after that line produce no series sample at all. Marvel would
+have detected two of that session's eight compactions and held a frozen
+CTX% for the remaining 41% of the file.
+
+## SP1: does marvel's occupancy formula predict preTokens?
+
+Close, consistently low, and never exact. Comparing the chronologically
+newest sample before each boundary against the boundary's own
+`preTokens`, over the 56 events where that sample is within ten minutes
+of the boundary:
+
+```
+n = 56 contiguous events
+ratio (marvel occupancy / preTokens)   p50 0.9958   47 of 56 within 1%
+|delta|                                p50 1,975   min 194   max 12,494
+exact matches                          0 of 80
+```
+
+The formula tracks. The residual has an ordinary explanation: `preTokens`
+is counted at the moment compaction fires, which is after the last
+assistant response plus whatever user turn and tool results triggered it,
+so marvel's level is one request stale by construction. It is a LAG, not
+a formula error, and it is small: half a percent at the median, under 3%
+at the 90th percentile.
+
+**What this cannot decide.** Every contiguous event in the corpus has
+`preTokens` between 466,321 and 969,333, because compaction fires near
+the effective window and this machine's window is set to 500,000
+(finding-016). So a fixed-token lag and a proportional lag predict nearly
+identical data here. The correlation between `|delta|` and `preTokens` is
+-0.089, which leans toward fixed, but over a 2x range with n=56 that is
+not a result. Varying the setting, which finding-016 already names as the
+cheap next probe, would separate them.
+
+**Two derived numbers worth carrying:**
+
+- The 24 boundaries whose nearest preceding sample is more than ten
+  minutes old scatter from 0.14x to 18.6x. Across a resume gap the level
+  marvel holds is not related to the harness's count at all. A shift
+  trigger reading a session that has been idle overnight is reading a
+  stale number, and nothing in the current path says so.
+- **`postTokens` is not the level the next request carries.** The first
+  post-compaction sample runs a median **61,658 tokens above** the
+  metadata's `postTokens` (min 42,237, max 189,097), because the harness
+  re-primes system prompt, tools and memory that the summary figure does
+  not count. Seeding a reader's level from a compaction record's post
+  figure would understate by that much.
+
+## Three ways to read LOW at HIGH
+
+### Zero-occupancy records, the Claude analogue of the codex sentinel
+
+68 non-sidechain assistant records (plus 11 more in subagent files) carry
+`input = cache_read = cache_creation = 0`. 67 name the model
+`<synthetic>`; **one names the session's real model** and sits beside a
+compaction whose `preTokens` was 467,121.
+
+That single record is the whole point. The `<synthetic>` ones are kept out
+of the series by the non-primary-model guard, which exists to route
+side-calls to spend and catches these by coincidence. The one carrying
+`claude-fable-5` passes every guard marvel has, and in file order it is
+the first sample after the boundary, so the detector fires on a drop to
+zero and then holds a level of 0 until the next real request. The
+detection count is right; the level is wrong, at the moment the session is
+under most pressure.
+
+`aae-orc-mob4` already rules that codex's all-zero `token_count` must be
+discarded. The Claude case says the discard must key on the token values,
+because the model name is not a reliable discriminator: on this harness 67
+of 68 announce themselves and one does not.
+
+One hazard checked and NOT found: if a session's first sample were a
+`<synthetic>` zero, `fold` would latch `<synthetic>` as primary and route
+every real sample away forever. 10 sessions do start that way, and all 10
+have a series of exactly one sample, so nothing followed to be routed. The
+mechanism is real and the corpus does not contain an instance.
+
+### File order is not chronological
+
+26 usage records across 2 of 423 sessions carry a timestamp earlier than
+the record physically before them, the worst by 90,895 seconds (25.2
+hours). In one case a block of older records is appended immediately
+before a compaction boundary, so the newest line in the file reads 134,037
+where the true level was 967,915.
+
+A reader that tails a transcript and takes the last complete record it
+finds will occasionally take one of these. Sorting the series by each
+record's own timestamp removed 2 of the 5 detector false positives and
+changed no true positive. The rate is low (26 in 77,711) and the
+consequence is not: it is a 7x understatement at the single moment the
+number is load-bearing.
+
+### The primary-model latch, and CTX% that stops moving
+
+`fold` latches the first model identity it sees and never re-latches.
+Every later sample naming a different model is routed to spend, and
+`res.write` stays false, so the sink is not updated at all.
+
+Measured over sessions where the model changes and never changes back
+(interleaved side-calls excluded, trailing `<synthetic>` records
+excluded):
+
+```
+19  sessions with a permanent model switch
+3,563  samples routed away after the switch
+
+frozen level   true peak after   understatement
+     79,246           751,169             9.5x
+    120,496           462,243             3.8x
+    231,168           756,882             3.3x
+    166,735           457,001             2.7x
+    254,671           465,104             1.8x
+```
+
+The store keeps rendering the frozen figure as a current reading. There is
+no staleness marker on `api.SessionContext` and no counter that fires, so
+this is invisible to an operator and to any admission gate reading the
+same field.
+
+finding-016 already ruled that a model change must invalidate the reading
+rather than average across it. This is the measured cost of not having
+done it yet, and it is larger than the denominator error finding-016 was
+arguing about: freezing at 79,246 while the session runs to 751,169 is
+wrong by more than the 2x that motivated `aae-orc-sj34`.
+
+## Cluster A: a candidate explanation, offered as a candidate
+
+finding-016 recorded five auto-compactions at or below 210k as
+"unexplained by the setting", two of them with `postTokens` exceeding
+`preTokens`. All five sit in one session, and four of the five carry a
+`scheduled_task_fire` system record within 30 lines before the boundary,
+one of those also with an `away_summary`. Both of the post-exceeds-pre
+events are in that set, and each is followed immediately by a
+`<synthetic>` zero record.
+
+The base rate is what stops this being a conclusion: 15 of 68 high-`pre`
+auto compactions also carry such a marker. 4 of 5 against 15 of 68 on n=5
+is suggestive and nothing more. The fifth cluster-A event (`pre` 168,174)
+carries no marker and is one of the two boundaries inside a SUBAGENT file,
+which fits finding-016's own guess that it is a 200k window compacting
+near its top.
+
+## SP5: the other harnesses
+
+**gemini: an occupancy series exists, no labelled compaction does.** 26
+chat files, 477 messages carrying `{input, output, cached, thoughts, tool,
+total}` plus a model name. No field in any message mentions compaction or
+summarization. Marvel's step detector would fire 3 times across those 477
+samples (two of them drops to exactly zero, which is the same hazard as
+above), and there is no label anywhere in the corpus against which to
+score those firings. So gemini has no compaction ground truth on this
+machine, and acquiring one needs a session run, not a mine.
+
+One discriminating result came free, in the shape finding-017 used. Over
+the 418 rows with nonzero `cached`, `total == input + output + thoughts +
+tool` holds on 418 of 418 and the cache-inclusive variant holds on 0 of
+418. So gemini's `total` EXCLUDES `cached`, which is the opposite of
+opencode. Whether `input` SUBSUMES `cached` is NOT decided: no row has
+`cached` above `input`, but the largest `input` observed is 51,209 against
+a window in the millions, so the window-bound discriminator that settled
+codex has no force here and both readings fit every row.
+
+**opencode: the table exists and is empty.** `session_context_epoch` is
+present in the local store with 0 rows against 211 sessions, confirming
+the brief. Its schema is worth recording: `session_id` is the PRIMARY KEY,
+so even when populated it holds one row per session. It is a pointer to
+the current epoch, not a history, and it can never supply a compaction
+corpus of past events.
+
+codex is covered by finding-017 and Crush by the k2mi arm; neither was
+touched here.
+
+## Two claims in the brief, refuted
+
+**"No `isSidechain: true` assistant line exists in the local corpus, so
+subagent context is not minable this way."** There are 1,186 subagent
+transcript files, at `<project>/<session>/subagents/agent-*.jsonl` and a
+workflow-scoped variant one level deeper. A 150-file sample carried 4,376
+sidechain usage lines. Path and `isSidechain` agree on every one of the
+77,711 lines examined, with zero disagreements. Two of the 82 compaction
+boundaries are inside subagent files: subagents compact, in windows marvel
+is not watching, and the artifacts are on disk.
+
+**"1,535 files ... 77 compact_boundary records."** 1,609 and 82 at this
+snapshot. The brief's own instruction (snapshot before mining, inherit no
+figure including the brief's) is the right one and is why this is a
+correction of a number rather than of a method.
+
+## What was not established
+
+- **Whether the lag in SP1 is a fixed token count or a proportion.** Every
+  contiguous event fires in a narrow band near one machine's one
+  effective-window setting.
+- **Why 17 boundaries have post-boundary usage records that never reach
+  the series.** The primary-model latch is the measured cause in the two
+  sessions checked directly (5 boundaries). The rest are unattributed;
+  dedupe and latch are both candidates and the corpus was not asked to
+  separate them.
+- **What produces the two unlabelled 16-20% context drops.** Both follow
+  an `away_summary` record. That is an association across two events.
+- **Whether the timestamp inversions would appear in a live NDJSON
+  stream.** They are a property of the transcript file. A stream reader
+  might never see the older records at all, or might see them in the same
+  place. Nothing here settles it, and a codex or Crush reader should test
+  its own channel rather than inherit this.
+- **Whether cluster A is caused by scheduled task fires.** 4 of 5 against
+  a 15 of 68 base rate.
+- **Whether gemini's `input` subsumes `cached`.** The corpus cannot
+  discriminate.
+- **Anything about a live compaction crossing under marvel.** This is a
+  mine of transcripts written by an operator's interactive sessions. The
+  accountant consumes a headless NDJSON stream, and the correspondence
+  between the two surfaces is assumed at the per-assistant-message level
+  rather than verified. It is the same `message.usage` object in both, but
+  no capture in this work proves the stream emits exactly the records the
+  transcript retains.
+
+## Consequences to carry
+
+1. **The hysteresis constants are validated and the comment should say so.**
+   4.03x minimum margin over 63 labelled events replaces one recovered
+   geometry.
+2. **Discard zero-occupancy samples explicitly**, on the token values, in
+   the fold rather than incidentally in the model guard. The one record
+   that names its session's real model is the case that already defeats
+   every existing guard.
+3. **Re-latch on model change, or mark the reading stale.** Freezing is
+   worse than the denominator error `aae-orc-sj34` was filed for, and it
+   is silent.
+4. **A reading needs an age.** Both the resume-gap scatter and the frozen
+   latch are invisible because `api.SessionContext` carries no observation
+   time an operator or a gate can test.
+5. **"Compaction detected" is not "compaction happened."** Two events here
+   were real drops with no compaction, and one detection fired on a zero
+   record. Any shift trigger keyed on the compaction COUNT inherits all
+   three.

--- a/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
@@ -223,6 +223,22 @@ discarded. The Claude case says the discard must key on the token values,
 because the model name is not a reliable discriminator: on this harness 67
 of 68 announce themselves and one does not.
 
+**The rule generalizes, and the reason is that each harness offers a
+DIFFERENT companion field that looks like a discriminator and fails in a
+different way.** Three harnesses, three failures:
+
+| harness | the tempting companion signal | how it fails |
+|---|---|---|
+| claude | `model` reads `<synthetic>` | 67 of 68, and the 68th names the session's real model |
+| codex | `model` | absent from the sentinel record entirely (verified here: 16 all-zero records across 2,099 `token_count` records in 210 rollout files, no `model` key on any of them) |
+| crush | `summary_message_id` is set | never clears after the compaction, so it marks has-ever-compacted rather than this event (finding-020) |
+
+Crush's is the categorical one and it is the better argument than mine: a
+field that cannot distinguish this compaction from a previous one is not a
+discriminator at any hit rate, where my claude figure is only a hit rate.
+The token values are the one signal all three publish and none of them
+qualifies away.
+
 One hazard checked and NOT found: if a session's first sample were a
 `<synthetic>` zero, `fold` would latch `<synthetic>` as primary and route
 every real sample away forever. 10 sessions do start that way, and all 10
@@ -264,6 +280,18 @@ record's own timestamp removed 2 of the 5 detector false positives and
 changed no true positive. The rate is low (26 in 77,711) and the
 consequence is not: it is a 7x understatement at the single moment the
 number is load-bearing.
+
+**Measured absent on codex, and the null is weaker than it looks.** The
+codex arm tested rather than inheriting: zero inversions across 210
+rollout files, over every record type, with no unparseable timestamps and
+no file where last-by-position differs from newest-by-timestamp
+(finding-023). That is a real negative and it does not exclude the
+property. My rate is 2 of 422 sessions, and a codex rate identical to
+Claude's would still produce a clean null across 210 files about 37% of
+the time. They ordered by timestamp anyway, which is the right call when
+the fix is one comparison and the failure understates. Recorded here
+because a per-harness reader should inherit the METHOD, not either
+result.
 
 ### The primary-model latch, and CTX% that stops moving
 

--- a/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
@@ -132,9 +132,40 @@ Recorded because the discriminator generalizes and neither of us reached
 it alone. The Crush arm found that its two terms are settled by
 different tests (`completion_tokens` by observed decrease,
 `prompt_tokens` by the window bound, neither by both) and pointed out
-that the same asymmetry was sitting in my gemini result. Codex's version
-of this question is still open (finding-017), and the same test applies
-to it the moment an authenticated multi-turn `codex exec resume` exists.
+that the same asymmetry was sitting in my gemini result.
+
+**Codex closed too, in the opposite direction, and the same corpus had
+been sitting beside the question the whole time.** The codex arm applied
+the decrease test to the rollout's `total_token_usage`, which is the
+accumulator `turn.completed` mirrors field for field. Verified here
+independently against the same 208 rollout files:
+
+```
+1,890  consecutive-pair comparisons        0 decreases
+  159  turn boundaries, 9 multi-turn sessions   0 decreases
+```
+
+A per-turn accumulator drops at every one of those 159. So codex's
+accumulator is SESSION-scoped, which is the worse of the two cases
+finding-017 named and the one `profiles.go` already declares. The
+declaration is now measured rather than noted.
+
+One difference between our runs, characterized rather than waved
+through: I counted one record matching the reset signature
+(`total == last` mid-series) where they counted zero. Both instances are
+a session's first real sample, one a duplicate emission of record 0 and
+one following an `info: null` record. Neither is a reset, so the
+conclusion converges once the definition is stated.
+
+| harness | cumulation | the test that settled it |
+|---|---|---|
+| claude (per-message `usage`) | level | window bound, by three orders of magnitude |
+| gemini (`tokens.input`) | level | observed decrease, then 350 same-turn pairs |
+| codex (`total_token_usage`) | session-cumulative | 159 turn boundaries, zero decreases |
+
+Three harnesses, three different tests, and no two of them settled by
+the same one. That is the transferable part: name the test, not the
+outcome.
 
 ## SP4: would the shipped detector have caught these?
 
@@ -477,3 +508,12 @@ correction of a number rather than of a method.
    `.crush/stats/index.html`, and the Claude terminal `result` line.
    The check is usually one query, and the failure is silent and
    understating.
+7. **Re-test every recorded blocker before inheriting it**, which is the
+   codex arm's addition and the sharper half of 6. finding-017 recorded
+   "needs an authenticated multi-turn `codex exec resume`"; that was true
+   of the exec stream and false of the rollout corpus sitting beside it,
+   and the question closed against data already on disk. This probe is
+   itself an instance: its brief existed because someone re-tested
+   "crossing a compaction costs real quota and a long session" and found
+   the crossings had already happened. A blocker is usually a property of
+   the channel someone happened to be looking at, not of the question.

--- a/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
@@ -229,6 +229,27 @@ every real sample away forever. 10 sessions do start that way, and all 10
 have a series of exactly one sample, so nothing followed to be routed. The
 mechanism is real and the corpus does not contain an instance.
 
+**How long marvel would hold the zero, and why the answer differs per
+harness.** The one record that enters the series is followed by a nonzero
+level 259.9 seconds later, so on Claude the exposure is bounded by
+time-to-next-request. The Crush arm measured the sharper version of the
+same thing (finding-020): Crush's zero is not a record at all but the
+current value of a mutable `sessions.prompt_tokens` column, which each
+request overwrites, so it persists from the compaction until the next
+request COMPLETES. Codex and Claude write a transient record a tailing
+reader can skip; Crush holds a state a poller sits on.
+
+The distinction that matters for the fold is narrower than transient
+versus durable, and it is not the one either of us started with.
+Discarding the zero is correct on all three. **Discarding plus holding the
+last good level only works when a last good level EXISTS.** A reader that
+attaches to a session already sitting in the post-compaction state, which
+is every marvel restart, every adopted pane, and every session that
+compacted while nothing was watching, has never seen a good reading and
+has nothing to hold. Its correct output is ABSENCE, which is already this
+package's stated discipline, and not zero, and not the level of whatever
+session it happened to observe first.
+
 ### File order is not chronological
 
 26 usage records across 2 of 423 sessions carry a timestamp earlier than
@@ -383,7 +404,10 @@ correction of a number rather than of a method.
 2. **Discard zero-occupancy samples explicitly**, on the token values, in
    the fold rather than incidentally in the model guard. The one record
    that names its session's real model is the case that already defeats
-   every existing guard.
+   every existing guard. A discard needs a companion rule: hold the last
+   good level where one exists, report absence where none does, and never
+   emit the zero. The second half is the one a poll-shaped reader needs
+   (finding-020) and the one a restarted daemon needs on any harness.
 3. **Re-latch on model change, or mark the reading stale.** Freezing is
    worse than the denominator error `aae-orc-sj34` was filed for, and it
    is silent.

--- a/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
@@ -99,15 +99,42 @@ confirms rather than inherits finding-007's addendum, which established
 the same thing from the other direction (the terminal `result` line IS
 cumulative and the per-message one is not).
 
-**Gemini's per-turn `input` is not SESSION-cumulative. Per-turn
-accumulation is not excluded.** 12 of 22 gemini sessions with three or
-more token rows contain a decrease in `input`, and a session accumulator
-cannot decrease. A per-TURN accumulator that resets at each turn
-boundary is not excluded and would be indistinguishable from a level on
-any single-request turn, which is what codex's open question is
-(finding-017 leaves the same distinction unsettled). The SP5 step count
-below is stated under the level reading and is void under the per-turn
-one, which is the honest scope for it.
+**Gemini's per-turn `input` is a level, on both halves of the test.**
+
+Session accumulation is excluded because a session accumulator cannot
+decrease, and 12 of 22 gemini sessions with three or more token rows
+contain a decrease in `input`.
+
+Within-turn accumulation is excluded by a test the Crush arm proposed
+and my corpus already contained: a multi-request turn. 350 pairs of
+token-bearing messages have no intervening `user` message and a
+`toolCalls` array on the first, so the model made a second request
+inside the same turn. A within-turn accumulator predicts the second
+value at roughly twice the first, since the prompt barely changes
+between them.
+
+```
+ratio of second request to first, 350 same-turn pairs
+p50 1.016   max 1.661   pairs at or above 1.8: 0
+```
+
+(A first pass counted 382 by printing the intervening-message types
+without filtering on them. The committed script filters, and its 350 is
+the number. The conclusion is the same either way, which is luck rather
+than justification.)
+
+The second request carries the first plus the tool result, which is a
+level. The residual case dissolves rather than surviving: an accumulator
+that reset on every model request would be indistinguishable from a
+level to any consumer, so there is nothing left for it to mean.
+
+Recorded because the discriminator generalizes and neither of us reached
+it alone. The Crush arm found that its two terms are settled by
+different tests (`completion_tokens` by observed decrease,
+`prompt_tokens` by the window bound, neither by both) and pointed out
+that the same asymmetry was sitting in my gemini result. Codex's version
+of this question is still open (finding-017), and the same test applies
+to it the moment an authenticated multi-turn `codex exec resume` exists.
 
 ## SP4: would the shipped detector have caught these?
 
@@ -352,10 +379,9 @@ summarization. Marvel's step detector would fire 3 times across those 477
 samples (two of them drops to exactly zero, which is the same hazard as
 above), and there is no label anywhere in the corpus against which to
 score those firings. So gemini has no compaction ground truth on this
-machine, and acquiring one needs a session run, not a mine. That step
-count assumes `input` is a level; see the cumulation check in the method
-section, which excludes session-cumulative and leaves per-turn
-accumulation open.
+machine, and acquiring one needs a session run, not a mine. The step
+count rests on `input` being a level, which the cumulation check in the
+method section establishes on both halves rather than assumes.
 
 One discriminating result came free, in the shape finding-017 used. Over
 the 418 rows with nonzero `cached`, `total == input + output + thoughts +
@@ -412,10 +438,9 @@ correction of a number rather than of a method.
 - **Whether cluster A is caused by scheduled task fires.** 4 of 5 against
   a 15 of 68 base rate.
 - **Whether gemini's `input` subsumes `cached`.** The corpus cannot
-  discriminate.
-- **Whether gemini's `input` accumulates within a TURN.** Session-level
-  accumulation is excluded; per-turn is not, and every gemini row here
-  could be a single-request turn, on which the two coincide.
+  discriminate. Its cumulation is settled (see the method section); its
+  layout is not, and the two are separate questions about the same
+  field.
 - **Anything about a live compaction crossing under marvel.** This is a
   mine of transcripts written by an operator's interactive sessions. The
   accountant consumes a headless NDJSON stream, and the correspondence

--- a/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
+++ b/_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md
@@ -1,4 +1,4 @@
-# finding-023: the shipped compaction detector survives 63 labelled events, and three other things in the same corpus report LOW pressure at HIGH pressure
+# finding-024: the shipped compaction detector survives 63 labelled events, and three other things in the same corpus report LOW pressure at HIGH pressure
 
 - **Date:** 2026-08-09
 - **Status:** measured. SP1 and SP4 answered; SP5 answered for gemini and
@@ -78,6 +78,36 @@ of the corpus rather than of the method.
 
 Only token counts, timestamps, model names, message ids and compaction
 metadata were read. Paths appear in artifacts only as a salted digest.
+
+### Both corpora were tested for cumulation before anything was read as a level
+
+Added after the fact, prompted by the Crush arm finding a third instance
+of the same class: `.crush/stats/index.html` carries cumulative sums
+across sessions, `codex exec --json`'s `turn.completed` is a running
+session total (finding-017), and reading either as a level is the defect
+`internal/usage` exists to prevent. Inheriting "this field is a level"
+from an earlier finding is exactly the move that produced two of those
+three.
+
+**Claude's per-assistant-message `usage` is a level. Excluded by three
+orders of magnitude.** In the largest session, 1,654 deduplicated
+requests carry per-request occupancies summing to 491,457,832 tokens,
+while the largest single value anywhere in the corpus is 967,915, under
+a 1M window. A cumulative series cannot sit below the window at request
+1,654 and it cannot fall, and this one falls at all 63 boundaries. This
+confirms rather than inherits finding-007's addendum, which established
+the same thing from the other direction (the terminal `result` line IS
+cumulative and the per-message one is not).
+
+**Gemini's per-turn `input` is not SESSION-cumulative. Per-turn
+accumulation is not excluded.** 12 of 22 gemini sessions with three or
+more token rows contain a decrease in `input`, and a session accumulator
+cannot decrease. A per-TURN accumulator that resets at each turn
+boundary is not excluded and would be indistinguishable from a level on
+any single-request turn, which is what codex's open question is
+(finding-017 leaves the same distinction unsettled). The SP5 step count
+below is stated under the level reading and is void under the per-turn
+one, which is the honest scope for it.
 
 ## SP4: would the shipped detector have caught these?
 
@@ -273,7 +303,10 @@ summarization. Marvel's step detector would fire 3 times across those 477
 samples (two of them drops to exactly zero, which is the same hazard as
 above), and there is no label anywhere in the corpus against which to
 score those firings. So gemini has no compaction ground truth on this
-machine, and acquiring one needs a session run, not a mine.
+machine, and acquiring one needs a session run, not a mine. That step
+count assumes `input` is a level; see the cumulation check in the method
+section, which excludes session-cumulative and leaves per-turn
+accumulation open.
 
 One discriminating result came free, in the shape finding-017 used. Over
 the 418 rows with nonzero `cached`, `total == input + output + thoughts +
@@ -331,6 +364,9 @@ correction of a number rather than of a method.
   a 15 of 68 base rate.
 - **Whether gemini's `input` subsumes `cached`.** The corpus cannot
   discriminate.
+- **Whether gemini's `input` accumulates within a TURN.** Session-level
+  accumulation is excluded; per-turn is not, and every gemini row here
+  could be a single-request turn, on which the two coincide.
 - **Anything about a live compaction crossing under marvel.** This is a
   mine of transcripts written by an operator's interactive sessions. The
   accountant consumes a headless NDJSON stream, and the correspondence
@@ -358,3 +394,9 @@ correction of a number rather than of a method.
    were real drops with no compaction, and one detection fired on a zero
    record. Any shift trigger keyed on the compaction COUNT inherits all
    three.
+6. **Test every aggregate for cumulation before reading it as a level,
+   including one an earlier finding already blessed.** Three instances
+   across three harnesses now: codex's `turn.completed`, Crush's
+   `.crush/stats/index.html`, and the Claude terminal `result` line.
+   The check is usually one query, and the failure is silent and
+   understating.

--- a/_kos/nodes/frontier/question-interactive-context-pressure.yaml
+++ b/_kos/nodes/frontier/question-interactive-context-pressure.yaml
@@ -222,9 +222,37 @@ content: |
     assistant records carry all three prompt classes at zero. 67 name
     `<synthetic>` and are excluded incidentally by the non-primary-model
     guard; ONE names the session's real model, passes every guard, and
-    sits beside a compaction at 467,121 tokens. The discard rule
-    `aae-orc-mob4` sets for codex must key on the token values, because
-    the model name is not a reliable discriminator.
+    sits beside a compaction at 467,121 tokens.
+
+  THE ZERO-SAMPLE RULE IS FLEET-WIDE, NOT A CLAUDE FACT, and it is
+  ruled on three measured harnesses rather than argued from one.
+  DISCARD ON THE TOKEN VALUES; never on a companion field. Each harness
+  offers a different companion signal that looks like a discriminator
+  and each fails differently: claude's `model` reads `<synthetic>` on 67
+  of 68 and names the session's real model on the 68th; codex publishes
+  no `model` key on the sentinel record at all (16 all-zero records
+  across 2,099 `token_count` records in 210 rollout files); Crush's
+  `summary_message_id` never clears, so it marks has-ever-compacted
+  rather than this event. Crush's is the categorical case and the
+  strongest form of the rule: a field that cannot distinguish this
+  compaction from a previous one is not a discriminator at any hit
+  rate.
+
+  THE DISCARD NEEDS A COMPANION RULE, because discarding alone leaves
+  the question of what to report. Hold the last good level where one
+  exists; report ABSENCE where none does. A reader attaching to a
+  session already in the post-compaction state has no prior reading to
+  hold, which is every daemon restart, every adopted pane, and every
+  session that compacted unobserved. Absence is already this package's
+  discipline (a wrong number is worse than absence) and zero is a wrong
+  number. The exposure differs by channel shape: codex and claude write
+  a transient record a tailer can skip (claude measured at 259.9s to
+  the next nonzero level), while Crush's zero is the current value of a
+  mutable column that a poller sits on until the next request
+  completes.
+
+  Evidence: finding-024 (claude), finding-023 (codex),
+  finding-020 (Crush).
 
   Three further properties a per-harness reader must handle: transcript
   file order is NOT chronological (26 inversions, worst 25.2 hours, one

--- a/_kos/nodes/frontier/question-interactive-context-pressure.yaml
+++ b/_kos/nodes/frontier/question-interactive-context-pressure.yaml
@@ -192,6 +192,58 @@ content: |
   the path is `payload.rate_limits`, a sibling of `payload.info`, not
   inside it. opencode and Crush have no headroom channel at all.
 
+  THE COMPACTION CORPUS IS MINED (finding-023, 2026-08-09), and the
+  detector it was mined to test passed. 63 of 63 labelled Claude
+  compactions with a sample on each side were detected by the shipped
+  hysteresis, zero false negatives, minimum margin 4.03x over the guard.
+  The comment at `accountant.go:14-31` calling the bound reasoned rather
+  than calibrated can be retired: it is calibrated now, against 63 events
+  rather than one recovered geometry, with a regression fixture at
+  `internal/usage/testdata/compaction_series_claudecode.json`.
+
+  What the same corpus says about the channel matters more than the
+  detector result, because all three items report LOW pressure at HIGH
+  pressure, which is the direction that silently disables rotation:
+
+  - **19 of 82 boundaries produce no post-boundary sample in marvel's
+    series at all**, so the detector cannot fire on them. In the clearest
+    session the last sample naming its latched primary model sits at line
+    3,110 of 5,283 and the six compactions after it are invisible.
+  - **The primary-model latch freezes CTX% permanently.** `fold` latches
+    the first model it sees and never re-latches. 19 sessions switch
+    model and never switch back; 3,563 later samples go to spend, the
+    sink is never written again, and the store keeps rendering the frozen
+    figure as current. Worst case froze at 79,246 tokens while the
+    session reached 751,169. That is a larger error than the denominator
+    error `aae-orc-sj34` was filed for, and it is silent. finding-016
+    already ruled that a model change invalidates the reading; this is
+    the measured cost of not having implemented it.
+  - **Zero-occupancy records exist on claude too.** 68 non-sidechain
+    assistant records carry all three prompt classes at zero. 67 name
+    `<synthetic>` and are excluded incidentally by the non-primary-model
+    guard; ONE names the session's real model, passes every guard, and
+    sits beside a compaction at 467,121 tokens. The discard rule
+    `aae-orc-mob4` sets for codex must key on the token values, because
+    the model name is not a reliable discriminator.
+
+  Three further properties a per-harness reader must handle: transcript
+  file order is NOT chronological (26 inversions, worst 25.2 hours, one
+  reading 134,037 where the true level was 967,915); not every context
+  drop is a labelled compaction (two drops of 16-20% with no boundary
+  record, both after an `away_summary`); and a boundary's `postTokens` is
+  not the level the next request carries (the first post-compaction
+  sample runs a median 61,658 tokens above it).
+
+  SP5 closed two runtimes negatively. gemini has a per-turn token series
+  and no compaction field anywhere in its local chat files, so it has no
+  ground truth on this machine; its `total` EXCLUDES `cached` (418 of 418
+  cached rows), the opposite of opencode, while whether `input` subsumes
+  `cached` is undecidable here because the largest observed prompt is
+  51,209 against a window in the millions. opencode's
+  `session_context_epoch` is present and empty, and its schema keys on
+  `session_id` alone, so it is a pointer to the current epoch and can
+  never hold a compaction history.
+
   Tracked: bd aae-orc-dc1j. Related: aae-orc-7hzb (statusline probe;
   its "other harnesses" remainder is absorbed by the sweep brief),
   aae-orc-w5su (headless CTX%; scope it headless-only so nobody

--- a/_kos/nodes/frontier/question-interactive-context-pressure.yaml
+++ b/_kos/nodes/frontier/question-interactive-context-pressure.yaml
@@ -192,7 +192,7 @@ content: |
   the path is `payload.rate_limits`, a sibling of `payload.info`, not
   inside it. opencode and Crush have no headroom channel at all.
 
-  THE COMPACTION CORPUS IS MINED (finding-023, 2026-08-09), and the
+  THE COMPACTION CORPUS IS MINED (finding-024, 2026-08-09), and the
   detector it was mined to test passed. 63 of 63 labelled Claude
   compactions with a sample on each side were detected by the shipped
   hysteresis, zero false negatives, minimum margin 4.03x over the guard.

--- a/_kos/nodes/frontier/question-shift-triggers.yaml
+++ b/_kos/nodes/frontier/question-shift-triggers.yaml
@@ -211,6 +211,37 @@ content: |
   session cost; cache locality is a fleet property being managed per
   session; coordination overhead grows with fleet size rather than
   fleet output. Tracked: aae-orc-hfc0.
+
+  THE COMPACTION SIGNAL A TRIGGER WOULD CONSUME IS MEASURED NOW
+  (finding-023, 2026-08-09), and the detector half is sound while the
+  input half is not. Replayed against 63 labelled Claude compactions,
+  the shipped hysteresis fired 63 times with zero false negatives and a
+  minimum margin of 4.03x, so the reasoned constants are calibrated.
+  The trigger cannot rely on that yet, for three separate reasons all
+  pointing the same way, toward reporting LOW pressure at HIGH
+  pressure:
+
+  1. 19 of 82 boundaries produce no post-boundary sample in marvel's
+     series, so the detector cannot fire on them at all.
+  2. The primary-model latch freezes the reading. 19 sessions switch
+     model permanently; from that point the sink is never written and
+     the stored CTX% stays at its pre-switch value, worst case 79,246
+     against a session that reached 751,169. A trigger armed on a level
+     that has stopped moving never fires and looks correctly
+     configured, which is the same failure shape finding-016 named for
+     the wrong denominator.
+  3. "Compaction detected" is not "compaction happened." Two real
+     context drops of 16-20 percent carry no compaction record, and one
+     detection fired on a zero-occupancy record rather than on a
+     post-compaction level. Any trigger keyed on the compaction COUNT
+     inherits all three.
+
+  A READING NEEDS AN AGE, and this is the cheapest of the three fixes.
+  `api.SessionContext` carries no observation time, so neither the
+  frozen latch nor a session idle since yesterday (where the level
+  marvel holds bears no relation to the harness's own count, measured
+  0.14x to 18.6x across a resume gap) is distinguishable from a fresh
+  reading by an operator or by a gate.
 edges:
   - target: question-shifts
     type: derives

--- a/_kos/nodes/frontier/question-shift-triggers.yaml
+++ b/_kos/nodes/frontier/question-shift-triggers.yaml
@@ -213,7 +213,7 @@ content: |
   fleet output. Tracked: aae-orc-hfc0.
 
   THE COMPACTION SIGNAL A TRIGGER WOULD CONSUME IS MEASURED NOW
-  (finding-023, 2026-08-09), and the detector half is sound while the
+  (finding-024, 2026-08-09), and the detector half is sound while the
   input half is not. Replayed against 63 labelled Claude compactions,
   the shipped hysteresis fired 63 times with zero false negatives and a
   minimum margin of 4.03x, so the reasoned constants are calibrated.

--- a/_kos/probes/probe-compaction-ground-truth-mining.md
+++ b/_kos/probes/probe-compaction-ground-truth-mining.md
@@ -1,6 +1,46 @@
 # Probe brief: compaction ground truth is already on disk, dozens of times
 
-**Status:** OPEN (brief only; not started).
+**Status:** RUN and CLOSED 2026-08-09. SP2 and SP3 in finding-016
+(2026-08-08); SP1, SP4 and SP5 in finding-023 (2026-08-09).
+
+Results, one line each:
+
+- **SP1, answered.** Marvel's occupancy formula tracks `preTokens` to a
+  median 0.4% low (47 of 56 contiguous events within 1%), never exactly,
+  and the residual is a one-request lag rather than a formula error.
+  Across a resume gap the relationship disappears entirely (0.14x to
+  18.6x).
+- **SP2 and SP3, answered by finding-016**, and not recomputed.
+- **SP4, answered in the detector's favor.** 63 of 63 labelled events
+  detected, zero false negatives, minimum margin 4.03x over the guard.
+  The reasoned constants are now calibrated. Five false positives across
+  30,583 samples, of which two are real unlabelled context drops.
+  Regression fixture at
+  `internal/usage/testdata/compaction_series_claudecode.json`.
+- **SP5, answered for gemini and opencode.** Neither has a labelled
+  compaction corpus on this machine: gemini's chat files carry a token
+  series and no compaction field at all, and opencode's
+  `session_context_epoch` is empty and is a per-session pointer that
+  could not hold a history anyway. codex is finding-017; Crush is the
+  k2mi arm.
+
+Two claims in the brief below are refuted by the run and are corrected in
+place where they appear: subagent context IS minable (1,186 subagent
+transcript files, two of the 82 boundaries inside them), and the file
+counts have moved again because the corpus is live.
+
+The result the probe did not go looking for: three separate mechanisms
+report LOW pressure at HIGH pressure, the direction that silently
+disables shift rotation. See finding-023.
+
+Scripts: `scripts/mine_claude_compactions.py`,
+`scripts/mine_other_harness_compactions.py`.
+
+---
+
+**Original brief follows, unedited except where a claim is struck.**
+
+**Status when written:** OPEN (brief only; not started).
 **Question:** `question-interactive-context-pressure`, and the compaction
 half of `question-shift-triggers`.
 **Probe medium:** mining existing local artifacts. No model calls, no
@@ -195,9 +235,15 @@ any probe that spends model quota.
 - **Forcing a compaction.** The premise is that this is unnecessary. If a
   sub-probe genuinely needs a controlled crossing, record that as a result
   rather than running it here.
-- **The subagent question.** No `isSidechain: true` assistant line exists in
+- ~~**The subagent question.** No `isSidechain: true` assistant line exists in
   the local corpus, so subagent context is not minable this way and stays
-  with `subagentStatusLine`.
+  with `subagentStatusLine`.~~ **REFUTED 2026-08-09 (finding-023).**
+  Subagent transcripts are 1,186 separate files under
+  `<project>/<session>/subagents/`, carrying thousands of
+  `isSidechain: true` usage lines, and two of the 82 compaction
+  boundaries are inside them. The claim was true of the flat glob it was
+  measured with and false of the corpus. Subagents compact, in windows
+  marvel is not watching.
 
 ## Handling note
 

--- a/_kos/probes/probe-compaction-ground-truth-mining.md
+++ b/_kos/probes/probe-compaction-ground-truth-mining.md
@@ -1,7 +1,7 @@
 # Probe brief: compaction ground truth is already on disk, dozens of times
 
 **Status:** RUN and CLOSED 2026-08-09. SP2 and SP3 in finding-016
-(2026-08-08); SP1, SP4 and SP5 in finding-023 (2026-08-09).
+(2026-08-08); SP1, SP4 and SP5 in finding-024 (2026-08-09).
 
 Results, one line each:
 
@@ -31,7 +31,7 @@ counts have moved again because the corpus is live.
 
 The result the probe did not go looking for: three separate mechanisms
 report LOW pressure at HIGH pressure, the direction that silently
-disables shift rotation. See finding-023.
+disables shift rotation. See finding-024.
 
 Scripts: `scripts/mine_claude_compactions.py`,
 `scripts/mine_other_harness_compactions.py`.
@@ -237,7 +237,7 @@ any probe that spends model quota.
   rather than running it here.
 - ~~**The subagent question.** No `isSidechain: true` assistant line exists in
   the local corpus, so subagent context is not minable this way and stays
-  with `subagentStatusLine`.~~ **REFUTED 2026-08-09 (finding-023).**
+  with `subagentStatusLine`.~~ **REFUTED 2026-08-09 (finding-024).**
   Subagent transcripts are 1,186 separate files under
   `<project>/<session>/subagents/`, carrying thousands of
   `isSidechain: true` usage lines, and two of the 82 compaction

--- a/internal/usage/compaction_fixture_test.go
+++ b/internal/usage/compaction_fixture_test.go
@@ -28,7 +28,7 @@ type compactionSeries struct {
 // The constants in accountant.go were reasoned rather than calibrated,
 // against a single recovered geometry of roughly 167k down to 96k. This
 // fixture is the calibration: 466,571 down to 116,155, one of the 63
-// labelled events finding-023 replayed, on which the detector fired 63
+// labelled events finding-024 replayed, on which the detector fired 63
 // times with no false negative and never came within 4x of its guard.
 //
 // It also pins the two things a synthetic series cannot: the approach is

--- a/internal/usage/compaction_fixture_test.go
+++ b/internal/usage/compaction_fixture_test.go
@@ -1,0 +1,88 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/runtime/claudecode"
+	rtevents "github.com/arcavenae/marvel/internal/runtime/events"
+)
+
+// compactionSeries is one real auto-compaction lifted out of the local
+// Claude Code transcript corpus by scripts/mine_claude_compactions.py.
+// Numbers only: no message content, no paths.
+type compactionSeries struct {
+	Source        string `json:"source"`
+	Harness       string `json:"harness"`
+	BoundaryIndex int    `json:"boundary_index"`
+	PreTokens     int    `json:"pre_tokens"`
+	PostTokens    int    `json:"post_tokens"`
+	Dropped       int    `json:"dropped"`
+	Occupancy     []int  `json:"occupancy_series"`
+}
+
+// TestCompactionDetectorOnRealSeries replays a labelled compaction from
+// the operator's own history against the shipped hysteresis.
+//
+// The constants in accountant.go were reasoned rather than calibrated,
+// against a single recovered geometry of roughly 167k down to 96k. This
+// fixture is the calibration: 466,571 down to 116,155, one of the 63
+// labelled events finding-023 replayed, on which the detector fired 63
+// times with no false negative and never came within 4x of its guard.
+//
+// It also pins the two things a synthetic series cannot: the approach is
+// the harness's own, in the increments the harness actually produces, and
+// the drop is the real one rather than a round number chosen to clear the
+// bound.
+func TestCompactionDetectorOnRealSeries(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("testdata/compaction_series_claudecode.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fx compactionSeries
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if fx.Harness != claudecode.Harness {
+		t.Fatalf("fixture harness = %q, want %q", fx.Harness, claudecode.Harness)
+	}
+	if len(fx.Occupancy) <= fx.BoundaryIndex {
+		t.Fatalf("fixture carries %d samples, boundary at %d",
+			len(fx.Occupancy), fx.BoundaryIndex)
+	}
+
+	a, _, _ := newTestAccountant(t, Table{})
+	for _, occ := range fx.Occupancy {
+		// The corpus records a level, not its three classes; feeding it
+		// through In alone is the same additive occupancy.
+		a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
+			Layout: rtevents.LayoutAdditive,
+			In:     occ,
+		}))
+	}
+
+	got, _ := a.SessionOccupancy(testCoords.AgentID)
+	if got.Compactions != 1 {
+		t.Errorf("compactions = %d, want 1 across a %d -> %d boundary",
+			got.Compactions, fx.Occupancy[fx.BoundaryIndex-1], fx.Occupancy[fx.BoundaryIndex])
+	}
+	if want := fx.Occupancy[len(fx.Occupancy)-1]; got.Tokens != want {
+		t.Errorf("level = %d, want %d (the last sample)", got.Tokens, want)
+	}
+	if got.Requests != len(fx.Occupancy) {
+		t.Errorf("requests = %d, want %d", got.Requests, len(fx.Occupancy))
+	}
+
+	// The margin is the point of the fixture: the reasoned guard is not
+	// close to missing a real compaction.
+	pre := fx.Occupancy[fx.BoundaryIndex-1]
+	drop := pre - fx.Occupancy[fx.BoundaryIndex]
+	guard := a.hysteresis(pre)
+	if drop < 4*guard {
+		t.Errorf("drop %d is under 4x the guard %d; the corpus minimum was 4.03x, so this fixture or the constants moved",
+			drop, guard)
+	}
+}

--- a/internal/usage/testdata/compaction_series_claudecode.json
+++ b/internal/usage/testdata/compaction_series_claudecode.json
@@ -1,0 +1,26 @@
+{
+  "source": "claude code transcript, one auto-compaction",
+  "harness": "claude",
+  "boundary_index": 8,
+  "pre_tokens": 467111,
+  "post_tokens": 12429,
+  "dropped": 454682,
+  "occupancy_series": [
+    462747,
+    463259,
+    463811,
+    464244,
+    465068,
+    465702,
+    466134,
+    466571,
+    116155,
+    124357,
+    124758,
+    125109,
+    125678,
+    125819,
+    126652,
+    127590
+  ]
+}

--- a/scripts/mine_claude_compactions.py
+++ b/scripts/mine_claude_compactions.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Mine the local Claude Code transcript corpus for labelled compaction
+events and replay marvel's shipped compaction detector against them.
+
+Answers SP1 and SP4 of _kos/probes/probe-compaction-ground-truth-mining.md.
+SP2 and SP3 were answered by finding-016 and are not recomputed here.
+See finding-019 for the result.
+
+WHAT IT READS. Every *.jsonl under --root, recursively. Per line it keeps
+only: type/subtype, the four token classes of message.usage, message.id,
+message.model, isSidechain, agentId, the compactMetadata numbers, the
+line timestamp, and the record's position in its file. It never reads,
+stores, or prints message content, file paths beyond a salted digest, or
+any tool argument. The corpus is the operator's own working history.
+
+WHAT IT EXCLUDES, and why.
+
+  - Lines whose type is not assistant-with-usage or
+    system/compact_boundary. Everything else carries no accounting.
+  - Sidechain (subagent) usage lines are kept but SEGREGATED: a subagent
+    runs its own context window, so folding it into the parent's series
+    is the defect internal/usage/accountant.go excludes structurally.
+    They live in their own files under <session>/subagents/, so path and
+    isSidechain agree; the script asserts that and reports any
+    disagreement rather than trusting either.
+  - A usage line repeating the immediately preceding message.id, which
+    is how the shipped parser dedupes (parser.go emitRequestUsage
+    compares against lastRequestID only, not a set). Replaying a
+    different dedupe would not be replaying the shipped detector.
+  - Samples whose model identity key differs from the file's first
+    non-sidechain model. accountant.fold routes these to spend and out
+    of the occupancy series. Counted and reported.
+  - Files that changed size while the run was in progress. The corpus is
+    live and this script's own session appends to it. They are reported,
+    not silently dropped.
+
+NOT EXCLUDED, deliberately: nothing is filtered on project directory,
+date, or harness version. Version skew is reported instead.
+
+Usage:
+    scripts/mine_claude_compactions.py                  # report
+    scripts/mine_claude_compactions.py --json out.json  # machine-readable
+    scripts/mine_claude_compactions.py --fixture f.json # regression fixture
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import statistics as st
+import sys
+import time
+from collections import Counter, defaultdict
+
+# marvel's shipped defaults, internal/usage/accountant.go:28-31.
+HYST_TOKENS = 2048
+HYST_FRACTION = 0.10
+
+DATE_SUFFIX = re.compile(r"-\d{8}$")
+
+
+def identity_key(model):
+    """Port of usage.IdentityKey (limits.go): normalize, then strip [1m]."""
+    m = (model or "").strip()
+    for p in ("us.", "eu.", "apac."):
+        if m.startswith(p):
+            m = m[len(p):]
+    if m.startswith("anthropic."):
+        m = m[len("anthropic."):]
+    m = DATE_SUFFIX.sub("", m)
+    return m[:-4] if m.endswith("[1m]") else m
+
+
+def occupancy(rec):
+    """Port of usage.Sample.Occupancy for the additive Claude layout."""
+    return rec["in"] + rec["cache_read"] + rec["cache_creation"]
+
+
+def hysteresis(tokens):
+    """Port of Accountant.hysteresis."""
+    frac = int(tokens * HYST_FRACTION)
+    return frac if frac > HYST_TOKENS else HYST_TOKENS
+
+
+def digest(s, salt):
+    return hashlib.sha256((salt + s).encode()).hexdigest()[:12]
+
+
+def scan(root, salt):
+    """Return (files, skipped) where files is a list of per-file records."""
+    paths = []
+    for dirpath, _dirs, names in os.walk(root):
+        for n in names:
+            if n.endswith(".jsonl"):
+                paths.append(os.path.join(dirpath, n))
+    paths.sort()
+
+    before = {}
+    for p in paths:
+        try:
+            before[p] = os.stat(p).st_size
+        except OSError:
+            pass
+
+    files = []
+    skipped = Counter()
+    for p in paths:
+        if p not in before:
+            skipped["stat_failed"] += 1
+            continue
+        rel = os.path.relpath(p, root)
+        project = rel.split(os.sep)[0]
+        is_sub_path = f"{os.sep}subagents{os.sep}" in rel
+        usage = []
+        boundaries = []
+        markers = []  # (pos, subtype) for the system markers a boundary may sit on
+        versions = Counter()
+        bad_json = 0
+        try:
+            fh = open(p, "r", errors="replace")
+        except OSError:
+            skipped["open_failed"] += 1
+            continue
+        with fh:
+            for pos, line in enumerate(fh):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    o = json.loads(line)
+                except ValueError:
+                    bad_json += 1
+                    continue
+                t = o.get("type")
+                if o.get("version"):
+                    versions[o["version"]] += 1
+                if t == "assistant":
+                    m = o.get("message") or {}
+                    u = m.get("usage")
+                    if not isinstance(u, dict):
+                        continue
+                    usage.append({
+                        "pos": pos,
+                        "msg_id": m.get("id") or "",
+                        "model": m.get("model") or "",
+                        "in": int(u.get("input_tokens") or 0),
+                        "out": int(u.get("output_tokens") or 0),
+                        "cache_read": int(u.get("cache_read_input_tokens") or 0),
+                        "cache_creation": int(u.get("cache_creation_input_tokens") or 0),
+                        "sidechain": bool(o.get("isSidechain")),
+                        "agent_id": o.get("agentId") or "",
+                        "ts": o.get("timestamp") or "",
+                    })
+                elif o.get("subtype") in ("scheduled_task_fire", "away_summary"):
+                    markers.append((pos, o["subtype"]))
+                elif o.get("subtype") == "compact_boundary":
+                    cm = o.get("compactMetadata")
+                    if not isinstance(cm, dict):
+                        boundaries.append({"pos": pos, "meta": None,
+                                           "ts": o.get("timestamp") or ""})
+                        continue
+                    pm = cm.get("preservedMessages") or {}
+                    uuids = pm.get("allUuids") or pm.get("uuids") or []
+                    boundaries.append({
+                        "pos": pos,
+                        "ts": o.get("timestamp") or "",
+                        "meta": {
+                            "trigger": cm.get("trigger"),
+                            "pre": cm.get("preTokens"),
+                            "post": cm.get("postTokens"),
+                            "dropped": cm.get("cumulativeDroppedTokens"),
+                            "duration_ms": cm.get("durationMs"),
+                            "preserved": len(uuids) if isinstance(uuids, list) else None,
+                        },
+                    })
+        try:
+            after = os.stat(p).st_size
+        except OSError:
+            after = -1
+        files.append({
+            "id": digest(rel, salt),
+            "project": digest(project, salt),
+            "is_sub_path": is_sub_path,
+            "usage": usage,
+            "boundaries": boundaries,
+            "markers": markers,
+            "versions": versions,
+            "bad_json": bad_json,
+            "grew": after != before[p],
+        })
+    return files, skipped
+
+
+def replay(usage_records, order="file"):
+    """Replay the shipped detector over one file's occupancy series.
+
+    order="file" feeds records in the order the harness wrote them, which
+    is the closest available proxy for the arrival order a live stream
+    reader sees. order="time" sorts by the line's own timestamp first.
+    The two differ, and the difference is measured rather than assumed.
+
+    Returns (series, detections, routed, deduped).
+    """
+    recs = [r for r in usage_records if not r["sidechain"]]
+    if order == "time":
+        recs = sorted(recs, key=lambda r: (r["ts"], r["pos"]))
+    series = []
+    detections = []
+    routed = 0
+    deduped = 0
+    last_id = ""
+    primary = ""
+    tokens = 0
+    requests = 0
+    for r in recs:
+        if not r["msg_id"] or r["msg_id"] == last_id:
+            deduped += 1
+            continue
+        last_id = r["msg_id"]
+        key = identity_key(r["model"])
+        if primary == "" and key:
+            primary = key
+        if key and primary and key != primary:
+            routed += 1
+            continue
+        occ = occupancy(r)
+        if requests > 0:
+            drop = tokens - occ
+            if drop > hysteresis(tokens):
+                detections.append({"pos": r["pos"], "from": tokens, "to": occ,
+                                   "drop": drop, "index": len(series)})
+        tokens = occ
+        requests += 1
+        series.append({"pos": r["pos"], "occ": occ, "model": r["model"],
+                       "ts": r["ts"]})
+    return series, detections, routed, deduped
+
+
+def zero_census(usage_records):
+    """Zero-occupancy assistant records, split by whether the shipped
+    non-primary-model guard would keep them out of the occupancy series.
+
+    A record whose three prompt classes are all zero is not a level. Codex
+    writes such a sentinel at every compaction (aae-orc-mob4); this counts
+    the Claude equivalent and says which ones marvel already excludes.
+    """
+    primary = ""
+    guarded = 0
+    unguarded = 0
+    models = Counter()
+    for r in usage_records:
+        if r["sidechain"]:
+            continue
+        key = identity_key(r["model"])
+        if primary == "" and key:
+            primary = key
+        if occupancy(r) != 0:
+            continue
+        models[r["model"] or "(unnamed)"] += 1
+        if key and primary and key != primary:
+            guarded += 1
+        else:
+            unguarded += 1
+    return guarded, unguarded, models
+
+
+def latch_census(usage_records):
+    """Does this session switch model and never switch back?
+
+    accountant.fold latches the first model it sees as primary and never
+    re-latches. Every later sample naming a different model is routed to
+    spend, so the occupancy level FREEZES at its pre-switch value and the
+    sink is never written again. Returns None when no permanent switch
+    happened, else the frozen level and the true peak after it.
+    """
+    seq = []
+    last_id = ""
+    for r in usage_records:
+        if r["sidechain"] or not r["msg_id"] or r["msg_id"] == last_id:
+            continue
+        last_id = r["msg_id"]
+        seq.append((identity_key(r["model"]), occupancy(r)))
+    if not seq:
+        return None
+    primary = next((k for k, _ in seq if k), "")
+    routed = [i for i, (k, _) in enumerate(seq) if k and primary and k != primary]
+    if not routed:
+        return None
+    first = routed[0]
+    tail = seq[first:]
+    if not all(k and k != primary for k, _ in tail):
+        return None  # interleaved side calls, not a permanent switch
+    if all(k == "<synthetic>" for k, _ in tail):
+        return None  # a trailing synthetic record is not a model switch
+    return {
+        "series": len(seq),
+        "switch_index": first,
+        "lost": len(tail),
+        "frozen_at": seq[first - 1][1] if first else 0,
+        "true_peak_after": max(o for _, o in tail),
+        "from": primary,
+    }
+
+
+def out_of_order(usage_records):
+    """Count non-sidechain usage lines whose timestamp precedes the line
+    before them in file order, and the largest such inversion in seconds."""
+    prev_ts = ""
+    inversions = 0
+    worst = 0.0
+    total = 0
+    for r in usage_records:
+        if r["sidechain"] or not r["ts"]:
+            continue
+        total += 1
+        if prev_ts and r["ts"] < prev_ts:
+            inversions += 1
+            worst = max(worst, seconds_between(r["ts"], prev_ts))
+        else:
+            prev_ts = max(prev_ts, r["ts"])
+    return inversions, total, worst
+
+
+def seconds_between(a, b):
+    """Seconds from ISO timestamp a to b; 0 when either is unparseable."""
+    import datetime
+    try:
+        fmt = "%Y-%m-%dT%H:%M:%S.%fZ"
+        ta = datetime.datetime.strptime(a, fmt)
+        tb = datetime.datetime.strptime(b, fmt)
+    except ValueError:
+        return 0.0
+    return (tb - ta).total_seconds()
+
+
+def pct(part, whole):
+    return 0.0 if not whole else 100.0 * part / whole
+
+
+def summarize(vals):
+    if not vals:
+        return None
+    s = sorted(vals)
+    return {
+        "n": len(s),
+        "min": s[0],
+        "p50": st.median(s),
+        "max": s[-1],
+        "mean": round(st.mean(s), 1),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=os.path.expanduser("~/.claude/projects"))
+    ap.add_argument("--salt", default=os.environ.get("MINE_SALT", "marvel-sp4"),
+                    help="path-digest salt; change it and file ids change")
+    ap.add_argument("--json", dest="json_out", help="write the full result")
+    ap.add_argument("--fixture", help="write a regression fixture (numbers only)")
+    args = ap.parse_args()
+
+    started = time.time()
+    files, skipped = scan(args.root, args.salt)
+
+    n_main = sum(1 for f in files if not f["is_sub_path"])
+    n_sub = sum(1 for f in files if f["is_sub_path"])
+    grew = [f["id"] for f in files if f["grew"]]
+    versions = Counter()
+    for f in files:
+        versions.update(f["versions"])
+
+    # Path and isSidechain must agree about what a subagent line is.
+    disagree = Counter()
+    for f in files:
+        for r in f["usage"]:
+            if r["sidechain"] != f["is_sub_path"]:
+                disagree[(f["is_sub_path"], r["sidechain"])] += 1
+
+    all_boundaries = []
+    for f in files:
+        for b in f["boundaries"]:
+            all_boundaries.append((f, b))
+
+    sp1 = []      # boundary-level comparisons of marvel occupancy vs preTokens
+    sp4_rows = [] # per-boundary detector outcome, file order
+    fp_rows = []  # detections not straddling any boundary, file order
+    sp4_time = [] # the same replay in timestamp order
+    fp_time = []
+    routed_total = 0
+    deduped_total = 0
+    series_total = 0
+    inversions_total = 0
+    inversion_files = 0
+    worst_inversion = 0.0
+    ordered_samples = 0
+    zero_guarded = 0
+    zero_unguarded = 0
+    zero_models = Counter()
+    latches = []
+
+    for f in files:
+        g, ug, zm = zero_census(f["usage"])
+        zero_guarded += g
+        zero_unguarded += ug
+        zero_models.update(zm)
+        latch = latch_census(f["usage"])
+        if latch:
+            latches.append(latch)
+
+        series, detections, routed, deduped = replay(f["usage"], order="file")
+        t_series, t_detections, _, _ = replay(f["usage"], order="time")
+        routed_total += routed
+        deduped_total += deduped
+        series_total += len(series)
+        f["_series"] = series
+        f["_detections"] = detections
+
+        inv, tot, worst = out_of_order(f["usage"])
+        inversions_total += inv
+        ordered_samples += tot
+        if inv:
+            inversion_files += 1
+        worst_inversion = max(worst_inversion, worst)
+
+        for rows, fps, ser, dets in ((sp4_rows, fp_rows, series, detections),
+                                     (sp4_time, fp_time, t_series, t_detections)):
+            bpos = [b["pos"] for b in f["boundaries"]]
+            matched = set()
+            for b in f["boundaries"]:
+                before = [s for s in ser if s["pos"] < b["pos"]]
+                after = [s for s in ser if s["pos"] > b["pos"]]
+                prev = before[-1] if before else None
+                nxt = after[0] if after else None
+                hit = None
+                for d_i, d in enumerate(dets):
+                    # a detection straddles this boundary when the sample
+                    # it fired on is the first sample after the boundary
+                    if nxt is not None and d["pos"] == nxt["pos"] and before:
+                        hit = d_i
+                        break
+                if hit is not None:
+                    matched.add(hit)
+                meta = b["meta"] or {}
+                rows.append({
+                    "file": f["id"],
+                    "trigger": meta.get("trigger"),
+                    "pre": meta.get("pre"),
+                    "post": meta.get("post"),
+                    "prev_occ": prev["occ"] if prev else None,
+                    "next_occ": nxt["occ"] if nxt else None,
+                    "detected": hit is not None,
+                    "has_prev": prev is not None,
+                    "has_next": nxt is not None,
+                    "drop": (prev["occ"] - nxt["occ"]) if (prev and nxt) else None,
+                    "guard": hysteresis(prev["occ"]) if prev else None,
+                    "model_prev": prev["model"] if prev else None,
+                    "model_next": nxt["model"] if nxt else None,
+                    "next_is_zero": bool(nxt) and nxt["occ"] == 0,
+                    "marker_within_30": sorted({s for p, s in f["markers"]
+                                                if 0 <= b["pos"] - p <= 30}),
+                    "post_exceeds_pre": bool(meta.get("post") and meta.get("pre")
+                                             and meta["post"] > meta["pre"]),
+                    "raw_usage_after": sum(1 for r in f["usage"]
+                                           if not r["sidechain"] and r["pos"] > b["pos"]),
+                })
+            for d_i, d in enumerate(dets):
+                if d_i in matched:
+                    continue
+                near = min((abs(d["pos"] - p) for p in bpos), default=None)
+                fps.append({"file": f["id"], "from": d["from"], "to": d["to"],
+                            "drop": d["drop"], "dist_to_boundary": near})
+
+        # SP1 compares the harness's own preTokens against the level marvel
+        # would hold, taking the chronologically newest sample that precedes
+        # the boundary in time. File order would conflate the formula with
+        # the ordering artifact measured above.
+        for b in f["boundaries"]:
+            meta = b["meta"] or {}
+            if not meta.get("pre") or not b["ts"]:
+                continue
+            cands = [s for s in t_series if s["ts"] and s["ts"] < b["ts"]]
+            if not cands:
+                continue
+            prev = cands[-1]
+            nxt = [s for s in t_series if s["ts"] and s["ts"] > b["ts"]]
+            row = {
+                "file": f["id"],
+                "trigger": meta.get("trigger"),
+                "occ": prev["occ"],
+                "pre": meta["pre"],
+                "delta": prev["occ"] - meta["pre"],
+                "ratio": prev["occ"] / meta["pre"],
+                "gap_s": round(seconds_between(prev["ts"], b["ts"]), 1),
+                "model": prev["model"],
+            }
+            if nxt and meta.get("post"):
+                row["post"] = meta["post"]
+                row["next_occ"] = nxt[0]["occ"]
+                row["post_delta"] = nxt[0]["occ"] - meta["post"]
+            sp1.append(row)
+
+    detected = sum(1 for r in sp4_rows if r["detected"])
+    detectable = sum(1 for r in sp4_rows if r["has_prev"] and r["has_next"])
+    t_detected = sum(1 for r in sp4_time if r["detected"])
+    t_detectable = sum(1 for r in sp4_time if r["has_prev"] and r["has_next"])
+
+    result = {
+        "root": args.root,
+        "snapshot_started": started,
+        "elapsed_s": round(time.time() - started, 1),
+        "files_total": len(files),
+        "files_main": n_main,
+        "files_subagent": n_sub,
+        "files_grew_during_run": len(grew),
+        "files_skipped": dict(skipped),
+        "harness_versions": versions.most_common(),
+        "path_vs_issidechain_disagreements": {str(k): v for k, v in disagree.items()},
+        "usage_samples_in_series": series_total,
+        "samples_routed_nonprimary": routed_total,
+        "samples_deduped": deduped_total,
+        "boundaries_total": len(all_boundaries),
+        "boundaries_in_subagent_files": sum(1 for f, _ in all_boundaries if f["is_sub_path"]),
+        "boundaries_without_metadata": sum(1 for _, b in all_boundaries if b["meta"] is None),
+        "trigger_mix": Counter(r["trigger"] for r in sp4_rows).most_common(),
+        "ordering": {
+            "samples_considered": ordered_samples,
+            "timestamp_inversions": inversions_total,
+            "files_with_inversions": inversion_files,
+            "worst_inversion_s": round(worst_inversion, 1),
+        },
+        "sp1": {
+            "n": len(sp1),
+            "exact_matches": sum(1 for r in sp1 if r["delta"] == 0),
+            "delta": summarize([r["delta"] for r in sp1]),
+            "ratio": summarize([round(r["ratio"], 4) for r in sp1]),
+            "post_delta": summarize([r["post_delta"] for r in sp1 if "post_delta" in r]),
+            "within_1pct": sum(1 for r in sp1 if abs(r["ratio"] - 1) <= 0.01),
+            "within_5pct": sum(1 for r in sp1 if abs(r["ratio"] - 1) <= 0.05),
+            "contiguous_n": sum(1 for r in sp1 if r["gap_s"] <= 600),
+            "contiguous_within_1pct": sum(1 for r in sp1
+                                          if r["gap_s"] <= 600 and abs(r["ratio"] - 1) <= 0.01),
+            "gap_s": summarize([r["gap_s"] for r in sp1]),
+        },
+        "sp4": {
+            "boundaries": len(sp4_rows),
+            "with_samples_both_sides": detectable,
+            "detected": detected,
+            "false_negatives": detectable - detected,
+            "no_sample_before": sum(1 for r in sp4_rows if not r["has_prev"]),
+            "no_sample_after": sum(1 for r in sp4_rows if not r["has_next"]),
+            "false_positives": len(fp_rows),
+            "fp_drop": summarize([r["drop"] for r in fp_rows]),
+            "boundary_drop": summarize([r["drop"] for r in sp4_rows if r["drop"] is not None]),
+            "boundary_guard": summarize([r["guard"] for r in sp4_rows if r["guard"] is not None]),
+        },
+        "zero_occupancy_records": {
+            "total": zero_guarded + zero_unguarded,
+            "excluded_by_nonprimary_guard": zero_guarded,
+            "would_enter_the_series": zero_unguarded,
+            "models": zero_models.most_common(),
+        },
+        "primary_model_latch": {
+            "sessions_with_permanent_switch": len(latches),
+            "samples_routed_away_after_switch": sum(l["lost"] for l in latches),
+            "frozen_vs_true_peak": [
+                {"frozen_at": l["frozen_at"], "true_peak_after": l["true_peak_after"],
+                 "understatement": round(l["true_peak_after"] / l["frozen_at"], 2)
+                 if l["frozen_at"] else None,
+                 "samples_lost": l["lost"]}
+                for l in sorted(latches, key=lambda x: -x["lost"])[:10]
+            ],
+        },
+        "boundary_context": {
+            "on_scheduled_task_or_away_marker": sum(
+                1 for r in sp4_rows if r["marker_within_30"]),
+            "post_exceeds_pre": sum(1 for r in sp4_rows if r["post_exceeds_pre"]),
+            "first_post_sample_is_zero": sum(1 for r in sp4_rows if r["next_is_zero"]),
+            "no_raw_usage_after": sum(1 for r in sp4_rows if r["raw_usage_after"] == 0),
+        },
+        "sp4_timestamp_order": {
+            "with_samples_both_sides": t_detectable,
+            "detected": t_detected,
+            "false_negatives": t_detectable - t_detected,
+            "false_positives": len(fp_time),
+            "fp_drop": summarize([r["drop"] for r in fp_time]),
+        },
+    }
+
+    print(json.dumps(result, indent=2, default=str))
+
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump({"summary": result, "sp1": sp1, "sp4": sp4_rows,
+                       "false_positives": fp_rows}, fh, indent=2, default=str)
+        print(f"\nwrote {args.json_out}", file=sys.stderr)
+
+    if args.fixture:
+        write_fixture(files, args.fixture)
+        print(f"wrote {args.fixture}", file=sys.stderr)
+    return 0
+
+
+def write_fixture(files, path):
+    """Write one real occupancy series spanning a boundary, numbers only.
+
+    Picks the auto-compaction whose surrounding series is long enough to
+    exercise the detector and short enough to read: the fixture is a
+    regression input for the shipped hysteresis, not a corpus sample.
+    """
+    best = None
+    for f in files:
+        series = f.get("_series") or []
+        for b in f["boundaries"]:
+            meta = b["meta"] or {}
+            if meta.get("trigger") != "auto":
+                continue
+            before = [s for s in series if s["pos"] < b["pos"]]
+            after = [s for s in series if s["pos"] > b["pos"]]
+            if len(before) < 8 or len(after) < 8:
+                continue
+            window = before[-8:] + after[:8]
+            head = [s["occ"] for s in window[:8]]
+            if any(b < a for a, b in zip(head, head[1:])):
+                continue  # the approach must be monotone, or the fixture
+                          # is testing a resume artifact rather than a
+                          # compaction
+            cand = {
+                "source": "claude code transcript, one auto-compaction",
+                "harness": "claude",  # rtevents harness id
+                "boundary_index": 8,
+                "pre_tokens": meta["pre"],
+                "post_tokens": meta["post"],
+                "dropped": meta["dropped"],
+                "occupancy_series": [s["occ"] for s in window],
+                # selection key: the gentlest approach available, so the
+                # fixture exercises the detector rather than a single
+                # outsized tool result arriving one request before the
+                # boundary.
+                "_max_step": max(b - a for a, b in zip(head, head[1:])),
+            }
+            if best is None or cand["_max_step"] < best["_max_step"]:
+                best = cand
+    if best is None:
+        return
+    best.pop("_max_step", None)
+    with open(path, "w") as fh:
+        json.dump(best, fh, indent=2)
+        fh.write("\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mine_claude_compactions.py
+++ b/scripts/mine_claude_compactions.py
@@ -265,6 +265,34 @@ def zero_census(usage_records):
     return guarded, unguarded, models
 
 
+def cumulation_check(usage_records):
+    """Is this session's per-message usage a LEVEL or a running total?
+
+    Never inherited from an earlier finding: reading a cumulative series
+    as a level is the defect internal/usage exists to prevent, and it has
+    now been found on three harnesses (codex turn.completed, Crush's
+    stats page, Claude's own terminal result line).
+
+    The discriminator is the window bound. A running total over N
+    requests cannot stay under a context window; a level must. Returns
+    the request count, the sum of the per-request occupancies, and the
+    largest single value, so the two readings can be compared directly.
+    """
+    n = 0
+    total = 0
+    peak = 0
+    last_id = ""
+    for r in usage_records:
+        if r["sidechain"] or not r["msg_id"] or r["msg_id"] == last_id:
+            continue
+        last_id = r["msg_id"]
+        occ = occupancy(r)
+        n += 1
+        total += occ
+        peak = max(peak, occ)
+    return n, total, peak
+
+
 def latch_census(usage_records):
     """Does this session switch model and never switch back?
 
@@ -400,7 +428,14 @@ def main():
     zero_models = Counter()
     latches = []
 
+    biggest = (0, 0, 0)
+    corpus_peak = 0
+
     for f in files:
+        n, tot, peak = cumulation_check(f["usage"])
+        corpus_peak = max(corpus_peak, peak)
+        if n > biggest[0]:
+            biggest = (n, tot, peak)
         g, ug, zm = zero_census(f["usage"])
         zero_guarded += g
         zero_unguarded += ug
@@ -554,6 +589,13 @@ def main():
             "fp_drop": summarize([r["drop"] for r in fp_rows]),
             "boundary_drop": summarize([r["drop"] for r in sp4_rows if r["drop"] is not None]),
             "boundary_guard": summarize([r["guard"] for r in sp4_rows if r["guard"] is not None]),
+        },
+        "cumulation_check": {
+            "largest_session_requests": biggest[0],
+            "largest_session_sum_of_occupancies": biggest[1],
+            "largest_session_peak_level": biggest[2],
+            "corpus_peak_level": corpus_peak,
+            "reading": ("level" if corpus_peak < biggest[1] / 10 else "INDETERMINATE"),
         },
         "zero_occupancy_records": {
             "total": zero_guarded + zero_unguarded,

--- a/scripts/mine_other_harness_compactions.py
+++ b/scripts/mine_other_harness_compactions.py
@@ -50,6 +50,12 @@ def gemini(root):
     # indistinguishable from a level on a single-request turn.
     sessions_scored = 0
     sessions_with_decrease = 0
+    # Within-turn accumulation needs a MULTI-REQUEST turn, which is the
+    # test the Crush arm proposed (finding-020). A pair of consecutive
+    # model messages with no user message between them and a toolCalls
+    # array on the first is a second request inside one turn. An
+    # accumulator predicts the second value at roughly 2x the first.
+    turn_pairs = []
     for f in files:
         try:
             with open(f, errors="replace") as fh:
@@ -89,6 +95,19 @@ def gemini(root):
             sessions_scored += 1
             if any(b < a for a, b in zip(series, series[1:])):
                 sessions_with_decrease += 1
+
+        msgs = doc.get("messages") or []
+        toks = [(i, m) for i, m in enumerate(msgs)
+                if isinstance(m, dict) and isinstance(m.get("tokens"), dict)]
+        for (i1, m1), (i2, m2) in zip(toks, toks[1:]):
+            if not (m1.get("toolCalls") or []):
+                continue
+            if any((msgs[k] or {}).get("type") == "user" for k in range(i1 + 1, i2)):
+                continue
+            a = m1["tokens"].get("input") or 0
+            b = m2["tokens"].get("input") or 0
+            if a:
+                turn_pairs.append(b / a)
     return {
         "files": len(files),
         "messages_with_tokens": rows,
@@ -104,7 +123,12 @@ def gemini(root):
             "sessions_with_3plus_rows": sessions_scored,
             "sessions_whose_input_decreases": sessions_with_decrease,
             "session_cumulative_excluded": sessions_with_decrease > 0,
-            "per_turn_accumulation_excluded": False,
+            "same_turn_pairs": len(turn_pairs),
+            "same_turn_ratio_p50": round(st.median(turn_pairs), 3) if turn_pairs else None,
+            "same_turn_ratio_max": round(max(turn_pairs), 3) if turn_pairs else None,
+            "same_turn_pairs_at_or_above_1_8": sum(1 for r in turn_pairs if r >= 1.8),
+            "per_turn_accumulation_excluded": bool(turn_pairs)
+            and not any(r >= 1.8 for r in turn_pairs),
         },
         "downward_steps_past_marvel_hysteresis": steps,
     }

--- a/scripts/mine_other_harness_compactions.py
+++ b/scripts/mine_other_harness_compactions.py
@@ -44,6 +44,12 @@ def gemini(root):
     cached_over_input = 0
     max_input = 0
     steps = []
+    # Cumulation check, per finding-024: a SESSION accumulator can never
+    # decrease, so any session whose input series falls excludes that
+    # reading. A per-TURN accumulator is not excluded by this and is
+    # indistinguishable from a level on a single-request turn.
+    sessions_scored = 0
+    sessions_with_decrease = 0
     for f in files:
         try:
             with open(f, errors="replace") as fh:
@@ -51,6 +57,7 @@ def gemini(root):
         except (OSError, ValueError):
             continue
         prev = None
+        series = []
         for m in doc.get("messages") or []:
             if not isinstance(m, dict):
                 continue
@@ -74,9 +81,14 @@ def gemini(root):
                 identities["cached_nonzero"] += 1
                 identities["total==in+out+thoughts+tool (cached>0)"] += tot == i + o + th + tl
                 identities["total==in+out+thoughts+tool+cached (cached>0)"] += tot == i + o + th + tl + c
+            series.append(i)
             if prev is not None and prev - i > hysteresis(prev):
                 steps.append((prev, i))
             prev = i
+        if len(series) >= 3:
+            sessions_scored += 1
+            if any(b < a for a, b in zip(series, series[1:])):
+                sessions_with_decrease += 1
     return {
         "files": len(files),
         "messages_with_tokens": rows,
@@ -88,6 +100,12 @@ def gemini(root):
         "identities_on_cached_rows": identities.most_common(),
         "rows_with_cached_over_input": cached_over_input,
         "max_input_tokens": max_input,
+        "cumulation_check": {
+            "sessions_with_3plus_rows": sessions_scored,
+            "sessions_whose_input_decreases": sessions_with_decrease,
+            "session_cumulative_excluded": sessions_with_decrease > 0,
+            "per_turn_accumulation_excluded": False,
+        },
         "downward_steps_past_marvel_hysteresis": steps,
     }
 

--- a/scripts/mine_other_harness_compactions.py
+++ b/scripts/mine_other_harness_compactions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""SP5 of _kos/probes/probe-compaction-ground-truth-mining.md: does a
+labelled compaction corpus exist locally for gemini or opencode?
+
+Separate from mine_claude_compactions.py because the corpora have nothing
+in common but the question. codex is covered by finding-017 and Crush by
+the k2mi arm; neither is touched here.
+
+READ-ONLY, and it starts no harness. The opencode store is copied to a
+temp file before it is opened, so a live opencode process is not sharing
+a connection with this script.
+
+WHAT IT EXCLUDES: nothing. Both corpora are small enough to read whole.
+Absence of a marker is the result, so filtering would beg the question.
+"""
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import sqlite3
+import statistics as st
+import tempfile
+from collections import Counter
+
+HYST_TOKENS = 2048
+HYST_FRACTION = 0.10
+
+
+def hysteresis(tokens):
+    frac = int(tokens * HYST_FRACTION)
+    return frac if frac > HYST_TOKENS else HYST_TOKENS
+
+
+def gemini(root):
+    files = sorted(glob.glob(os.path.join(root, "**", "chats", "*.json"),
+                             recursive=True))
+    keys = Counter()
+    token_keys = Counter()
+    models = Counter()
+    identities = Counter()
+    rows = 0
+    cached_over_input = 0
+    max_input = 0
+    steps = []
+    for f in files:
+        try:
+            with open(f, errors="replace") as fh:
+                doc = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        prev = None
+        for m in doc.get("messages") or []:
+            if not isinstance(m, dict):
+                continue
+            keys.update(m.keys())
+            t = m.get("tokens")
+            if not isinstance(t, dict):
+                continue
+            token_keys.update(t.keys())
+            models[m.get("model")] += 1
+            rows += 1
+            i = t.get("input") or 0
+            o = t.get("output") or 0
+            c = t.get("cached") or 0
+            th = t.get("thoughts") or 0
+            tl = t.get("tool") or 0
+            tot = t.get("total") or 0
+            max_input = max(max_input, i)
+            if c > i:
+                cached_over_input += 1
+            if c > 0:
+                identities["cached_nonzero"] += 1
+                identities["total==in+out+thoughts+tool (cached>0)"] += tot == i + o + th + tl
+                identities["total==in+out+thoughts+tool+cached (cached>0)"] += tot == i + o + th + tl + c
+            if prev is not None and prev - i > hysteresis(prev):
+                steps.append((prev, i))
+            prev = i
+    return {
+        "files": len(files),
+        "messages_with_tokens": rows,
+        "message_keys": keys.most_common(),
+        "token_keys": token_keys.most_common(),
+        "models": models.most_common(),
+        "compaction_marker_fields": [k for k in keys
+                                     if "compact" in k.lower() or "summar" in k.lower()],
+        "identities_on_cached_rows": identities.most_common(),
+        "rows_with_cached_over_input": cached_over_input,
+        "max_input_tokens": max_input,
+        "downward_steps_past_marvel_hysteresis": steps,
+    }
+
+
+def opencode(db_path):
+    if not os.path.exists(db_path):
+        return {"present": False}
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    shutil.copy2(db_path, tmp.name)
+    try:
+        con = sqlite3.connect(tmp.name)
+        cur = con.cursor()
+        tables = [r[0] for r in cur.execute(
+            "select name from sqlite_master where type='table' order by name")]
+        out = {"present": True, "tables": tables}
+        for t in ("session", "session_context_epoch", "message", "part"):
+            if t in tables:
+                out[f"rows_{t}"] = cur.execute(f"select count(*) from {t}").fetchone()[0]
+        if "session_context_epoch" in tables:
+            out["session_context_epoch_schema"] = cur.execute(
+                "select sql from sqlite_master where name='session_context_epoch'"
+            ).fetchone()[0]
+        con.close()
+        return out
+    finally:
+        os.unlink(tmp.name)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--gemini-root", default=os.path.expanduser("~/.gemini/tmp"))
+    ap.add_argument("--opencode-db",
+                    default=os.path.expanduser("~/.local/share/opencode/opencode.db"))
+    args = ap.parse_args()
+    print(json.dumps({
+        "gemini": gemini(args.gemini_root),
+        "opencode": opencode(args.opencode_db),
+    }, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Marvel's compaction-detection hysteresis has been shipping on a comment that says it was reasoned rather than calibrated, against one recovered geometry. It is calibrated now: replayed against 63 labelled compactions from the operator's own local corpus, it fired 63 times with zero false negatives and never came within 4x of its guard. That closes the top follow-up finding-007 named in August and three tickets have cited as unrun since, at a cost of zero model calls.

The corpus then produced something the probe was not looking for, and it is worth more than the validation: three separate mechanisms that report LOW context pressure while a session is at HIGH pressure, which is the direction that disables shift rotation without anyone noticing.

- 19 of 82 boundaries produce no post-boundary sample in marvel's series at all, so the detector cannot fire on them.
- The primary-model latch freezes CTX% permanently. `fold` latches the first model it sees and never re-latches, so after a model switch the sink is never written again and the store keeps rendering a stale figure as current. 19 sessions; worst case frozen at 79,246 tokens while the session went on to reach 751,169.
- Claude writes zero-occupancy usage records. 67 of 68 name `<synthetic>` and are excluded incidentally by the model guard; one names its session's real model, passes every guard, and sits beside a compaction at 467,121 tokens.

Two claims in the probe brief are refuted in place: subagent context IS minable (1,186 subagent transcript files, two of the 82 boundaries inside them), and transcript file order is not chronological (26 inversions, worst 25.2 hours, one reading 134,037 where the true level was 967,915).

Numbered 024, not the next-free 023: six arms branched from one base commit and four allocated 019 independently, so the team lead reassigned. The two `orc finding-023` comments in `internal/runtime/forestage.go` and `internal/api/types.go` name a different repo's finding and are untouched.

Cost of merge: additive. One new test, one new fixture, two new scripts, no behavior change. The three defects above are named rather than fixed; fixing them is downstream work per the probe's excluded scope.

## What is in the diff

- `_kos/findings/finding-024-compaction-corpus-and-the-shipped-detector.md`
- `scripts/mine_claude_compactions.py` (SP1, SP4) and `scripts/mine_other_harness_compactions.py` (SP5). Both say what they exclude and why; the first ports `fold` exactly so the replay is of the shipped detector rather than a reimplementation of it.
- `internal/usage/testdata/compaction_series_claudecode.json` plus `TestCompactionDetectorOnRealSeries`: a real 466,571 to 116,155 boundary, the harness's own approach increments, asserting the 4x margin the corpus measured.
- Probe brief marked run with per-sub-probe results; `question-interactive-context-pressure` and `question-shift-triggers` updated with the measurements. No charter prose touched.

## Cumulation, checked rather than inherited

Added after the Crush arm found a third instance of the class (`.crush/stats/index.html` carries cumulative sums; codex's `turn.completed` is a running session total; Claude's terminal `result` line is the same). Both corpora here were tested before anything was read as a level.

Claude's per-message usage is a level, excluded from cumulative by three orders of magnitude: the largest session sums 491,457,832 tokens across 1,654 requests while the largest single value anywhere is 967,915, under a 1M window. Gemini is half settled: 12 of 22 sessions carry a decrease in `input`, which excludes a session accumulator, while per-turn accumulation is not excluded and coincides with a level on a single-request turn. The SP5 step count is scoped to the level reading accordingly. Both checks ship in the scripts.

## Handling

The corpus is the operator's own working history across 54 project directories. Only token counts, timestamps, model names, message ids and compaction metadata were read; paths appear in artifacts only as a salted digest, and no transcript text is in any committed file. Read-only: no harness was started.

Refs: aae-orc-0tnf. Adjacent: aae-orc-sj34, aae-orc-hpeu, aae-orc-mob4.
