### PR TITLE
probe(marvel): question-router-and-backend-layering — specify the repair, and a worse instance of the same defect at rung 2

### DIFF
--- a/_kos/nodes/frontier/question-router-and-backend-layering.yaml
+++ b/_kos/nodes/frontier/question-router-and-backend-layering.yaml
@@ -401,6 +401,91 @@ content: |
   measurement above answers the question the probe was wanted for and the
   probe would answer a weaker one. Recorded as UNTESTED rather than
   soft-closed.
+  EIGHTH PASS 2026-08-09: THE REPAIR, SPECIFIED AND COSTED. Operator
+  instruction via the lead: not "file it and move on" but study the problem
+  and task out a fix. Defect ticket is `aae-orc-l8v1` (P1). Prior instances,
+  neither a duplicate: `aae-orc-wyza` (bare-vs-[1m] encodes an undocumented
+  default-vs-maximum reading; the entitlement axis; already cost a reviewer a
+  round of investigation) and `aae-orc-rm6o` (claude-sonnet-5 likely missing
+  its [1m] spelling; a MISS, therefore loud, and the useful contrast case).
+
+  A WORSE INSTANCE ONE RUNG FROM THE TOP, measured at HEAD and unnamed until
+  now. `Resolver.learned` is keyed on the identical narrow `NormalizeModel`
+  key, and three facts compound it: (1) ONE Resolver per daemon
+  (internal/daemon/daemon.go:256), so `learned` is fleet-wide across every
+  session; (2) `LimitLearned` is RUNG 2, ABOVE `LimitFromManifest`, and the
+  learned branch returns before the manifest branch is reached, so a learned
+  window silently overrules an operator's explicit runtime.context_window;
+  (3) it is SILENT where its neighbours are not, since stream-vs-manifest and
+  feed-vs-manifest both call warnOnce and the learned branch logs nothing.
+  `Learn` is reached today only by claude. On a daemon running claude across
+  two backends, the first session to finish teaches a window that outranks the
+  operator's override for every later session naming that model id, with no
+  log line. Strictly worse than the table defect: rung 2 not rung 5, populated
+  at runtime rather than shipped and reviewable, and it overrules the one rung
+  the operator controls. NOT ESTABLISHED that any operator has run a
+  mixed-backend fleet on one daemon; this is a mechanism, not an incident.
+
+  THE DESIGN INSIGHT: the discriminator is NOT "which provider". Widening the
+  key to (model, provider, entitlement) fails on this study's own conclusion,
+  that marvel cannot know which provider served a request, and a key naming a
+  value marvel cannot supply never matches. The answerable question is
+  narrower: IS THIS SESSION ON THE VENDOR DEFAULT, OR HAS SOMETHING REDIRECTED
+  IT? Redirection mechanisms are enumerated in finding-016 axis 4
+  (CLAUDE_CODE_USE_BEDROCK/_VERTEX/_FOUNDRY/_MANTLE/_GATEWAY/_ANTHROPIC_AWS/
+  _ANTHROPIC_GOOGLE_CLOUD, ANTHROPIC_BASE_URL, ANTHROPIC_BEDROCK_SERVICE_TIER).
+  MEASURED: marvel's Go tree contains NONE of these strings, so the
+  discriminator does not exist yet and is the deliverable of the KNOW step.
+  The asymmetry that makes it work: the table's shipped values ARE the
+  vendor's direct-API windows, so when nothing has redirected the session they
+  are right and today's behavior is correct. The guard only has to detect
+  DEPARTURE FROM DEFAULT, and may treat "cannot tell" as departure.
+
+  FOUR OPTIONS, COSTED.
+  - A. PROVENANCE GRADE on the resolved value, beside LimitSource,
+    distinguishing a fully-discriminating key from one known to be narrower
+    than the fact. Cost SMALL (one field plus plumbing that exists for
+    LimitSource). Buys: a consumer can refuse and an operator can see why a
+    number is soft. Prevents nothing by itself. NECESSARY, NOT SUFFICIENT.
+  - B. WIDER KEY with provider in it. Cost HIGH and BLOCKED: needs provider
+    observation this study concludes is unavailable, and which pass 5 showed
+    a repo-supplied .crushrc defeats even when marvel builds the environment.
+    If built anyway it degrades into option C with more machinery. DO NOT
+    BUILD NOW; revisit on the standing trigger.
+  - C. REFUSE ON A KNOWN-AMBIGUOUS KEY (recommended core). Mark entries whose
+    window is not determined by model id alone; when the discriminator says
+    redirected or undeterminable, resolve LimitUnresolved rather than the
+    default-path value. Cost MODERATE: needs the discriminator as input (the
+    real work); the guard in Resolve is small, and
+    TestResolveAgreesWithTheLadder usefully constrains it, since the guard
+    must refuse WITHIN a rung and never reorder rungs. Regression smaller than
+    it looks: no change for default-path sessions; for redirected sessions
+    cold-start CTX% renders `?` until the harness teaches a window, which for
+    claude is ONE session because Learn fills the learned rung from the
+    terminal line. Buys: converts the silent-wrong HIT into the loud-absent
+    MISS that rm6o already gets for free.
+  - D. FIX THE LEARNED KEY and warn when it overrules the manifest. Cost
+    SMALL and mostly independent. SHIP FIRST: highest rung affected, live for
+    claude today, and the only one of the four that silently overrules the
+    operator.
+
+  RECOMMENDED SEQUENCE: D first (small, self-contained, correct regardless of
+  what the rest becomes), then A as the vocabulary, then the DISCRIMINATOR
+  (the spawn-time environment record, the real engineering and the KNOW step),
+  then C on top of it, with B deferred behind the trigger. Sequence wyza and
+  rm6o INSIDE this rather than beside it: rm6o is a one-line data question A
+  and C do not touch, and wyza's empirical question (does a bare-keyed session
+  on a split model actually get 200k) is exactly the fixture the discriminator
+  work produces anyway.
+
+  WHAT THE REPAIR DOES NOT FIX: a .crushrc, a project-scope setting, or any
+  config file redirecting the backend WITHOUT touching the environment marvel
+  constructed leaves marvel believing the session is on the default when it is
+  not. The guard is sound for ENVIRONMENT-MEDIATED redirection only. It makes
+  the common case correct and the env-redirected case loud-absent, and leaves
+  config-file redirection silent-wrong. That residue is smaller than today's
+  and is not zero, and anyone reading a graded value must know which of the
+  three cases they are in.
 edges:
   - target: question-interactive-context-pressure
     type: derives

--- a/_kos/probes/study-router-and-backend-layering.md
+++ b/_kos/probes/study-router-and-backend-layering.md
@@ -1176,3 +1176,157 @@ and `tool_call.ndjson`, `internal/usage/doc.go`,
 `_kos/nodes/bedrock/elem-runtime-names-harness.yaml`. Gemini and Crush channel
 detail from bd `aae-orc-6c2r` notes (2026-08-08).
 
+
+---
+
+# Eighth pass, 2026-08-09: the repair, specified and costed
+
+Operator instruction relayed via the lead: this is not "file it and move on".
+Study the problem and task out a fix, saying what the repair is and what each
+option costs. `aae-orc-l8v1` (P1) carries the defect; this section specifies
+the work.
+
+Read first, and neither is a duplicate of the general claim: **`aae-orc-wyza`**
+(the bare-versus-`[1m]` split encodes an undocumented default-versus-maximum
+reading, which is the entitlement axis, and it already cost a reviewer a round
+of investigation on 2026-08-08) and **`aae-orc-rm6o`** (`claude-sonnet-5`
+likely missing its `[1m]` spelling). They are the entitlement instance and the
+miss instance of the same key defect, and `rm6o` is the useful contrast: a
+miss renders `?` and announces itself, which is exactly the behavior this
+repair is trying to buy for the hit.
+
+## 24. A worse instance of the same defect, one rung from the top
+
+**MEASURED (this repo, HEAD).** Before designing anything, the same key
+narrowness turns out to bite somewhere higher and more dangerous than the
+table, and nothing in this arc has named it.
+
+`Resolver.learned` is keyed on `NormalizeModel(model)`, the identical narrow
+key. Three facts compound it:
+
+1. **One Resolver per daemon.** `internal/daemon/daemon.go:256` builds it once
+   (`usage.New(store, usage.NewResolver(limits), ...)`), so `learned` is
+   fleet-wide across every session that daemon runs.
+2. **`LimitLearned` is rung 2, above `LimitFromManifest`.** In `Resolve`, the
+   learned branch returns before the manifest branch is reached, so a learned
+   window silently overrules an operator's explicit `runtime.context_window`.
+3. **It is silent where the neighbouring branches are not.** A stream
+   declaration that contradicts the manifest calls `warnOnce`. A feed
+   declaration that loses to the manifest calls `warnOnce`. The learned branch
+   returns with no comparison and no log.
+
+`Learn` is reached today only by claude (the only harness declaring a window
+in a stream marvel reads). So on a daemon running claude sessions across two
+backends, the first session to finish teaches a window that then outranks the
+operator's own override for every later session naming that model id, without
+a line in the log.
+
+That is strictly worse than the table defect that prompted this work: rung 2
+rather than rung 5, populated at runtime rather than shipped and reviewable,
+and it overrules the one rung an operator controls. It should be fixed first.
+
+Not established: whether any operator has run a mixed-backend fleet on one
+daemon. This is a mechanism, like the copilot figure, not an incident.
+
+## 25. The design insight: the discriminator is not "which provider"
+
+The obvious repair is to widen the key to (model, provider, entitlement). It
+does not work, and the reason is this study's own conclusion: **marvel cannot
+know which provider served a request.** A key naming a value marvel cannot
+supply is a key that never matches.
+
+The usable question is narrower and answerable:
+
+> Not "which provider is this?" but "is this session on the vendor default,
+> or has something redirected it?"
+
+That is cheap and conservative. The redirection mechanisms for claude are
+enumerated in finding-016 axis 4 (`CLAUDE_CODE_USE_BEDROCK`, `_VERTEX`,
+`_FOUNDRY`, `_MANTLE`, `_GATEWAY`, `_ANTHROPIC_AWS`,
+`_ANTHROPIC_GOOGLE_CLOUD`, plus `ANTHROPIC_BASE_URL` and
+`ANTHROPIC_BEDROCK_SERVICE_TIER`). **MEASURED: marvel's Go tree contains none
+of these strings.** The discriminator does not exist yet; it is the deliverable
+of the KNOW step this study has recommended since the first pass.
+
+The asymmetry that makes it work: the table's shipped values are the vendor's
+direct-API windows. When nothing has redirected the session, they are right,
+and today's behavior is correct. When something has, they are unkeyed for that
+path. So the guard only has to detect *departure from default*, and it can
+treat "cannot tell" as departure.
+
+## 26. Four options, costed
+
+**Option A. Provenance grade on the resolved value.** Attach a key-confidence
+grade beside `LimitSource`, distinguishing a window whose key was fully
+discriminating from one resolved on a key known to be narrower than the fact.
+
+- Cost: small. One field, plus the plumbing that already exists for
+  `LimitSource` through the store, the API and the renderer.
+- Buys: a consumer *can* refuse, and an operator can see why a number is soft.
+- Does not itself prevent a wrong number being shown.
+- Verdict: necessary, not sufficient. Ships as the vocabulary the other
+  options speak.
+
+**Option B. Wider key, provider in the key.**
+
+- Cost: high, and **blocked**. Requires provider observation, which sections 2
+  through 21 conclude is unavailable from where marvel stands, and which pass
+  5 showed is defeatable by a repo-supplied `.crushrc` even when marvel
+  constructs the environment.
+- Failure mode if built anyway: every lookup misses until a provider is known,
+  which is Option C with more machinery and a worse name.
+- Verdict: **do not build now.** Revisit only if a provider becomes reliably
+  observable, which is the study's standing trigger.
+
+**Option C. Refuse on a known-ambiguous key (the recommended core).** Mark the
+table entries whose window is not determined by the model id alone, and when
+the discriminator says the session is redirected (or cannot be determined),
+resolve `LimitUnresolved` rather than the default-path value.
+
+- Cost: moderate. Needs the discriminator from section 25 (the spawn-time
+  environment record) as its input, which is the real work. The guard in
+  `Resolve` is small, and `TestResolveAgreesWithTheLadder` constrains it
+  usefully: the guard must refuse *within* a rung, never reorder rungs.
+- Regression, and it is smaller than it looks: for a session on the vendor
+  default, nothing changes. For a redirected session, cold-start CTX% renders
+  `?` until the harness teaches a window. For claude that is one session,
+  because `Learn` fills the learned rung from the terminal line, so the table
+  is the cold-start guess rather than the steady-state answer.
+- Buys: converts the silent-wrong hit into a loud-absent miss, which is the
+  behavior `rm6o` already gets for free by missing.
+
+**Option D. Fix the learned key, and warn when it overrules the manifest.**
+Key `learned` on the same discriminated key as the table, and log once when a
+learned value contradicts a manifest override, matching what the stream and
+feed branches already do.
+
+- Cost: small, and mostly independent of the others. The key change is the
+  same function; the warn is three lines beside two existing ones.
+- Verdict: **ship first.** Highest rung affected, live for claude today, and
+  the only one of the four that silently overrules the operator.
+
+## 27. Recommended sequence, and what it does not fix
+
+1. **D** first. Small, self-contained, highest rung, and correct regardless of
+   what the rest of the design becomes.
+2. **A** next, as the vocabulary. Grading is additive and unblocks the
+   renderer showing why a number is soft.
+3. The **discriminator** (spawn-time environment record). This is the real
+   engineering, it is the KNOW step, and it is the input C needs.
+4. **C** on top of it.
+5. **B** deferred behind the standing trigger.
+
+Sequence tickets `wyza` and `rm6o` inside this rather than beside it: `rm6o`
+is a one-line data question that A and C do not touch, and `wyza` is the
+entitlement half of the same key, whose empirical question (does a bare-keyed
+session on a split model actually get 200k) is exactly the fixture the
+discriminator work would produce anyway.
+
+**What this does not fix, stated plainly.** A `.crushrc`, a project-scope
+setting, or any config file that redirects the backend without touching the
+environment marvel constructed leaves marvel believing the session is on the
+default when it is not. The guard is sound for environment-mediated
+redirection only. It converts the common case to correct and the
+env-redirected case to loud-absent, and leaves config-file redirection
+silent-wrong. That residue is smaller than today's and it is not zero, and
+anyone reading a graded value must know which of the three they are in.


### PR DESCRIPTION
The operator asked for the window-table defect (`aae-orc-l8v1`) to be studied and the fix tasked out, not just filed. Specifying it turned up a worse instance of the same defect sitting one rung from the top of the ladder, which changes what should ship first.

## The thing to read first

**`Resolver.learned` is keyed on the same narrow `NormalizeModel` key, and it silently overrules the operator.** Measured at HEAD:

- **One Resolver per daemon** (`internal/daemon/daemon.go:256`), so `learned` is fleet-wide across every session that daemon runs.
- **`LimitLearned` is rung 2, above `LimitFromManifest`.** In `Resolve`, the learned branch returns before the manifest branch is reached, so a learned window overrules an explicit `runtime.context_window`.
- **It is silent where its neighbours are not.** Stream-vs-manifest and feed-vs-manifest both call `warnOnce`. The learned branch logs nothing.

`Learn` is reached today only by claude. On a daemon running claude across two backends, the first session to finish teaches a window that then outranks the operator's own override for every later session naming that model id, with no line in the log.

That is strictly worse than the table defect that prompted this: rung 2 rather than rung 5, populated at runtime rather than shipped and reviewable, and it overrules the one rung an operator controls. Not established that anyone has run a mixed-backend fleet on one daemon; this is a mechanism, not an incident.

## The design insight

Widening the key to (model, provider, entitlement) does not work, on this study's own conclusion: marvel cannot know which provider served a request, and a key naming a value marvel cannot supply never matches.

The answerable question is narrower. **Not "which provider is this?" but "is this session on the vendor default, or has something redirected it?"** Redirection is enumerated in `finding-016` axis 4, and **marvel's Go tree contains none of those strings**, so the discriminator does not exist yet and is the deliverable of the KNOW step this study has recommended since its first pass. The table's shipped values *are* the vendor's direct-API windows, so the guard only has to detect departure from default, and may treat "cannot tell" as departure.

## Four options, costed

| | cost | verdict |
|---|---|---|
| **A** provenance grade beside `LimitSource` | small | necessary, prevents nothing alone; ships as the vocabulary |
| **B** wider key with provider in it | high, **blocked** | do not build now; degrades into C with more machinery |
| **C** refuse on a known-ambiguous key | moderate, needs the discriminator | the recommended core |
| **D** fix the learned key, warn on manifest override | small, independent | **ship first** |

C's regression is smaller than it looks: no change for default-path sessions, and for redirected sessions cold-start CTX% renders `?` until the harness teaches a window, which for claude is one session because `Learn` fills the learned rung from the terminal line. It buys the loud-absent miss that `aae-orc-rm6o` already gets for free.

**Recommended sequence:** D, A, the discriminator, then C, with B deferred behind the standing trigger. `aae-orc-wyza` and `aae-orc-rm6o` sequence *inside* this rather than beside it: `rm6o` is a one-line data question A and C do not touch, and `wyza`'s empirical question is exactly the fixture the discriminator work produces anyway.

## What it does not fix

A `.crushrc`, a project-scope setting, or any config file that redirects the backend without touching the environment marvel constructed leaves marvel believing the session is on the default. The guard is sound for environment-mediated redirection only. It makes the common case correct and the env-redirected case loud-absent, and leaves config-file redirection silent-wrong. Smaller residue than today's, and not zero.

## Scope and cost

Documentation only, one commit, no code and no behavior change. `kos validate` passes (35 nodes, 0 failed). The implementation is a separate ticket this section specifies; I have not filed it, to avoid a repeat of the filing gap closed earlier tonight.

Refs: aae-orc-eooi, aae-orc-l8v1