### PR TITLE
probe(marvel): question-router-and-backend-layering — the workspace is a fifth routing locus, and it defeats the spawn-time record

### DIFF
--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -243,7 +243,7 @@ content: |
 
   FOURTH PASS 2026-08-09: the k2mi rig answered the schema questions by
   measurement (crush v0.88.1, isolated rig,
-  CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1, zero host drift; finding-019,
+  CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1, zero host drift; finding-020,
   marvel#166). Three open items close, one framing corrects.
 
   - The hedge RESOLVES IN FAVOR of the design-vote argument. `provider` is
@@ -294,10 +294,77 @@ content: |
   unaffected. What is new is a BOUND on how much a harness-read can ever
   deliver, which belongs in whatever design aae-orc-k2mi produces.
 
+  FIFTH PASS 2026-08-09. Two further k2mi results, relayed as measured by that
+  rig rather than re-measured here, plus one claim hoisted out of the Crush
+  narrative because it is not about Crush.
+
+  THE WORKSPACE IS A FIFTH ROUTING LOCUS, AND IT DEFEATS THE KNOW STEP. Crush
+  executes a project-local `.crushrc` as BASH at config load, measured firing
+  on `crush run` with no trust prompt and outside the allowed_tools permission
+  list, because it runs before any agent turn exists. A crushrc is documented
+  as building config by calling builtins including `provider` and `model`. So
+  routing can be decided by marvel's constructed environment, the operator's
+  global config, the harness's internal slot policy, an external router, OR a
+  script shipped in the repository being worked on.
+
+  The consequence is negative for this node's own recommendation. Recording
+  the ambient provider-selecting environment at spawn was called load-bearing
+  in the fourth pass. A .crushrc overrides it AFTER the record is taken, so
+  marvel would hold a spawn-time observation accurate about what marvel handed
+  over and wrong about what ran. This is finding-016's open-loop ruling with a
+  concrete mechanism instead of a caution. What changes: a spawn-time
+  environment read cannot be the guard's only input, and the honest grade for
+  a provider derived that way is ASSIGNED, NOT OBSERVED. That collapses the
+  two warranted fixes into one: the provider-sensitivity guard is sound only
+  if the provider it keys on carries its own provenance grade. Recorded
+  without overreach: for an agent fleet the repository being worked on is
+  frequently content an agent can write, so a routing locus writable by the
+  workload is a different kind of locus from the other four. Nothing was
+  tested from that angle.
+
+  CONFIG/DATA SPLIT: `~/.config/crush/crush.json` is 0600 and carries
+  per-provider api_key; `~/.local/share/crush/crush.json` is 0644, model
+  selections and recent_models, no secrets. CRUSH_GLOBAL_DATA is relocatable,
+  CRUSH_GLOBAL_CONFIG is the credential store, project-local outranks both.
+  The precedence a fleet must respect to pin a per-workspace provider is
+  project-local over data over config, the reverse of where credentials live.
+  The MANAGE=no ruling gains its cleanest supporting case: the relocatable
+  half is the one marvel could touch without going near a credential store, so
+  the SOUL section 3 boundary has a natural seam rather than needing care.
+
+  HOISTED, BECAUSE IT IS A CLAIM ABOUT internal/usage/limits.go AND NOT ABOUT
+  CRUSH. Marvel's table encodes the 1M window as a property of a model NAME,
+  via the `[1m]` suffix NormalizeModel deliberately preserves. finding-016
+  axis 5 says the 1M window is a BETA ENTITLEMENT (context-1m-2025-08-07),
+  gated per account per backend, so the same model id is a 200k model or a 1M
+  model depending on whether the beta is enabled for that account on that
+  backend. A suffix in a model name cannot express an account-and-backend
+  scoped grant; it can only express what the harness chose to spell. So
+  `claude-opus-4-8` and `claude-opus-4-8[1m]` are not two models. They are one
+  model under two entitlement states, read as two keys because that is how the
+  spelling arrives. This is NOT an assertion that the table is wrong (two
+  values are fixture-verified). It asserts that the table's KEY is an axis
+  narrower than the fact it stores, and marvel has no way to notice a
+  mismatch. Would be equally true if Crush did not exist; Crush's catalog was
+  only the instrument that made it visible. Compounds with the provider
+  result: the window depends on at least model, provider and entitlement, and
+  the table is keyed on a string that reliably carries only the first.
+
   STILL NOT ESTABLISHED: whether Crush's catalog matches any vendor's served
-  window (no live API was called); which of marvel or Crush models the
-  1M-entitlement axis correctly; and whether a Crush session in practice ever
-  holds two providers, which the schema permits and the rig did not exhibit.
+  window (no live API was called); whether the harness's `[1m]` spelling
+  tracks the entitlement faithfully in every case, which is the test the
+  hoisted claim asks for; and whether a Crush session in practice ever holds
+  two providers, which the schema permits and the rig did not exhibit. On the
+  last, the rig proposed a cheaper substitute than waiting for a live routing
+  decision: set models.large and models.small to different PROVIDERS and
+  trigger a summarize, which runs on the small slot and DOES persist a row
+  (is_summary_message=1). If that row carries the small slot's provider while
+  conversational rows carry the large slot's, one session holds two providers
+  without needing the router to decide anything. The sharper result it would
+  buy is not "two providers occur" but whether the partial record of the
+  fourth pass is ARBITRARILY partial: the same small slot persists a row for
+  summarize and none for title generation, so a consumer cannot reason about
+  which calls are recorded from any boundary the harness exposes.
 edges:
   - target: question-interactive-context-pressure
     type: derives

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -944,7 +944,7 @@ provider-keyed windows. Whoever ships that adapter meets both.
 The `k2mi` rig answered the four schema questions by measurement (crush
 v0.88.1, isolated rig, `CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1` to avoid the
 global-cache refresh, zero host drift). Full detail in
-`finding-019-crush-context-pressure-channel.md`, marvel#166. Three of my open
+`finding-020-crush-context-pressure-channel.md`, marvel#166. Three of my open
 items close and one framing of mine needs correcting.
 
 **The hedge resolves in favor of the argument.** `provider` is its own
@@ -1007,6 +1007,102 @@ provider a session was pointed at when the harness's own record is silent, and
 the provider-sensitivity guard is unaffected. What is new is a bound on how
 much a harness-read can ever deliver, which belongs in whatever design
 `aae-orc-k2mi` produces.
+
+## 22. Fifth pass: the workspace is a routing locus, and it defeats my own recommendation
+
+Two further results from the `k2mi` rig, neither of which I asked for, and the
+first of which lands on the recommendation this study has been strengthening
+for three passes. Both relayed as measured by that rig, not re-measured here.
+
+**Crush executes a project-local `.crushrc` as bash at config load.** Measured
+firing on `crush run` with no trust prompt, and outside the `allowed_tools`
+permission list, because it runs before any agent turn exists. A `crushrc` is
+documented as building configuration by calling builtins including `provider`
+and `model`.
+
+That makes the **workspace** a routing locus, and it is a fifth one, distinct
+from the four in section 10. Routing can be decided by marvel's constructed
+environment, by the operator's global config, by the harness's internal slot
+policy, by an external router, and now by a script shipped in the repository
+being worked on.
+
+**The consequence for section 6's KNOW recommendation is direct and negative.**
+Recording the ambient provider-selecting environment at spawn is what the
+fourth pass called load-bearing, on the grounds that it is what tells marvel
+which provider a session was pointed at when the harness's own record is
+silent. A `.crushrc` overrides that after the record is taken. Marvel would
+hold a spawn-time observation that is accurate about what marvel handed over
+and wrong about what ran.
+
+This is finding-016's open-loop ruling arriving with a concrete mechanism
+rather than as a caution. The first pass already stated it in the abstract:
+recording the environment records what marvel handed the harness, not what the
+harness used, so the record is an assignment and "assignment without
+observation is open-loop". Section 19 then leaned on that record anyway,
+because the provider-sensitivity guard needs an input. The guard still needs
+one; what changes is that a spawn-time environment read cannot be that input
+on its own, and the honest grade for a provider derived that way is
+**assigned, not observed**, which is precisely the provenance grading section
+12 said was the warranted fix. The two recommendations turn out to be one:
+the guard is only sound if the provider it keys on carries its own grade.
+
+Worth naming without overreaching: for an agent fleet, the repository being
+worked on is frequently content an agent can write. I am not developing that
+into a threat claim, and nothing here was tested from that angle. It is
+recorded because a routing locus that is writable by the workload is a
+different kind of locus from the other four.
+
+**Config and data are split, and only one half holds credentials.**
+`~/.config/crush/crush.json` is mode 0600 and carries per-provider `api_key`;
+`~/.local/share/crush/crush.json` is 0644, model selections and
+`recent_models`, no secrets. `CRUSH_GLOBAL_DATA` is relocatable,
+`CRUSH_GLOBAL_CONFIG` is the operator's credential store, and project-local
+config outranks both.
+
+Two things follow. The precedence chain a fleet would have to respect to pin a
+per-workspace provider is project-local over data over config, which is the
+reverse of where the credentials live. And section 6's MANAGE ruling gains its
+cleanest supporting case: the relocatable half is the one marvel could touch
+without going near a credential store, so the SOUL section 3 boundary has a
+natural seam here rather than needing to be drawn by care.
+
+## 23. Hoisting one claim out of the Crush sections, because it is not about Crush
+
+The rig's closing observation is correct and I am acting on it. This sentence
+has been sitting inside a Crush narrative across two passes:
+
+> Marvel and Crush disagree about which axis carries the 1M window. Marvel
+> puts it in the model name (`claude-opus-4-8` 200000 beside
+> `claude-opus-4-8[1m]` 1000000, the entitlement axis, finding-016 axis 5).
+> Crush puts it in the provider row (anthropic's `claude-opus-4-8` is
+> 1000000).
+
+**That is a claim about `internal/usage/limits.go`, not about Crush.** It says
+marvel's table may be mis-keyed for a reason that has nothing to do with which
+harness reads it, and it would be equally true if Crush did not exist. Crush's
+catalog is only the instrument that made the disagreement visible.
+
+Stated on its own terms: marvel's table encodes the 1M window as a property of
+a model NAME, via the `[1m]` suffix that `NormalizeModel` deliberately
+preserves. finding-016 axis 5 says the 1M window is a BETA ENTITLEMENT
+(`context-1m-2025-08-07`), gated per account per backend, so the same model id
+is a 200k model or a 1M model depending on whether the beta is enabled for
+that account on that backend. A suffix in a model name cannot express an
+account-and-backend-scoped grant. It can only express what the harness chose
+to spell.
+
+So `claude-opus-4-8` and `claude-opus-4-8[1m]` are not two models. They are one
+model under two entitlement states, and the table reads them as two keys
+because that is how the spelling arrives. Whether that is harmless depends on
+whether the harness's spelling tracks the entitlement faithfully in every case,
+which is untested here and is the thing to test. Two of the table's values are
+fixture-verified, so this is not an assertion that the table is wrong; it is
+an assertion that the table's KEY is an axis narrower than the fact it stores,
+and that marvel currently has no way to notice a mismatch.
+
+This is the same shape as the provider result in section 19 and it compounds
+with it: the window depends on at least model, provider, and entitlement, and
+the table is keyed on a string that reliably carries only the first.
 
 ## Third-pass provenance
 


### PR DESCRIPTION
Follow-up to #164 (merged). It closed with a recommendation that marvel record the provider-selecting environment at spawn, called load-bearing because it is what tells marvel which provider a session was pointed at when the harness's own record is silent. A result from the `k2mi` rig says that record can be overridden after it is taken, by a script shipped in the repository being worked on. That is worth landing before anyone builds on the recommendation.

## The workspace is a fifth routing locus

Crush executes a project-local `.crushrc` **as bash at config load**, measured firing on `crush run` with no trust prompt and outside the `allowed_tools` permission list, because it runs before any agent turn exists. A `crushrc` is documented as building configuration by calling builtins including `provider` and `model`.

So routing can be decided in five places, not four: marvel's constructed environment, the operator's global config, the harness's internal slot policy, an external router, and now a file in the workspace.

**The consequence for #164's own recommendation is negative.** A `.crushrc` overrides the spawn-time environment after marvel has recorded it, so marvel would hold an observation that is accurate about what marvel handed over and wrong about what ran. This is `finding-016`'s open-loop ruling arriving with a mechanism instead of a caution.

What changes: a spawn-time environment read cannot be the provider-sensitivity guard's only input, and the honest grade for a provider derived that way is **assigned, not observed**. That collapses #164's two warranted fixes into one, which is a simplification rather than new scope: the guard is sound only if the provider it keys on carries its own provenance grade.

Recorded without overreach: for an agent fleet, the repository being worked on is frequently content an agent can write, so a routing locus writable by the workload is a different kind of locus from the other four. Nothing was tested from that angle and no threat claim is developed here.

## One claim hoisted out of the Crush sections, because it is not about Crush

Marvel's table encodes the 1M window as a property of a model **name**, via the `[1m]` suffix `NormalizeModel` deliberately preserves. `finding-016` axis 5 says the 1M window is a beta entitlement (`context-1m-2025-08-07`), gated per account per backend. A suffix in a model name cannot express an account-and-backend-scoped grant; it can only express what the harness chose to spell.

So `claude-opus-4-8` and `claude-opus-4-8[1m]` are one model under two entitlement states, read as two keys because that is how the spelling arrives. This is **not** an assertion that the table is wrong, since two of its values are fixture-verified. It asserts that the table's key is an axis narrower than the fact it stores, and that marvel has no way to notice a mismatch. It would be equally true if Crush did not exist; Crush's catalog was only the instrument that made it visible.

## Also in this change

- **Citation fix:** the Crush channel finding is `finding-020`, not `finding-019`. Four arms independently claimed 019 after branching from the same base and the lead reallocated. #164 shipped the wrong number in two places; both corrected here. The PR reference (#166) was right.
- Config and data are split across two paths and only the config half holds credentials (0600 with per-provider `api_key`, against 0644 model selections). The precedence a fleet must respect to pin a per-workspace provider is project-local over data over config, the reverse of where the credentials live. #164's MANAGE ruling gains a natural seam: the relocatable half is the one marvel could touch without going near a credential store.

## Scope and cost

Documentation only, one commit, no code and no behavior change. `kos validate` passes (34 nodes, 0 failed). The two `.crushrc` and config-split results are relayed as measured by the `k2mi` rig (`finding-020`, #166) and are labelled as relayed rather than re-measured; I started no Crush server. The ruling and the trigger from #164 are unchanged.

Refs: aae-orc-eooi