### PR TITLE
finding: the provider-blind window defect is in marvel's own table, and it does not move the rung ask

### DIFF
--- a/_kos/findings/finding-020-crush-context-pressure-channel.md
+++ b/_kos/findings/finding-020-crush-context-pressure-channel.md
@@ -191,6 +191,24 @@ across providers, and an operator writing a window by hand will write the
 model's headline number, which is the value that is wrong by up to 3.8x.
 On this harness the manifest is the more likely error, not the correction.
 
+**The same defect is in marvel's own shipped table, and it does NOT change
+the rung ask.** Stating that plainly because a new cross-reference inside a
+decision document invites the reader to assume it moves the decision. The
+router study reports `claude-opus-5` at 1000000 for anthropic against 264000
+for copilot, so `LimitFromTable` can resolve wrong by 3.8x with no signal
+(`aae-orc-eooi`; the copilot figure is that study's catalog measurement, not
+mine). I checked the marvel half directly: `defaultTable` in
+`internal/usage/limits.go` carries eleven keys over seven distinct model ids,
+every one keyed on the model id alone with no provider dimension, and
+`claude-opus-5` is 1_000_000 there. `table` already sits below `feed` in
+`limitLadder`, so placing Crush's route at either candidate rung already
+outranks it and nothing here needs a different answer. What it does is
+promote the paragraph above from a claim about one harness to a claim about
+a class: a provider-blind static number outranking a provider-aware live one
+is wrong in the same direction wherever it appears, and it appears in our
+code, not only in a hypothetical operator's manifest. The table's own defect
+is the router study's to file, not this finding's.
+
 **This belongs to the operator.** It is a change to a ruled ladder, the
 ruling was the operator's on 2026-08-08, and the evidence for revisiting it
 did not exist then. What I would put in front of them: either Crush's route


### PR DESCRIPTION
#172 put a ladder question in front of the operator: where does Crush's live window route sit relative to `LimitFromManifest`. This adds one paragraph of context to that question and states plainly that it does **not** change the answer, because a new cross-reference inside a decision document otherwise invites the reader to assume it does.

The router study (`aae-orc-eooi`) measured `claude-opus-5` at 1000000 for anthropic against 264000 for copilot. I verified the marvel half before citing it: `defaultTable` in `internal/usage/limits.go` carries eleven keys over seven distinct model ids, every one keyed on model id alone with no provider dimension, `claude-opus-5` at `1_000_000`. So `LimitFromTable` can resolve wrong by 3.8x with no signal.

`table` already sits below `feed` in `limitLadder`, so either candidate rung for Crush's route already outranks it and nothing here needs a different ruling.

What it earns is scope. The paragraph above it already argued that on Crush a hand-written manifest window is the more likely error than the correction. This promotes that from a claim about one harness to a claim about a class: a provider-blind static number outranking a provider-aware live one is wrong in the same direction wherever it appears, and it appears in marvel's code, not only in a hypothetical operator's manifest.

The copilot catalog figure is attributed to the router study rather than asserted here, and the table's own defect is that study's to file. This PR does not change it.

Cost of merge: one paragraph in a finding. No code, no behavior, no test changes.

Recovered onto a fresh branch after #172 merged ahead of the push. No history rewritten.

Refs: aae-orc-k2mi, aae-orc-eooi