### PR TITLE
fix(heartbeat): codex CTX% is dead on main; one wire type so no producer can omit the token

### DIFF
--- a/_kos/findings/finding-023-codex-rollout-reader.md
+++ b/_kos/findings/finding-023-codex-rollout-reader.md
@@ -408,6 +408,57 @@ unable to answer it. The same thing happened here. The framing "needs an
 authenticated multi-turn resume" was true of the exec stream and false of
 the corpus beside it.
 
+## Two correct PRs broke each other on merge, and CI could not see it
+
+Added after the fact, because it is the most transferable thing in this
+finding.
+
+PR #168 made the heartbeat RPC require a per-session token:
+`UpdateSessionHeartbeat` takes it as a parameter, `authenticateHeartbeat`
+fails open only when the record carries no hash, and `Manager.Create`
+mints a hash before the record exists. PR #170, this one, added a second
+heartbeat producer that presented no token, because it was written
+against a base where the parameter did not exist. Both merged the same
+night, #168 first.
+
+The result on `b8cc831`: every codex session spawned by a current daemon
+has a hash, so `subtle.ConstantTimeCompare(Hash(""), hash)` mismatches,
+the beat is refused as `ErrHeartbeatUnauthorized`, `ContextAt` stays
+zero, and CTX% renders `-`. The feature this whole finding is about was
+dead on arrival at merge.
+
+**Neither PR was wrong and neither CI run could have caught it.** The
+heartbeat payload is a `map[string]any` marshalled to JSON, so a missing
+key is not a type error; the build was clean. #168's tests cover the
+daemon's auth behavior and #170's cover the payload decision, and both
+suites pass at the merge commit. The contract that broke lives between
+two packages and was asserted in neither.
+
+Three things generalize:
+
+1. **A new producer against a contract under concurrent change is the
+   risk, not a new consumer.** The fanout gave each arm a different
+   harness and told each to reach the same RPC. That shape guarantees N
+   independent implementations of one contract, and the contract was
+   itself being hardened by an arm none of the others could see.
+2. **`map[string]any` on a wire seam converts a compile error into a
+   silent one.** `ctxforward.go` and `codexctx.go` build the same payload
+   as untyped literals inside cobra closures, which is also why no test
+   could reach either. The fix extracts `codexHeartbeatParams` so the
+   payload is addressable; a shared typed struct for the params would be
+   stronger and is not in this PR.
+3. **Green CI on two PRs is not evidence about their merge.** Both were
+   verified against a base that predated the other. The check that would
+   have caught it is running the feature end to end after the merge, not
+   before it, and I had run exactly that check before #168 existed.
+
+Cheapest durable guard, and what this PR does: assert the wire key by
+name in `cmd/marvel`, verified to fail without the fix. The daemon-side
+field is `heartbeatParams.SessionToken`, tagged
+`json:"session_token,omitempty"` in `internal/daemon/daemon.go`; it is
+unexported, so the test spells the key rather than deriving it, and says
+so.
+
 ## What was not established
 
 - **Whether hook trust can be pre-seeded at all**, and where an accepted

--- a/cmd/marvel/codexctx.go
+++ b/cmd/marvel/codexctx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/arcavenae/marvel/internal/api"
 	"github.com/arcavenae/marvel/internal/daemon"
 	"github.com/arcavenae/marvel/internal/runtime/codex"
 	"github.com/spf13/cobra"
@@ -121,39 +122,7 @@ func newCodexCtxCmd() *cobra.Command {
 			if !send || socket == "" || workspace == "" || session == "" {
 				return nil
 			}
-			p := map[string]any{
-				"session_key":     workspace + "/" + session,
-				"context_percent": pct,
-				"model":           model,
-			}
-			// context_window is the producer half of a seam whose
-			// consumer does not exist: internal/daemon.heartbeatParams
-			// has no field for it and drops it. See the long comment in
-			// ctxforward.go, which names the two edits that finish it.
-			//
-			// Codex sharpens that open decision rather than settling it.
-			// This window is a `stream` declaration (rung 1), and codex is
-			// the clean case: limitLadder's rung-1 sentence has two
-			// conjuncts, the harness enforcing compaction against the
-			// window AND stating it "in the same channel as the token
-			// counts it is stating it about", and model_context_window
-			// satisfies both by riding the level's own record.
-			//
-			// Do NOT generalize the rung from this comment. A window the
-			// harness serves over a separate contracted query satisfies
-			// the first conjunct and not the second, and rung 4's text
-			// (a human-facing status hook, no version handle) does not
-			// describe it either. That case is open with the operator,
-			// marvel PR #172; see finding-023 and finding-020. Whatever
-			// rung it lands on, it needs a refetch rule codex does not:
-			// fetched under a different model, a window is unresolved
-			// rather than stale.
-			//
-			// The heartbeat RPC carries no rung and no window, so the
-			// distinction is lost at this seam today.
-			if window > 0 {
-				p["context_window"] = window
-			}
+			p := codexHeartbeatParams(workspace, session, os.Getenv(api.HeartbeatTokenEnv), model, pct, window)
 			params, _ := json.Marshal(p)
 			// Best-effort by design; see the failure posture above.
 			_, _ = daemon.SendRequest(socket, daemon.Request{
@@ -163,4 +132,60 @@ func newCodexCtxCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// codexHeartbeatParams builds the heartbeat RPC's params. It is a
+// separate function so a test can assert what goes on the wire without
+// standing up a daemon; the pair of keys below is exactly what the
+// merge of #170 and #168 got wrong, and an inline literal inside a
+// cobra closure is not reachable by any test that would have caught it.
+func codexHeartbeatParams(workspace, session, token, model string, pct float64, window int) map[string]any {
+	p := map[string]any{
+		"session_key":     workspace + "/" + session,
+		"context_percent": pct,
+		"model":           model,
+	}
+	// The token marvel minted for this session at spawn, exactly as
+	// ctx-forward sends it. Without it the daemon refuses the beat:
+	// authenticateHeartbeat fails open only when the record carries no
+	// hash, and Manager.Create now mints one before the record exists, so
+	// every session spawned by a current daemon has one. A tokenless codex
+	// beat lands as ErrHeartbeatUnauthorized and CTX% renders absence.
+	//
+	// That is not hypothetical: it is what the merge of #170 and #168
+	// produced. codexctx was written against a base where
+	// UpdateSessionHeartbeat took no token, and the two landed the same
+	// night. Nothing failed to compile, because the payload is a
+	// map[string]any on the wire, and no test on either side covered the
+	// pair.
+	if token != "" {
+		p["session_token"] = token
+	}
+	// context_window is the producer half of a seam whose consumer does
+	// not exist: internal/daemon.heartbeatParams has no field for it and
+	// drops it. See the long comment in ctxforward.go, which names the two
+	// edits that finish it.
+	//
+	// Codex sharpens that open decision rather than settling it. This
+	// window is a `stream` declaration (rung 1), and codex is the clean
+	// case: limitLadder's rung-1 sentence has two conjuncts, the harness
+	// enforcing compaction against the window AND stating it "in the same
+	// channel as the token counts it is stating it about", and
+	// model_context_window satisfies both by riding the level's own record.
+	//
+	// Do NOT generalize the rung from this comment. A window the harness
+	// serves over a separate contracted query satisfies the first conjunct
+	// and not the second, and rung 4's text (a human-facing status hook,
+	// no version handle) does not describe it either. That case is open
+	// with the operator, marvel PR #172; see finding-023 and finding-020.
+	// Whatever rung it lands on, it needs a refetch rule codex does not:
+	// fetched under a different model, a window is unresolved rather than
+	// stale.
+	//
+	// The heartbeat RPC carries no rung and no window, so the distinction
+	// is lost at this seam today.
+	if window > 0 {
+		p["context_window"] = window
+	}
+	return p
 }

--- a/cmd/marvel/codexctx_test.go
+++ b/cmd/marvel/codexctx_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
 )
 
 // hookPayload builds a codex hook payload in the shape codex-cli 0.146.0
@@ -162,5 +165,81 @@ func TestCodexReadingIgnoresTheCumulativeTotal(t *testing.T) {
 	}
 	if pct < 49.99 || pct > 50.01 {
 		t.Errorf("pct = %v, want 50: total_token_usage was read as the level", pct)
+	}
+}
+
+// TestCodexHeartbeatParamsCarriesTheSessionToken is the test whose
+// absence let #170 and #168 break each other. Each PR was correct and
+// tested on its own: #168 made the daemon require a token, #170 added a
+// second forwarder that did not send one. The payload is a
+// map[string]any on the wire, so nothing failed to compile, and CI was
+// green on both.
+//
+// The daemon side of this contract is heartbeatParams in
+// internal/daemon/daemon.go, whose token field is tagged
+// `json:"session_token,omitempty"`. That type is unexported, so this
+// asserts the wire key by name. A rename there without a change here
+// reintroduces exactly this class, which is why the key is spelled out
+// rather than derived.
+func TestCodexHeartbeatParamsCarriesTheSessionToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		token     string
+		wantToken bool
+	}{
+		{
+			name:      "token present is forwarded",
+			token:     "abc123",
+			wantToken: true,
+		},
+		{
+			// A session spawned before tokens existed has no token to
+			// present. The daemon admits that beat and says so on the
+			// ring, so sending an empty string would be worse than
+			// omitting the key: it hashes to a value that matches no
+			// record and turns a documented fail-open into a refusal.
+			name:      "no token omits the key rather than sending empty",
+			token:     "",
+			wantToken: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := codexHeartbeatParams("ws", "sess", tt.token, "gpt-5.6-sol", 94.0, 258400)
+
+			raw, err := json.Marshal(p)
+			if err != nil {
+				t.Fatalf("marshal params: %v", err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("unmarshal params: %v", err)
+			}
+
+			v, present := got["session_token"]
+			if present != tt.wantToken {
+				t.Errorf("session_token present = %v, want %v (params: %s)", present, tt.wantToken, raw)
+			}
+			if tt.wantToken && v != tt.token {
+				t.Errorf("session_token = %v, want %q", v, tt.token)
+			}
+			if got["session_key"] != "ws/sess" {
+				t.Errorf("session_key = %v, want ws/sess", got["session_key"])
+			}
+		})
+	}
+}
+
+// TestCodexHeartbeatTokenEnvMatchesCtxForward pins the env var the hook
+// reads. ctx-forward reads api.HeartbeatTokenEnv and the adapter writes
+// it into the pane environment; a codex hook reading a different name
+// would find nothing and fail silently, which is the same failure with
+// a different cause.
+func TestCodexHeartbeatTokenEnvMatchesCtxForward(t *testing.T) {
+	t.Parallel()
+	if api.HeartbeatTokenEnv != "MARVEL_HEARTBEAT_TOKEN" {
+		t.Fatalf("HeartbeatTokenEnv = %q; the codex hook stanza documented in docs/user-guide.md names the old one", api.HeartbeatTokenEnv)
 	}
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -361,9 +361,13 @@ run the review has only `codex exec --dangerously-bypass-hook-trust`,
 which runs every enabled hook in that `CODEX_HOME` without review.
 
 Attribution needs nothing extra. `marvel codex-ctx` reads
-`MARVEL_SOCKET`, `MARVEL_WORKSPACE` and `MARVEL_SESSION` from the
-environment the adapter already constructs at spawn, so a codex started
-outside marvel finds none of them and the command does nothing. It also
+`MARVEL_SOCKET`, `MARVEL_WORKSPACE`, `MARVEL_SESSION` and
+`MARVEL_HEARTBEAT_TOKEN` from the environment the adapter already
+constructs at spawn, so a codex started outside marvel finds none of them
+and the command does nothing. The token is what lets the daemon tell this
+session reporting itself from any other process on the host reporting on
+its behalf; without it a beat is refused and the CTX% cell shows `-`. It
+also
 prints nothing at all: a codex hook's stdout is fed to the model as a
 developer message, so a status line here would be context the reporter
 itself added.


### PR DESCRIPTION
Codex CTX% renders `-` on current main for every codex session, and this restores it. The reader merged in #170 works; its heartbeat never lands. The fix is a shared wire type rather than a second call site remembering, because there were already three producers and #168 could only see two of them.

## What happened

#168 made the heartbeat RPC require a per-session token: `UpdateSessionHeartbeat` takes it as a parameter, `authenticateHeartbeat` fails open only when the record carries no hash, and `Manager.Create` mints a hash before the record exists. #170 added a third heartbeat producer that presents no token, because it was written against a base where the parameter did not exist. Both merged the same night, #168 first.

So on `b8cc831` every codex session has a hash, `subtle.ConstantTimeCompare(Hash(""), hash)` mismatches, the beat is refused as `ErrHeartbeatUnauthorized`, `ContextAt` stays zero, and the column shows absence.

**Neither PR was wrong, and neither CI run could have caught it.** The payload was a `map[string]any`, so a missing key is not a type error and the build was clean. #168's tests cover the daemon's auth behavior with params it constructs itself; #170's cover its payload decision without a daemon. Both suites pass at the merge commit. Nothing on either side put a real producer's bytes in front of the real handler, which is the only place the break was visible.

## The fix

Three producers already existed: `cmd/marvel/ctxforward.go`, `cmd/marvel/codexctx.go`, `cmd/simulator/main.go`. #168 updated two. Crush is a likely fourth. So this is the shared-constructor case rather than the one-line case.

- `api.HeartbeatRequest` is the single definition of the wire shape; `internal/daemon`'s `heartbeatParams` becomes an alias of it. A field rename is now a compile error at every producer instead of a missing key at one.
- `api.NewHeartbeatRequest` reads the token from the environment marvel already constructs at spawn. **The token is deliberately not a parameter**, because a parameter is a thing a fourth forwarder can forget to pass. There is nothing to omit.
- An empty token still rides as an empty field rather than a placeholder. Empty hashes to a value matching no record, which would convert #168's documented fail-open for pre-token sessions into a refusal.

## The guard is at the boundary, not in a mirror

My first attempt asserted the wire key inside `cmd/marvel`. It fails without the fix, and it would not have caught the next instance, so it is no longer the guard.

`TestEveryProducerShapeIsAdmitted` drives each real producer's bytes through the real `handleHeartbeat` against a session registered the way the manager registers one. `TestABareMapPayloadIsRefused` is the negative half, without which a handler that admitted everything would pass; it sends the exact payload `codexctx` sent on the merge commit, spelled as a map so it cannot silently acquire the field the shared type would give it.

Falsified by pointing the constructor at the wrong environment variable, which reproduces tonight's failure with tonight's payload:

```
handleHeartbeat({"session_key":"ws/agent-bound","context_percent":93.85,
  "model":"gpt-5.6-sol","context_window":258400})
  = "session ws/agent-bound: heartbeat token does not match the session it claims", want admitted
```

## One seam half-closed, deliberately

`context_window` was a stray map key the daemon dropped. It is now a typed field the daemon parses and still never reads. That closes the first of the two edits named in `ctxforward.go`'s seam comment, and the comment now says which half is done. Typing a value is not consuming it; the contract decision about whether `UpdateSessionHeartbeat` should take a window is untouched.

## Cost of merge

`internal/daemon`'s struct becomes an alias, so its tests are unchanged. Producer behavior is identical on the wire except that `codexctx` now sends `session_token`. `go build ./...`, `go test -race ./...` and `golangci-lint run ./...` clean at `6a4df17`.

## Also here

- `finding-023` records the merge collision, the weaker first guard and why it was replaced.
- It also states plainly that **hook trust is off the critical path**: marvel cannot install the codex hook at all, since `auth.json` lives in `$CODEX_HOME`, so the stanza is operator setup and an operator who can write it can run the TUI trust review. finding-017 marked this critical path and the graph still carries that; the harvest should retire the marking.
- The user guide names `MARVEL_HEARTBEAT_TOKEN` as the fourth environment variable the hook depends on.

Refs: aae-orc-pt8k, aae-orc-mob4