### PR TITLE
probe(marvel): question-router-and-backend-layering — the harness's routing record is arbitrarily partial, measured

### DIFF
--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -350,21 +350,37 @@ content: |
   result: the window depends on at least model, provider and entitlement, and
   the table is keyed on a string that reliably carries only the first.
 
+  SIXTH PASS 2026-08-09: ARBITRARILY PARTIAL IS NOW MEASURED, not inferred,
+  and it needed no extra run. The fourth pass recorded that the harness's
+  routing record is partial. The k2mi rig had both halves already and put them
+  together (finding-020 section 8):
+
+  - Title generation: `message_count` HELD at 2 while `sessions.title`
+    changed. No row.
+  - Summarization: `message_count` went 2 to 3 with `summary_message_id` set,
+    and `is_summary_message` on that row. A row.
+
+  Same `models.small` slot, same class of internal call, opposite persistence.
+  So there is NO property Crush exposes from which a consumer could predict
+  which model calls leave an artifact. The consequence, stated plainly: ANY
+  per-model or per-provider aggregate built from that table is over an
+  UNKNOWN SUBSET. That includes the `crush stats` page the fourth pass already
+  declined to price from, for a second and independent reason.
+
+  This upgrades the fourth pass's caution from "the record is partial with no
+  marker" to "the partiality is unpredictable from anything the harness
+  publishes", which is the stronger form and the one a k2mi design must carry.
+
   STILL NOT ESTABLISHED: whether Crush's catalog matches any vendor's served
   window (no live API was called); whether the harness's `[1m]` spelling
   tracks the entitlement faithfully in every case, which is the test the
   hoisted claim asks for; and whether a Crush session in practice ever holds
-  two providers, which the schema permits and the rig did not exhibit. On the
-  last, the rig proposed a cheaper substitute than waiting for a live routing
-  decision: set models.large and models.small to different PROVIDERS and
-  trigger a summarize, which runs on the small slot and DOES persist a row
-  (is_summary_message=1). If that row carries the small slot's provider while
-  conversational rows carry the large slot's, one session holds two providers
-  without needing the router to decide anything. The sharper result it would
-  buy is not "two providers occur" but whether the partial record of the
-  fourth pass is ARBITRARILY partial: the same small slot persists a row for
-  summarize and none for title generation, so a consumer cannot reason about
-  which calls are recorded from any boundary the harness exposes.
+  two providers, which the schema permits and the rig did not exhibit. The rig
+  did NOT run the two-provider probe it had proposed (large and small slots on
+  different providers, then a summarize), on the correct ground that the
+  measurement above answers the question the probe was wanted for and the
+  probe would answer a weaker one. Recorded as UNTESTED rather than
+  soft-closed.
 edges:
   - target: question-interactive-context-pressure
     type: derives

--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -163,11 +163,31 @@ content: |
   on the window, 52 of them by 1.5x or more. `claude-sonnet-4-6` is 200000
   at anthropic and 1000000 at vertexai.
 
-  ALL SEVEN model ids in marvel's shipped table are provider-variable at
-  exact spelling. The cleanest collision: marvel's table returns 1000000 for
-  `claude-opus-5` and a copilot-served model of that exact id is catalogued
-  at 264000, so marvel would resolve `LimitFromTable`, the most confident
-  non-measured rung, and be wrong by 3.8x with no signal.
+  ALL SEVEN base model ids in marvel's shipped table are provider-variable at
+  exact spelling (the table's 11 keys reduce to 7 distinct base ids). The
+  cleanest collision: marvel's table returns 1000000 for `claude-opus-5` and
+  the catalog assigns 264000 to copilot's model of that exact id, so marvel
+  would resolve `LimitFromTable` and be wrong by 3.8x with no signal.
+
+  CORRECTION 2026-08-09 (seventh pass), because the wrong version was about
+  to be escalated. An earlier revision called `LimitFromTable` "the most
+  confident non-measured rung". That is FALSE: `limitLadder` puts
+  `LimitFromManifest` two rungs above the table, and manifest is equally
+  non-measured, being an operator assertion. The table is rung 5 of 7, above
+  only `table-alias` and `unresolved`, and finding-016 already names it the
+  rung of last resort.
+
+  THE SEVERITY DOES NOT COME FROM RUNG POSITION. It comes from the failure
+  MODE: a table MISS resolves `?` and renders absence, which is loud; a table
+  HIT renders a number, and nothing distinguishes a hit that is right from a
+  hit whose key was too narrow. The rung could sit last and the problem would
+  be identical.
+
+  SCOPE OF THE HARM: marvel ships no copilot adapter, so the 3.8x is a
+  demonstrated MECHANISM rather than a live defect. Nothing shows marvel
+  returning a wrong number to anyone today. What is shown is that the key
+  cannot exclude it, and that the catalog claim is a third party's curation
+  rather than measured vendor behavior.
 
   A hypothesis formed and REFUTED in the same pass: copilot's uniform cost 0
   suggested the finding-017 codex pattern (a per-account plan limit wearing a

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -1066,6 +1066,34 @@ cleanest supporting case: the relocatable half is the one marvel could touch
 without going near a credential store, so the SOUL section 3 boundary has a
 natural seam here rather than needing to be drawn by care.
 
+### 22a. Sixth pass: the partiality is measured, and it is unpredictable
+
+The fourth pass recorded that Crush's routing record is partial and carries no
+marker. I proposed a probe to test whether it is *arbitrarily* partial. The
+rig did not need one: it held both halves already and put them together
+(`finding-020` section 8).
+
+| internal call, both on `models.small` | `message_count` | artifact |
+|---|---|---|
+| title generation | held at 2 | none; `sessions.title` changed |
+| summarization | 2 to 3 | a row, `summary_message_id` set, `is_summary_message` on it |
+
+Same slot, same class of call, opposite persistence. **There is no property
+Crush exposes from which a consumer could predict which model calls leave an
+artifact.** The consequence is worth stating in its plainest form: any
+per-model or per-provider aggregate built from that table is over an unknown
+subset. That is a second and independent reason not to price anything off the
+`crush stats` page, beside the level-versus-total error in section 21.
+
+This upgrades the fourth pass from "partial, with no marker" to "the
+partiality is unpredictable from anything the harness publishes", which is the
+form a Crush adapter design has to carry.
+
+The two-provider probe was **not** run, on the correct ground that the
+measurement above answers the question the probe was wanted for while the
+probe itself would answer a weaker one. My open item stays open and untested
+rather than soft-closed.
+
 ## 23. Hoisting one claim out of the Crush sections, because it is not about Crush
 
 The rig's closing observation is correct and I am acting on it. This sentence

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -843,9 +843,33 @@ spelling.** All seven keys, ignoring the `[1m]` suffixed forms:
 | `claude-opus-5` | 1000000 | 264000 (copilot), 1000000 (anthropic) |
 
 `claude-opus-5` is the cleanest collision: marvel's table returns 1000000, and
-a copilot-served model of that exact id is catalogued at 264000. Marvel would
-resolve `LimitFromTable`, the most confident non-measured rung, and be wrong
-by 3.8x with no signal.
+the catalog assigns 264000 to copilot's model of that exact id. Marvel would
+resolve `LimitFromTable` and be wrong by 3.8x with no signal.
+
+**Correction, 2026-08-09 (seventh pass).** An earlier revision of this
+sentence called `LimitFromTable` "the most confident non-measured rung". That
+is wrong and the ladder in `limits.go` says so: `LimitFromManifest` sits two
+rungs above the table and is equally non-measured, being an operator
+assertion. The table is rung 5 of 7, above only `table-alias` and
+`unresolved`, and finding-016 already gives it its correct name, the rung of
+last resort.
+
+**The severity does not come from the rung's position, and restating it that
+way was a mistake worth naming.** It comes from the failure MODE. A table MISS
+resolves `?` and renders absence, which is loud. A table HIT renders a number,
+and nothing anywhere distinguishes a hit that is right from a hit whose key
+was too narrow to be right. The rung could sit last and the problem would be
+identical, because the problem is that a wrong hit is indistinguishable from a
+correct one.
+
+Two further precisions the same correction pass adds:
+
+- The table has 11 keys which reduce to 7 distinct base model ids. All 7 are
+  provider-variable in the catalog at exact spelling. "All seven ids" means
+  the base ids, not 7 of the 11 keys.
+- Marvel ships no copilot adapter, so the 3.8x is a demonstrated MECHANISM
+  rather than a live defect. Nothing here shows marvel returning a wrong
+  number to anyone today. What it shows is that the key cannot exclude it.
 
 **A hypothesis I formed and the data refuted.** Copilot's rows show cost 0 for
 every model, which looked like the codex pattern from finding-017: a


### PR DESCRIPTION
Third and final follow-up on `aae-orc-eooi` (after #164 and #171, both merged). It upgrades a caution this study published as inference into a measurement, which matters because the caution constrains what a Crush adapter can claim from the harness's own database.

## What changed

#164's fourth pass recorded that Crush's routing record is partial: `messages.provider/model` names the model that served each persisted conversational turn, not every model call, with no marker distinguishing the two. I proposed a probe to test whether the partiality is *arbitrary*. The `k2mi` rig answered it without a run, having held both halves already (`finding-020` §8).

| internal call, both on `models.small` | `message_count` | artifact |
|---|---|---|
| title generation | held at 2 | none; `sessions.title` changed |
| summarization | 2 to 3 | a row, `summary_message_id` set, `is_summary_message` on it |

Same slot, same class of internal call, opposite persistence. **There is no property Crush exposes from which a consumer could predict which model calls leave an artifact.**

The consequence in its plainest form: any per-model or per-provider aggregate built from that table is over an unknown subset. That is a second and independent reason not to price anything off the `crush stats` page, beside the level-versus-total error #171 already recorded.

## Why it matters beyond Crush

This study's ruling is that router and backend warrant no new marvel primitive, and that the warranted fix is a provenance grade on the values marvel keys on. Each pass has tightened the same point from a different direction: a spawn-time environment read is an assignment rather than an observation (#171), and now a harness's own per-message record is an observation over a subset of unknown extent. Both say the value needs its grade attached, not a second mechanism.

## Scope and cost

Documentation only, one commit, no code and no behavior change. `kos validate` passes (35 nodes, 0 failed). The measurement is relayed as made by the `k2mi` rig and labelled as relayed; I started no Crush server at any point in this study.

The two-provider probe was **not** run, on the correct ground that this measurement answers the question the probe was wanted for while the probe would answer a weaker one. That item stays open and untested rather than soft-closed.

Ruling and trigger unchanged across six passes.

Refs: aae-orc-eooi