### PR TITLE
fix(heartbeat): one wire type and one constructor, so no producer can omit the token

### DIFF
--- a/_kos/findings/finding-023-codex-rollout-reader.md
+++ b/_kos/findings/finding-023-codex-rollout-reader.md
@@ -176,11 +176,24 @@ thing a hook and share event names.** Codex's vocabulary is
 shared hook body looks obviously correct. The event names match; the
 stdout contracts do not.
 
-## Hook trust: mapped, not closed
+## Hook trust: off the critical path, and the graph should say so
 
-finding-017 marked this critical path, on the reasoning that a design
-requiring `--dangerously-bypass-hook-trust` is not shippable. I did not
-close it. What I established:
+**Stated plainly, because finding-017 marked this critical path and the
+graph still carries that**: `--dangerously-bypass-hook-trust` is not
+needed by the shipped design, and nothing in this channel depends on the
+trust question. Marvel cannot install the codex hook at all, because
+`auth.json` lives in `$CODEX_HOME` and the hook stanza is operator setup;
+an operator who can write the stanza can run the TUI review that grants
+trust. What remains open is only whether trust can be pre-seeded
+non-interactively, which is a convenience with no dependent.
+
+finding-017's reasoning was that a design requiring the bypass flag is not
+shippable. That reasoning is sound and its premise turned out false: this
+design does not require it. Whoever harvests should retire the critical-
+path marking rather than carry it forward.
+
+Below is what I established while the question still looked load-bearing.
+I did not close it:
 
 - **The gate is silent.** An enabled, untrusted hook does not run and
   nothing says so: no warning on stderr, no line in the rollout, no
@@ -452,12 +465,43 @@ Three things generalize:
    have caught it is running the feature end to end after the merge, not
    before it, and I had run exactly that check before #168 existed.
 
-Cheapest durable guard, and what this PR does: assert the wire key by
-name in `cmd/marvel`, verified to fail without the fix. The daemon-side
-field is `heartbeatParams.SessionToken`, tagged
-`json:"session_token,omitempty"` in `internal/daemon/daemon.go`; it is
-unexported, so the test spells the key rather than deriving it, and says
-so.
+**The first guard I wrote was too weak, and the operator named why.** I
+asserted the wire key by name in `cmd/marvel`, verified to fail without
+the fix. That catches this instance and not the next one, because a
+fourth forwarder that never calls my constructor is not covered by a test
+of my constructor. A test that builds the params in-process cannot catch
+the omission of a field it does not know to set.
+
+Three forwarders already existed, which decides the fix: `ctxforward.go`,
+`codexctx.go`, and `cmd/simulator/main.go`. #168 updated two of the
+three. Mine was the one it could not see. Crush is a likely fourth.
+
+So the guard is a shared type and constructor rather than a third call
+site remembering. `api.HeartbeatRequest` is now the one definition of the
+wire shape, `internal/daemon`'s local name is an alias of it, and every
+producer builds it through `api.NewHeartbeatRequest`. **The token is
+deliberately not a parameter**: every forwarder reads it from the same
+variable, and a parameter is a thing a fourth forwarder can forget to
+pass. There is nothing to omit.
+
+The boundary test is `TestEveryProducerShapeIsAdmitted`, which drives
+each real producer's bytes through the real `handleHeartbeat` against a
+session registered the way the manager registers one, with
+`TestABareMapPayloadIsRefused` as its negative half (without which a
+handler that admitted everything would pass). Falsified by pointing the
+constructor at the wrong environment variable, which reproduces tonight's
+failure with tonight's payload:
+
+    handleHeartbeat({"session_key":"ws/agent-bound","context_percent":93.85,
+      "model":"gpt-5.6-sol","context_window":258400})
+      = "session ws/agent-bound: heartbeat token does not match the session it claims"
+
+One thing typing the shape did settle by accident. `context_window` had
+been a stray map key the daemon dropped; it is now a field the daemon
+parses and still never reads. The comment in `ctxforward.go` named two
+edits that would finish that seam, and one of them is now made. Typing a
+value is not consuming it, and the contract decision it named is
+untouched.
 
 ## What was not established
 

--- a/cmd/marvel/codexctx.go
+++ b/cmd/marvel/codexctx.go
@@ -139,32 +139,23 @@ func newCodexCtxCmd() *cobra.Command {
 // standing up a daemon; the pair of keys below is exactly what the
 // merge of #170 and #168 got wrong, and an inline literal inside a
 // cobra closure is not reachable by any test that would have caught it.
-func codexHeartbeatParams(workspace, session, token, model string, pct float64, window int) map[string]any {
-	p := map[string]any{
-		"session_key":     workspace + "/" + session,
-		"context_percent": pct,
-		"model":           model,
-	}
-	// The token marvel minted for this session at spawn, exactly as
-	// ctx-forward sends it. Without it the daemon refuses the beat:
-	// authenticateHeartbeat fails open only when the record carries no
-	// hash, and Manager.Create now mints one before the record exists, so
-	// every session spawned by a current daemon has one. A tokenless codex
-	// beat lands as ErrHeartbeatUnauthorized and CTX% renders absence.
+func codexHeartbeatParams(workspace, session, token, model string, pct float64, window int) api.HeartbeatRequest {
+	// The token marvel minted for this session at spawn. Without it the
+	// daemon refuses the beat: authenticateHeartbeat fails open only when
+	// the record carries no hash, and Manager.Create now mints one before
+	// the record exists, so every session spawned by a current daemon has
+	// one. A tokenless codex beat lands as ErrHeartbeatUnauthorized and
+	// CTX% renders absence.
 	//
 	// That is not hypothetical: it is what the merge of #170 and #168
-	// produced. codexctx was written against a base where
-	// UpdateSessionHeartbeat took no token, and the two landed the same
-	// night. Nothing failed to compile, because the payload is a
-	// map[string]any on the wire, and no test on either side covered the
-	// pair.
-	if token != "" {
-		p["session_token"] = token
-	}
+	// produced. This forwarder was written against a base where the field
+	// did not exist. It now builds the same type every other producer
+	// builds, so the next field added to the contract breaks this line at
+	// compile time rather than at runtime. See finding-023.
+	p := api.NewHeartbeatRequestWithToken(workspace+"/"+session, token, pct, model)
 	// context_window is the producer half of a seam whose consumer does
-	// not exist: internal/daemon.heartbeatParams has no field for it and
-	// drops it. See the long comment in ctxforward.go, which names the two
-	// edits that finish it.
+	// not exist: the daemon parses it and never reads it. See the long
+	// comment in ctxforward.go, which names the edit that would finish it.
 	//
 	// Codex sharpens that open decision rather than settling it. This
 	// window is a `stream` declaration (rung 1), and codex is the clean
@@ -182,10 +173,10 @@ func codexHeartbeatParams(workspace, session, token, model string, pct float64, 
 	// fetched under a different model, a window is unresolved rather than
 	// stale.
 	//
-	// The heartbeat RPC carries no rung and no window, so the distinction
-	// is lost at this seam today.
+	// Zero means the payload declared no window, and an undeclared window
+	// must not arrive as a declared zero.
 	if window > 0 {
-		p["context_window"] = window
+		p.ContextWindow = window
 	}
 	return p
 }

--- a/cmd/marvel/codexctx_test.go
+++ b/cmd/marvel/codexctx_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/arcavenae/marvel/internal/api"
 )
 
 // hookPayload builds a codex hook payload in the shape codex-cli 0.146.0
@@ -168,19 +166,12 @@ func TestCodexReadingIgnoresTheCumulativeTotal(t *testing.T) {
 	}
 }
 
-// TestCodexHeartbeatParamsCarriesTheSessionToken is the test whose
-// absence let #170 and #168 break each other. Each PR was correct and
-// tested on its own: #168 made the daemon require a token, #170 added a
-// second forwarder that did not send one. The payload is a
-// map[string]any on the wire, so nothing failed to compile, and CI was
-// green on both.
-//
-// The daemon side of this contract is heartbeatParams in
-// internal/daemon/daemon.go, whose token field is tagged
-// `json:"session_token,omitempty"`. That type is unexported, so this
-// asserts the wire key by name. A rename there without a change here
-// reintroduces exactly this class, which is why the key is spelled out
-// rather than derived.
+// TestCodexHeartbeatParamsCarriesTheSessionToken covers this forwarder's
+// own payload. The contract itself is pinned at the boundary instead, in
+// internal/daemon: TestEveryProducerShapeIsAdmitted drives every real
+// producer's bytes through the real handler, and TestABareMapPayloadIsRefused
+// is its negative half. This one stays because it is the cheap local
+// check, not because it is the guard.
 func TestCodexHeartbeatParamsCarriesTheSessionToken(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -228,18 +219,9 @@ func TestCodexHeartbeatParamsCarriesTheSessionToken(t *testing.T) {
 			if got["session_key"] != "ws/sess" {
 				t.Errorf("session_key = %v, want ws/sess", got["session_key"])
 			}
+			if got["context_window"] != float64(258400) {
+				t.Errorf("context_window = %v, want 258400", got["context_window"])
+			}
 		})
-	}
-}
-
-// TestCodexHeartbeatTokenEnvMatchesCtxForward pins the env var the hook
-// reads. ctx-forward reads api.HeartbeatTokenEnv and the adapter writes
-// it into the pane environment; a codex hook reading a different name
-// would find nothing and fail silently, which is the same failure with
-// a different cause.
-func TestCodexHeartbeatTokenEnvMatchesCtxForward(t *testing.T) {
-	t.Parallel()
-	if api.HeartbeatTokenEnv != "MARVEL_HEARTBEAT_TOKEN" {
-		t.Fatalf("HeartbeatTokenEnv = %q; the codex hook stanza documented in docs/user-guide.md names the old one", api.HeartbeatTokenEnv)
 	}
 }

--- a/cmd/marvel/ctxforward.go
+++ b/cmd/marvel/ctxforward.go
@@ -416,19 +416,13 @@ func newCtxForwardCmd() *cobra.Command {
 			// is not a property of any session; see the rateLimits type.
 			// It reaches the pane and stops there until an account-scoped
 			// home exists to send it to.
-			p := map[string]any{
-				"session_key":     workspace + "/" + session,
-				"context_percent": pct,
-				"model":           model,
-			}
-			// The token marvel minted for this session at spawn. It is
-			// what lets the daemon tell this session reporting itself
-			// from any other process on the host reporting on its
-			// behalf. Absent (a session spawned before tokens existed)
-			// the daemon admits the beat and says so on the ring.
-			if token := os.Getenv(api.HeartbeatTokenEnv); token != "" {
-				p["session_token"] = token
-			}
+			// The constructor reads the token marvel minted for this
+			// session at spawn. It is what lets the daemon tell this
+			// session reporting itself from any other process on the host
+			// reporting on its behalf. Absent (a session spawned before
+			// tokens existed) the daemon admits the beat and says so on
+			// the ring.
+			p := api.NewHeartbeatRequest(workspace+"/"+session, pct, model)
 			// context_window is the harness's own declared window for this
 			// session. It is emitted as the PRODUCER half of a seam whose
 			// consumer does not exist yet: internal/daemon's heartbeatParams
@@ -438,9 +432,15 @@ func newCtxForwardCmd() *cobra.Command {
 			// feature, and nothing renders differently because of it.
 			//
 			// Two edits complete it, both outside cmd/marvel and both
-			// deliberately not made here: a window field on
-			// internal/daemon.heartbeatParams, and a window argument on
+			// deliberately not made here: a window field on the wire type,
+			// and a window argument on
 			// internal/api.Store.UpdateSessionHeartbeat.
+			//
+			// The first of those is now made and the second is not, which
+			// is why this window still goes nowhere. api.HeartbeatRequest
+			// carries ContextWindow, so the daemon parses it into a field
+			// instead of dropping an untyped map key; it still reads it
+			// nowhere. Typing a value is not consuming it.
 			//
 			// Whoever makes them should read the comment already standing in
 			// UpdateSessionHeartbeat first. It states that a percentage is
@@ -456,7 +456,7 @@ func newCtxForwardCmd() *cobra.Command {
 			// Zero means the payload declared no window, and an undeclared
 			// window must not arrive as a declared zero.
 			if window > 0 {
-				p["context_window"] = window
+				p.ContextWindow = window
 			}
 			params, _ := json.Marshal(p)
 			// Best-effort by design; see the failure posture above.

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -80,13 +80,10 @@ func main() {
 		// token is what separates them.
 		token := os.Getenv(api.HeartbeatTokenEnv)
 		engine.OnHeartbeat = func(pct float64) error {
-			p := map[string]any{
-				"session_key":     sessionKey,
-				"context_percent": pct,
-			}
-			if token != "" {
-				p["session_token"] = token
-			}
+			// The simulator does not know a model name, so it sends none
+			// and any prior reading stands. Built through the shared
+			// constructor so this producer moves with the contract.
+			p := api.NewHeartbeatRequestWithToken(sessionKey, token, pct, "")
 			params, _ := json.Marshal(p)
 			resp, err := daemon.SendRequest(*socket, daemon.Request{
 				Method: "heartbeat",

--- a/internal/api/heartbeat.go
+++ b/internal/api/heartbeat.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 )
 
 // HeartbeatTokenEnv is the environment variable adapters inject the
@@ -74,4 +75,66 @@ func authenticateHeartbeat(sess *Session, token string) (HeartbeatAuth, error) {
 		return "", ErrHeartbeatUnauthorized
 	}
 	return HeartbeatAuthToken, nil
+}
+
+// HeartbeatRequest is the heartbeat RPC's wire shape, shared by every
+// producer and by the daemon that consumes it. One type rather than a
+// map literal per forwarder, so a field rename is a compile error at all
+// of them instead of a missing key at runtime.
+//
+// It exists because the map-literal version failed exactly that way.
+// PR #168 added SessionToken and updated the two forwarders it could see;
+// PR #170 added a third in the same night, built against the base before
+// the field existed. Nothing failed to compile, both suites passed, and
+// codex context pressure was dead on the merge commit. See
+// finding-023.
+type HeartbeatRequest struct {
+	SessionKey string `json:"session_key"`
+	// SessionToken is the secret marvel minted for this session at spawn
+	// and injected into its environment as MARVEL_HEARTBEAT_TOKEN. It is
+	// what binds the reading below to the session named above; the key
+	// alone is public, guessable from `marvel get sessions`, and every
+	// agent on the host can reach this socket.
+	SessionToken   string  `json:"session_token,omitempty"`
+	ContextPercent float64 `json:"context_percent"`
+	// Model is the model as the reporter names it, "" when the reporter
+	// does not know (the simulator). The statusline feed sends the
+	// harness's display name.
+	Model string `json:"model,omitempty"`
+	// ContextWindow is carried and NOT consumed. It is the producer half
+	// of a seam whose consumer does not exist: the daemon parses it into
+	// this field and never reads it, exactly as it did when this was a
+	// stray map key. Typing it changes nothing about that contract
+	// decision, which is still the one named in ctxforward.go: whether
+	// UpdateSessionHeartbeat should take a window narrows the
+	// discriminator that tells the two context producers apart.
+	ContextWindow int `json:"context_window,omitempty"`
+}
+
+// NewHeartbeatRequest builds a heartbeat, reading the session token from
+// the environment marvel constructed at spawn.
+//
+// The token is deliberately NOT a parameter. Every forwarder gets it from
+// the same variable, and a parameter is a thing a fourth forwarder can
+// forget to pass; there is nothing here to omit. Tests and any caller
+// holding a token by other means use NewHeartbeatRequestWithToken.
+func NewHeartbeatRequest(sessionKey string, contextPercent float64, model string) HeartbeatRequest {
+	return NewHeartbeatRequestWithToken(sessionKey, os.Getenv(HeartbeatTokenEnv), contextPercent, model)
+}
+
+// NewHeartbeatRequestWithToken is NewHeartbeatRequest with the token
+// supplied rather than read from the environment.
+//
+// An empty token is passed through as an empty field rather than being
+// rejected: a session spawned before tokens existed has none to present,
+// and authenticateHeartbeat admits that case and says so on the event
+// ring. Sending a placeholder instead would hash to a value matching no
+// record and convert that documented fail-open into a refusal.
+func NewHeartbeatRequestWithToken(sessionKey, token string, contextPercent float64, model string) HeartbeatRequest {
+	return HeartbeatRequest{
+		SessionKey:     sessionKey,
+		SessionToken:   token,
+		ContextPercent: contextPercent,
+		Model:          model,
+	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1039,21 +1039,16 @@ func (d *Daemon) handleScale(params json.RawMessage) Response {
 	return Response{Result: result}
 }
 
-// Heartbeat params
-type heartbeatParams struct {
-	SessionKey string `json:"session_key"`
-	// SessionToken is the secret marvel minted for this session at spawn
-	// and injected into its environment as MARVEL_HEARTBEAT_TOKEN. It is
-	// what binds the reading below to the session named above; the key
-	// alone is public, guessable from `marvel get sessions`, and every
-	// agent on the host can reach this socket.
-	SessionToken   string  `json:"session_token,omitempty"`
-	ContextPercent float64 `json:"context_percent"`
-	// Model is the model as the reporter names it, "" when the
-	// reporter does not know (the simulator). The statusline feed
-	// sends the harness's display name.
-	Model string `json:"model,omitempty"`
-}
+// heartbeatParams is an alias, not a copy: producers build the same type
+// through api.NewHeartbeatRequest, so the wire contract has one
+// definition and a field rename breaks every call site at compile time
+// rather than one of them at runtime. The alias keeps the local spelling
+// used throughout this file and its tests.
+//
+// The previous arrangement was a struct here and a map literal at each
+// producer, which is how a forwarder came to omit SessionToken silently.
+// See api.HeartbeatRequest and finding-023.
+type heartbeatParams = api.HeartbeatRequest
 
 func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 	var p heartbeatParams

--- a/internal/daemon/heartbeat_producer_test.go
+++ b/internal/daemon/heartbeat_producer_test.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// TestEveryProducerShapeIsAdmitted is the boundary test whose absence let
+// PRs #168 and #170 break each other. Both were green: #168 tested the
+// daemon's auth behavior with params it constructed itself, and #170
+// tested its payload decision without a daemon. Neither exercised a real
+// producer's bytes against the real handler, which is the only place the
+// break was visible.
+//
+// A test that builds heartbeatParams in-process cannot catch the next
+// instance either, because the field it would omit is the field it does
+// not know to set. So this drives api.NewHeartbeatRequest, the
+// constructor every forwarder now calls, through handleHeartbeat against
+// a session registered the way the manager registers one.
+//
+// A fourth forwarder is covered as long as it builds its payload with the
+// constructor. That is the point of the constructor: the token is not a
+// parameter it can forget to pass, it is read from the environment marvel
+// already constructs at spawn.
+func TestEveryProducerShapeIsAdmitted(t *testing.T) {
+	d := newHandlerDaemon(t)
+	boundKey, boundToken := registerSession(t, d, "agent-bound", true)
+
+	t.Setenv(api.HeartbeatTokenEnv, boundToken)
+
+	tests := []struct {
+		name string
+		// build produces the payload the way one real forwarder does.
+		build func() api.HeartbeatRequest
+	}{
+		{
+			// cmd/marvel/ctxforward.go, the claude statusline feed.
+			name: "ctx-forward reads the token from the environment",
+			build: func() api.HeartbeatRequest {
+				return api.NewHeartbeatRequest(boundKey, 61, "claude-opus-5")
+			},
+		},
+		{
+			// cmd/marvel/codexctx.go, the codex rollout hook. This is the
+			// producer that was refused on the merge commit.
+			name: "codex-ctx carries a window alongside the token",
+			build: func() api.HeartbeatRequest {
+				p := api.NewHeartbeatRequest(boundKey, 93.85, "gpt-5.6-sol")
+				p.ContextWindow = 258400
+				return p
+			},
+		},
+		{
+			// cmd/simulator/main.go, which names no model.
+			name: "simulator sends no model",
+			build: func() api.HeartbeatRequest {
+				return api.NewHeartbeatRequestWithToken(boundKey, boundToken, 40, "")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(tt.build())
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if resp := d.handleHeartbeat(raw); resp.Error != "" {
+				t.Fatalf("handleHeartbeat(%s) = %q, want admitted", raw, resp.Error)
+			}
+		})
+	}
+}
+
+// TestABareMapPayloadIsRefused is the negative half, and without it the
+// test above proves nothing: a handler that admitted everything would
+// pass it. This is the exact payload cmd/marvel/codexctx.go sent on the
+// merge commit, spelled as a map so it cannot silently acquire the field
+// the shared type would give it.
+func TestABareMapPayloadIsRefused(t *testing.T) {
+	d := newHandlerDaemon(t)
+	boundKey, _ := registerSession(t, d, "agent-bound", true)
+
+	raw, err := json.Marshal(map[string]any{
+		"session_key":     boundKey,
+		"context_percent": 93.85,
+		"model":           "gpt-5.6-sol",
+		"context_window":  258400,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := d.handleHeartbeat(raw)
+	if !strings.Contains(resp.Error, "does not match") {
+		t.Fatalf("handleHeartbeat(%s) = %q, want a refusal; a producer that omits the token must fail loudly", raw, resp.Error)
+	}
+}
+
+// TestNewHeartbeatRequestReadsTheSpawnEnvironment pins the variable name.
+// The constructor's whole guarantee is that a forwarder cannot forget the
+// token, and that guarantee is only as good as this string matching what
+// the adapter writes into the pane.
+func TestNewHeartbeatRequestReadsTheSpawnEnvironment(t *testing.T) {
+	t.Setenv(api.HeartbeatTokenEnv, "tok-abc")
+	if got := api.NewHeartbeatRequest("ws/sess", 12, "m").SessionToken; got != "tok-abc" {
+		t.Fatalf("SessionToken = %q, want it read from %s", got, api.HeartbeatTokenEnv)
+	}
+	if os.Getenv(api.HeartbeatTokenEnv) != "tok-abc" {
+		t.Fatal("t.Setenv did not apply")
+	}
+}


### PR DESCRIPTION
#176 stopped codex CTX% rendering absence. It did not stop the next producer from repeating the mistake, and this does. You asked for a guard at the boundary rather than a mirror test, and for a shared constructor if a third forwarder existed. Three already did.

This is the second half of #176, on a fresh branch because #176 merged at my first commit while I was writing this one.

## Why a constructor rather than a third call site remembering

`cmd/marvel/ctxforward.go`, `cmd/marvel/codexctx.go` and `cmd/simulator/main.go` each built the heartbeat payload as its own `map[string]any`. #168 added `SessionToken` and updated the two it could see; mine did not exist on its base. Crush is a likely fourth.

- `api.HeartbeatRequest` is now the single definition of the wire shape, and `internal/daemon`'s `heartbeatParams` is an alias of it. A field rename is a compile error at every producer instead of a missing key at one.
- `api.NewHeartbeatRequest` reads the token from the environment marvel already constructs at spawn. **The token is deliberately not a parameter**, because a parameter is a thing a fourth forwarder can forget to pass. There is nothing left to omit.
- An empty token still rides as an empty field rather than a placeholder: empty hashes to a value matching no record, which would convert #168's documented fail-open for pre-token sessions into a refusal.

## The guard, and why the one in #176 was not good enough

#176 asserted the wire key inside `cmd/marvel`. It fails without the fix and it would not have caught the next instance, because a forwarder that never calls that constructor is not covered by a test of that constructor. Your diagnosis was right and it is no longer the guard.

`TestEveryProducerShapeIsAdmitted` drives each real producer's bytes through the real `handleHeartbeat`, against a session registered the way the manager registers one. `TestABareMapPayloadIsRefused` is the negative half, without which a handler that admitted everything would pass; it sends the exact payload `codexctx` sent on the merge commit, spelled as a map so it cannot silently acquire the field the shared type would give it.

Falsified by pointing the constructor at the wrong environment variable, which reproduces the failure with its own payload:

```
handleHeartbeat({"session_key":"ws/agent-bound","context_percent":93.85,
  "model":"gpt-5.6-sol","context_window":258400})
  = "session ws/agent-bound: heartbeat token does not match the session it claims", want admitted
```

## One seam half-closed, on purpose

`context_window` was a stray map key the daemon dropped. It is now a typed field the daemon parses and still never reads. That closes the first of the two edits named in `ctxforward.go`'s seam comment, and the comment now says which half is done. Typing a value is not consuming it; the contract decision about whether `UpdateSessionHeartbeat` should take a window is untouched.

## Cost of merge

`internal/daemon`'s type becomes an alias, so its existing tests are unchanged. On-the-wire behavior is identical for all three producers. `go build ./...`, `go test -race ./...` and `golangci-lint run ./...` clean at `e83dcd7` against current main (`7391749`).

## Also here

- `finding-023` records the merge collision, the weaker first guard, and why it was replaced.
- It states plainly that **hook trust is off the critical path**: marvel cannot install the codex hook at all, since `auth.json` lives in `$CODEX_HOME`, so the stanza is operator setup and an operator who can write it can run the TUI trust review. finding-017 marked this critical path and the graph still carries the marking, which the harvest should retire.

Refs: aae-orc-pt8k, aae-orc-mob4