### PR TITLE
harvest: findings 019 and 022 had no node back-reference

### DIFF
--- a/_kos/nodes/bedrock/question-healthchecks.yaml
+++ b/_kos/nodes/bedrock/question-healthchecks.yaml
@@ -11,6 +11,31 @@ content: |
 
   Prompt-response and richer agent signals are future work.
   See finding-003-healthchecks and _kos/ideas/health-signal-taxonomy.md.
+
+  HARVEST 2026-08-09 (finding-019). Two corrections to the restart
+  accounting, both measured on a three-replica role whose tmux session
+  died out of band.
+
+  The charge is ONE CRASH PER ROLE PER RECONCILE TICK, not one per lost
+  replica. RoleHealth is per-role state, so the old charge scaled a
+  single event by replica count in both the backoff exponent and the
+  MaxRestarts budget: restart count went 0 to 3 and backoff 30s to 4m on
+  one event, and with max_restarts=3 the whole budget was spent, freezing
+  the role at the year-9999 sentinel on the next loss. Flapping still
+  escalates, because flapping repeats across ticks.
+
+  ReapDead now sets health=unhealthy alongside state=crashed. The pane's
+  absence IS the process-alive verdict, so the stale healthy reading was
+  the bug. It was reachable by any reap rather than only by external
+  kills, and invisible because a normal crash is followed by a respawn
+  that clears the marker.
+
+  STILL OPEN, and both are pre-existing MaxRestarts properties rather
+  than anything the external kill introduced: RestartCount never decays
+  (no success-based reset, so a role losing a pane once a month walks to
+  saturation), and the only path to clear it is `marvel delete team`,
+  which destroys sessions to reset a counter. Operator ruling wanted
+  before either is built.
 edges:
   - target: aae-orc::question-marvel-beyond-mvp
     type: derives

--- a/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
+++ b/_kos/nodes/frontier/question-daemon-isolation-boundary.yaml
@@ -152,6 +152,30 @@ content: |
   `aae-orc-kvcs` (tmux namespace and the unlogged kill),
   `aae-orc-by6j` (the layout-derived tmux server name),
   `aae-orc-sqh0` (the same uid question this does not answer).
+
+  HARVEST 2026-08-09 (finding-019), and it answers one thing this
+  question was circling.
+
+  Marvel CANNOT distinguish an external kill from an application exit at
+  the point ReapDead runs, and should not try. Both present as a pane id
+  tmux no longer lists. The tempting discriminator (whole tmux session
+  gone means external) fails a direct check: a single-pane session
+  collapses the server when its own process exits, so a harness finishing
+  its work leaves exactly the evidence a reclaim leaves. A classifier on
+  that signal must choose which way to be wrong, and wrong-toward-external
+  reopens marvel#11.
+
+  The repair is therefore cause-agnostic: bound the blast radius rather
+  than classify the cause. That is a general shape for this question, not
+  only for the crash-charging instance.
+
+  ALSO VERIFIED STILL LIVE, and not fixed: a store opened against a bolt
+  file holding only a team record spawns processes on the first tick.
+  With a claude or codex runtime that is live model spend against
+  whatever workspace the stale record names, and `marvel daemon` is the
+  entire trigger. The 2026-08-07 accumulation posture governs panes
+  marvel FINDS; it says nothing about desired state marvel REHYDRATES.
+  That gap is this question's, not the crash-charging ticket's.
 edges:
   - target: elem-data-directory-permissions
     type: derives

--- a/_kos/nodes/frontier/question-permission-model.yaml
+++ b/_kos/nodes/frontier/question-permission-model.yaml
@@ -49,6 +49,46 @@ content: |
   - How does the layer-1 enforcement compose with curtain's
     sandbox profiles when both are present?
   - What's the audit-trail signal for capability denials?
+
+  HARVEST 2026-08-09 (finding-022). The heartbeat RPC is now bound to the
+  session it claims, and the way it was done is the answer to the third
+  sub-question above for at least this one capability.
+
+  session.Manager.Create mints a 256-bit token before the record exists;
+  the digest rides the record (persisted, so adopted sessions survive a
+  daemon restart) and the plaintext goes only into the pane environment.
+  The check moved INTO Store.UpdateSessionHeartbeat's signature under the
+  same lock as the write, so it is not caller discipline. Refusals emit
+  heartbeat.refused on the ring. Senders read the env var rather than a
+  flag, because argv is world-readable from the process table. One
+  deliberate fail-open: a record with no token hash is admitted and emits
+  heartbeat.unbound, because refusing would make adopt-on-restart
+  destructive on upgrade; it drains as those sessions end.
+
+  This is enforcement locus 1 doing work, and it stayed inside the M1
+  boundary: no principal model, no token service, no policy language.
+
+  THE DURABLE POINT IS BROADER THAN THE FIX. api.Session reaches bbolt
+  and every mrvl:// client through the same encoder, so ANY CREDENTIAL
+  ADDED TO A STORE RESOURCE IS PUBLISHED BY DEFAULT. Bears on
+  aae-orc-wbqi (projected policy tamper-proofing).
+
+  A SECOND INSTANCE OF THE SAME SHAPE landed the same day from an
+  unrelated arm: Crush's GET /v1/workspaces serves the registering
+  client's full process environment, so enabling that channel would
+  publish the environment marvel constructed at spawn to every client of
+  a host-shared socket (finding-020 section 6). One path is ours and one
+  is a vendor's, and both say the same thing: a credential adjacent to a
+  value that gets serialized is a credential that gets served, and the
+  axis that predicts it is where the bytes go rather than who was asked.
+  Since environment construction at spawn is marvel's ONE built
+  enforcement locus, that is an inversion of this question's premise
+  rather than a cost to price against it.
+
+  TWO LIMITS NOT ADDRESSED by the heartbeat fix, both named in
+  finding-022: same-uid environment reads (an agent that hunts can take a
+  sibling's token, which is enforcement locus 3 plus curtain), and
+  event-ring pressure from spammed refusals.
 edges:
   - target: elem-runtime-adapter-framework
     type: derives


### PR DESCRIPTION
Sixteen pull requests merged last night and six findings landed, but two of them never reached the graph, so the knowledge is in `_kos/findings/` where nobody traverses to it. This closes the harvest debt for both and carries their still-open questions with them, which is the part that would otherwise be re-derived.

Per `charter-light-touch.md` the harvest target is nodes, never charter prose, and the completeness check is node coverage of findings rather than charter recency. All six of last night's findings now have a back-reference.

**`question-healthchecks` gains finding-019's restart accounting.** The charge is one crash per role per reconcile tick, not one per lost replica: `RoleHealth` is per-role state, so the old charge scaled a single event by replica count in both the backoff exponent and the `MaxRestarts` budget. `ReapDead` now sets `health=unhealthy` alongside `state=crashed`, because the pane's absence is the process-alive verdict. Two pre-existing `MaxRestarts` properties are carried as open: `RestartCount` never decays, and the only path to clear it is `marvel delete team`, which destroys sessions to reset a counter.

**`question-daemon-isolation-boundary` gains the part that answers it.** Marvel cannot distinguish an external kill from an application exit at `ReapDead` and should not try: a single-pane session collapses its server when its own process exits, so a harness finishing work leaves exactly the evidence a reclaim leaves. The repair is cause-agnostic, which is a general shape for this question rather than a detail of one ticket. It also carries the verified-live gap that the accumulation posture governs panes marvel finds and says nothing about desired state marvel rehydrates.

**`question-permission-model` gains finding-022 and, more usefully, a second instance of its shape.** The heartbeat binding is enforcement locus 1 doing work inside the M1 boundary. The durable point is broader: `api.Session` reaches bbolt and every `mrvl://` client through one encoder, so any credential added to a store resource is published by default. An unrelated arm measured the same shape in a vendor's path the same day (finding-020 section 6), which makes it a class rather than a defect.

Cost of merge: three node files, additive only. `kos validate` passes, 0 failed, 0 parse errors. No code, no tests, no behaviour.

Refs: aae-orc-4bz2, aae-orc-mr5c