### PR TITLE
docs: the sessions table, the claude context feed, and an event catalog

### DIFF
--- a/cmd/marvel/kindcatalog_test.go
+++ b/cmd/marvel/kindcatalog_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/events"
+)
+
+// TestKindCatalogPrintsEveryKind is the reason --list-kinds exists: the
+// operator has to be able to trust that what it prints is the whole set.
+// A catalog missing one name sends the reader back to the source, which
+// is the state this command replaces.
+func TestKindCatalogPrintsEveryKind(t *testing.T) {
+	var buf bytes.Buffer
+	printKindCatalog(&buf)
+	out := buf.String()
+	for _, k := range events.AllKinds() {
+		if !strings.Contains(out, "  "+string(k)+"\n") {
+			t.Errorf("catalog omits kind %q", k)
+		}
+	}
+}
+
+// TestKindCatalogSplitsTheTwoFamilies holds the grouping, which is the
+// only structure in the output. Agent kinds depend on a runtime marvel
+// can observe and control-plane kinds do not, so a reader who cannot tell
+// them apart cannot tell a missing event from an unobservable one.
+func TestKindCatalogSplitsTheTwoFamilies(t *testing.T) {
+	var buf bytes.Buffer
+	printKindCatalog(&buf)
+	out := buf.String()
+
+	controlHeader := strings.Index(out, "Control plane (")
+	agentHeader := strings.Index(out, "Agent stream (")
+	if controlHeader < 0 || agentHeader < 0 {
+		t.Fatalf("catalog missing a group header:\n%s", out)
+	}
+	if controlHeader > agentHeader {
+		t.Error("agent group printed before the control-plane group")
+	}
+
+	for _, k := range events.AllKinds() {
+		at := strings.Index(out, "  "+string(k)+"\n")
+		if at < 0 {
+			continue // covered by TestKindCatalogPrintsEveryKind
+		}
+		isAgent := strings.HasPrefix(string(k), "agent.")
+		if isAgent && at < agentHeader {
+			t.Errorf("agent kind %q listed under the control-plane group", k)
+		}
+		if !isAgent && at > agentHeader {
+			t.Errorf("control-plane kind %q listed under the agent group", k)
+		}
+	}
+}
+
+// TestKindCatalogCountsMatchTheGroups guards the two numbers in the
+// headers. They are the only claim in the output a reader cannot check by
+// counting the lines themselves without effort.
+func TestKindCatalogCountsMatchTheGroups(t *testing.T) {
+	var control, agent int
+	for _, k := range events.AllKinds() {
+		if strings.HasPrefix(string(k), "agent.") {
+			agent++
+		} else {
+			control++
+		}
+	}
+	var buf bytes.Buffer
+	printKindCatalog(&buf)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Control plane (" + strconv.Itoa(control) + ")",
+		"Agent stream (" + strconv.Itoa(agent) + ")",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("catalog header missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -438,6 +438,7 @@ func eventsCmd() *cobra.Command {
 	var workspace, team, role, session, kind string
 	var warningsOnly bool
 	var follow bool
+	var listKinds bool
 	cmd := &cobra.Command{
 		Use:   "events",
 		Short: "List recent session/team state-transition events",
@@ -467,8 +468,17 @@ Examples:
   marvel events --kind admission.refused     # spawns a team budget refused
   marvel events --warnings                   # only warning-severity events
   marvel events --follow                     # live tail; poll the ring every second
-  marvel --cluster desk events               # remote daemon via mrvl://`,
+  marvel events --list-kinds                 # every kind --kind accepts
+  marvel --cluster desk events               # remote daemon via mrvl://
+
+A --kind that matches nothing prints no events rather than an error, so a
+misspelled kind and a kind that never fired look the same. --list-kinds
+prints the catalog, and needs no daemon.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if listKinds {
+				printKindCatalog(os.Stdout)
+				return nil
+			}
 			buildParams := func(sinceSeq uint64) json.RawMessage {
 				params := map[string]any{"n": n}
 				if sinceSeq > 0 {
@@ -557,6 +567,13 @@ Examples:
 			if err != nil {
 				return err
 			}
+			// An empty result under a --kind nobody declares is the
+			// silent-success shape: it reads as "this never happened".
+			// Say which of the two it is, on stderr so a script's
+			// stdout and exit code are unchanged.
+			if len(evs) == 0 && kind != "" && !events.IsKnownKind(kind) {
+				_, _ = fmt.Fprintf(os.Stderr, "note: no event kind named %q; run 'marvel events --list-kinds' for the catalog\n", kind)
+			}
 			if len(evs) == 0 && !follow {
 				fmt.Println("no events")
 				return nil
@@ -592,7 +609,33 @@ Examples:
 	cmd.Flags().StringVar(&kind, "kind", "", "filter by event kind (e.g. session.crashed, health.failed, agent.tool.call)")
 	cmd.Flags().BoolVar(&warningsOnly, "warnings", false, "show only warning-severity events")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "poll for new events every second until interrupted")
+	cmd.Flags().BoolVar(&listKinds, "list-kinds", false, "print every event kind --kind accepts, then exit")
 	return cmd
+}
+
+// printKindCatalog renders the event-kind catalog in two groups, because
+// the split is the one thing an operator scanning the list needs: the
+// control-plane kinds report what marvel did to a session, the agent
+// kinds report what the agent inside it did, and only the second family
+// depends on a runtime marvel can observe.
+func printKindCatalog(w io.Writer) {
+	var control, agent []events.Kind
+	for _, k := range events.AllKinds() {
+		if strings.HasPrefix(string(k), "agent.") {
+			agent = append(agent, k)
+		} else {
+			control = append(control, k)
+		}
+	}
+	_, _ = fmt.Fprintf(w, "Control plane (%d): what marvel did to a session\n", len(control))
+	for _, k := range control {
+		_, _ = fmt.Fprintf(w, "  %s\n", k)
+	}
+	_, _ = fmt.Fprintf(w, "\nAgent stream (%d): what the agent inside a session did\n", len(agent))
+	for _, k := range agent {
+		_, _ = fmt.Fprintf(w, "  %s\n", k)
+	}
+	_, _ = fmt.Fprintf(w, "\nAgent kinds appear only for sessions whose runtime marvel can\nobserve; an interactive pane publishes no stream to parse.\n")
 }
 
 // openRotatingLog opens the daemon's on-disk log file with the rlog

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -124,15 +124,26 @@ crashed, and (after a crash-loop backoff) spawns a replacement:
 
 ```sh
 ./bin/marvel events --kind session.crashed     # "pane %1 gone"  (immediate)
-sleep 35
+./bin/marvel get sessions                       # crashed row, DESK blank, RSS 0B
+sleep 75
 ./bin/marvel events --kind session.created     # replacement line-worker-g1-2
 ./bin/marvel get sessions                       # back to two healthy workers
 ```
 
-Timing note: marvel treats a vanished pane as a crash and applies a 30-second
-crash-loop backoff before respawning, so the replacement appears roughly 30 to
-60 seconds after the kill, not instantly. That backoff is deliberate: it is
-what stops a process that exits on startup from respawning in a tight loop.
+Timing note, measured 2026-08-09: the crash lands within about 2 seconds and
+the replacement about 62 seconds after the kill. Marvel treats a vanished pane
+as a crash and charges the role a restart, and the first charge sets a
+60-second window; the second is 2 minutes, the third 4, doubling to a 5-minute
+ceiling. So kill the same role twice in a session and the second wait is twice
+as long. That backoff is deliberate: it is what stops a process that exits on
+startup from respawning in a tight loop.
+
+Nothing announces the wait. `health.crashloop-backoff` fires only when a live
+session is re-evaluated inside its window, and on this path the session is a
+crashed marker rather than a live one, so the ring stays quiet between the two
+events above. The crashed row in `get sessions` is the whole signal: it holds
+its place with `DESK` blank and `RSS` at `0B` until the replacement spawns. If
+you sample too early, read the row, not the empty event filter.
 
 TODO(finding): the task brief described this beat as `session.crashed` then
 `session.restarted`. That is not what the pane-loss path emits. The recovery
@@ -189,14 +200,38 @@ sleep 12
 ./bin/marvel events --kind session.restarted     # restarter + capped, restart #1
 ./bin/marvel events --kind session.failed         # failstop, restart_policy=never
 
-sleep 60
+sleep 90
 ./bin/marvel events --kind role.saturated          # capped hit max_restarts=1
 ./bin/marvel events --kind session.restarted        # restarter now on restart #2
 ```
 
 The healthcheck uses a 6-second timeout and a threshold of 1, so the first
-action lands about 8 to 10 seconds after spawn; `capped` saturates about a
-minute later, after one backoff window.
+action lands about 7 seconds after spawn; `capped` saturates about 70 seconds
+after that, once its one backoff window has elapsed and the replacement has
+gone stale in turn.
+
+Then check the table, because the three policies leave three different rows
+behind and only one of them is the row a reader expects. Measured 2026-08-09,
+about two minutes in:
+
+```sh
+./bin/marvel get sessions   # capped + failstop, both failed; restarter absent
+```
+
+- `failstop` holds its row from the first failure onward: `failed`,
+  `unhealthy`, pane alive. It never leaves the table.
+- `capped` leaves the table for about 60 seconds after its one restart, comes
+  back, saturates, and then holds its row permanently as `failed` /
+  `unhealthy`. Saturation is what makes the row stay, not what removes it.
+- `restarter` is the one that goes missing. Every restart deletes the session
+  and the replacement waits out the backoff, so the row is absent for 60
+  seconds, then 2 minutes, then 4. Look at an arbitrary moment a few minutes
+  in and a healthy always-restart role is more likely to be missing from the
+  table than present.
+
+A beat that verifies only an event cannot catch a state defect, which is how
+the 1d rollback bug (`aae-orc-d0pt`) survived a verified run. Read the table
+after the events, every time.
 
 TODO(finding): two events in the health vocabulary are not observable through
 this beat.
@@ -303,8 +338,9 @@ drive it by hand.
 A verified run produced, across the three harnesses uniformly:
 `agent.session.started`, `agent.turn.started`, `agent.turn.completed` (with
 token counts), `agent.message.completed`, and `agent.session.ended` (with cost,
-token totals, and duration). That the same five event kinds describe three
-unrelated harnesses is the point of the act.
+token totals, and duration). That those same five kinds describe three
+unrelated harnesses is the point of the act. They are five of the thirty-five
+the ring carries; `marvel events --list-kinds` prints the rest.
 
 Deterministic vs auth-dependent:
 
@@ -318,9 +354,14 @@ CTX% producers, current state (supersedes an earlier TODO here that said
 the heartbeat RPC was the only producer): there are three. The stream-fed
 usage accountant meters headless sessions; the statusline feed
 (`context_feed`, finding-011) meters interactive claude via the heartbeat
-RPC; and the heartbeat RPC accepts any cooperative reporter (the
-simulator). Interactive codex/opencode remain unmetered — no statusline
-equivalent has been probed for them yet (aae-orc-7hzb).
+RPC; and the heartbeat RPC accepts any cooperative reporter, which now
+covers codex as well as the simulator. Codex reports through a hook on
+its rollout file rather than a statusline, because its `exec --json`
+stream carries a running total instead of a level; the operator installs
+that stanza in `~/.codex/config.toml` by hand, since marvel does not
+write to `CODEX_HOME`. Setup for both feeds is in the user guide under
+"Interactive claude context pressure" and "Codex context pressure".
+Interactive opencode remains unmetered (aae-orc-7hzb).
 
 Because each `-p` role is headless with a one-shot prompt, the harness exits
 when its turn completes, and marvel reaps the vacated pane with

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -264,10 +264,26 @@ marvel get sessions
 
 Output:
 ```
-WORKSPACE  TEAM       ROLE    GEN  NAME                   STATE    HEALTH   CTX%  CPU%   RSS   DESK  AGENT
-dev        squad      worker  1    squad-worker-g1-0      running  unknown  3%    99.9   412M  1     claude
-dev        squad      worker  1    squad-worker-g1-1      running  unknown  ?     0.4    380M  2     codex
+WORKSPACE  TEAM   ROLE    GEN  AGENT NAME         STATE    HEALTH   CTX%  CPU%  RSS   DESK  RUNTIME  LLM
+dev        squad  worker  1    squad-worker-g1-0  running  unknown  3%    99.9  412M  1     claude   claude-opus-5
+dev        squad  worker  1    squad-worker-g1-1  running  unknown  -     0.4   380M  2     codex    gpt-5.6-sol
 ```
+
+Two of those columns are easy to read as one thing, and they are not:
+
+- `RUNTIME` is the **harness** the session runs: `claude`, `codex`,
+  `opencode`, `generic`. It is the manifest's `runtime` block, and it
+  names a program.
+- `LLM` is the **model** that harness is talking to, as the metering
+  producer named it. A `-` means marvel has no model name for the
+  session, which is the normal reading before the first turn.
+
+The agent is neither column. An agent is its persona, identity, role,
+model and tools together; `AGENT NAME` is the session key marvel gave
+that composition. Two roles can run the same runtime against different
+models, and one runtime can be pointed at a different model per role, so
+reading `RUNTIME` as "which agent is this" gives the wrong answer as soon
+as a team is heterogeneous.
 
 `CPU%` and `RSS` come from a sampler that runs every 5 seconds and rolls
 up each agent's whole process subtree, not just the process tmux started
@@ -282,10 +298,11 @@ zero:
   of a headless `claude` or `opencode` stream, and the cooperative
   `heartbeat` RPC that the bundled simulator, the claude statusline feed
   and the codex hook feed all call. An interactive pane publishes
-  neither on its own. After a daemon restart, a stream-derived reading
-  goes back to `-`, because nothing can refresh one for a stream marvel
-  is no longer reading; a heartbeat reading survives the restart and is
-  refreshed by the next heartbeat.
+  neither on its own until you turn a feed on: see "Interactive claude
+  context pressure" and "Codex context pressure" below. After a daemon
+  restart, a stream-derived reading goes back to `-`, because nothing
+  can refresh one for a stream marvel is no longer reading; a heartbeat
+  reading survives the restart and is refreshed by the next heartbeat.
 - Codex is not on the stream list, and no runtime setting puts it there.
   Its `exec --json` usage object is a running total rather than a level,
   so there is no occupancy in it to read at any window. See "Codex
@@ -316,6 +333,74 @@ this session compacts".
 
 Per-process IO counters are read on Linux only; `marvel describe session`
 reports `IOAvailable: false` elsewhere.
+
+### Interactive claude context pressure
+
+An interactive claude session emits no stream to parse, so the usage
+accountant cannot meter it and `CTX%` stays `-`. One manifest line turns
+on a cooperative feed instead:
+
+```toml
+[team.role.runtime]
+image = "claude"
+command = "claude"
+context_feed = "statusline"
+```
+
+`"statusline"` is the only value. Anything else fails manifest
+validation rather than being ignored.
+
+That is the whole setup. You add nothing to your own Claude Code
+settings, and marvel writes nothing under `~/.claude`. At spawn, marvel
+projects a per-session settings file (the same file a `policy` is written
+into) carrying `statusLine` and `subagentStatusLine` hooks that invoke
+`marvel ctx-forward`, and passes that file to the harness with
+`--settings`. Claude Code calls the hook with its own status JSON;
+`ctx-forward` reads the context figure out of the payload, forwards it to
+the daemon's heartbeat RPC, and prints the status line the human in the
+pane sees. Both feeds are wired: the main session's and its subagents'.
+
+This is the opposite arrangement from codex below, and the difference is
+whose file it is. Claude Code takes a settings path on the command line,
+so marvel can hand it one it owns. Codex reads hooks only from
+`$CODEX_HOME/config.toml`, next to your credentials, which marvel does
+not write. So claude is one manifest line and codex is a stanza you
+install by hand.
+
+What to know before relying on it:
+
+- **The main hook carries `refreshInterval = 15`.** Statusline updates
+  are event-driven and go quiet between prompts, so without the interval
+  an idle session would stop beating and starve a heartbeat healthcheck
+  watching it. The subagent hook has no interval; a subagent turn is
+  bounded.
+- **A policy wins.** If the role's `policy` defines `statusLine` or
+  `subagentStatusLine` itself, marvel leaves it alone and adds nothing.
+  Marvel only fills keys the settings document does not already carry.
+- **The feed is fixed at spawn.** Adding `context_feed` to a manifest and
+  re-applying does not retrofit the feed onto sessions that are already
+  running: re-projection reads the flag from the session's spawn-time
+  runtime copy. New sessions get it, so `marvel shift` the team (or
+  scale, or let a restart happen) to migrate a running one.
+
+Verify it end to end with `examples/context-feed.toml`, which is this
+manifest with nothing else in it:
+
+```bash
+marvel work examples/context-feed.toml
+# CTX% is "-" until the session takes a turn, so give it one
+marvel inject feed/watch-watcher-g1-0 "say only the word ready" -e
+marvel get sessions                            # CTX% populates
+marvel describe session feed/watch-watcher-g1-0
+```
+
+The pane's own bottom line shows the human-facing half of the same feed
+(`Haiku 4.5 · CTX 13% · $0.04`). Marvel's `CTX%` reads lower, for the
+raw-occupancy reason above.
+
+Roles whose harness has no settings surface log the feed as advisory and
+get nothing projected; the daemon log says so rather than failing
+quietly.
 
 ### Codex context pressure
 
@@ -429,6 +514,33 @@ marvel inject dev/squad-worker-g1-0 "C-c" --literal=false
 **When to use:** Giving an agent a task, interrupting a stuck agent,
 sending Ctrl-C to stop a runaway process. This is the "executive
 privilege" operation — you're typing into another agent's terminal.
+
+## Events
+
+```bash
+marvel events                             # the last 100
+marvel events --follow                    # live tail
+marvel events --warnings                  # warning severity only
+marvel events --workspace dev             # scope to a workspace
+marvel events --kind session.crashed      # one kind
+```
+
+Two families share the ring. Control-plane kinds report what marvel did
+to a session; `agent.*` kinds report what the agent inside it did, and
+appear only for sessions whose runtime marvel can observe.
+
+`--kind` on a name that does not exist prints no events rather than an
+error, so a typo and "this never happened" produce the same table. Ask
+for the catalog rather than guessing:
+
+```bash
+marvel events --list-kinds
+```
+
+It needs no daemon, and it is generated from the same constants the ring
+emits, so it cannot describe kinds this binary does not have. When a
+`--kind` filter matches nothing and the name is not one marvel declares,
+the command says so on stderr.
 
 ## Scaling
 

--- a/internal/events/catalog_test.go
+++ b/internal/events/catalog_test.go
@@ -1,0 +1,118 @@
+package events
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+// declaredKinds parses events.go and returns every string literal assigned
+// to a constant of type Kind, keyed by the constant's name.
+//
+// Parsing the source is the point. A test that enumerated the constants by
+// hand would need the same edit a new kind already needs, which is the
+// drift it is supposed to catch.
+func declaredKinds(t *testing.T) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "events.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse events.go: %v", err)
+	}
+	out := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			ident, ok := vs.Type.(*ast.Ident)
+			if !ok || ident.Name != "Kind" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote %s = %s: %v", name.Name, lit.Value, err)
+				}
+				out[name.Name] = value
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("parsed no Kind constants from events.go; the parser, not the catalog, is wrong")
+	}
+	return out
+}
+
+// TestAllKindsCoversEveryDeclaredConstant is the drift guard on the
+// catalog. Adding a Kind constant without adding it to allKinds fails
+// here, at the commit that introduces the gap, rather than in an
+// operator's `--list-kinds` output some months later.
+func TestAllKindsCoversEveryDeclaredConstant(t *testing.T) {
+	declared := declaredKinds(t)
+	listed := map[string]bool{}
+	for _, k := range AllKinds() {
+		if listed[string(k)] {
+			t.Errorf("AllKinds lists %q twice", k)
+		}
+		listed[string(k)] = true
+	}
+	for name, value := range declared {
+		if !listed[value] {
+			t.Errorf("Kind constant %s (%q) is declared but missing from allKinds", name, value)
+		}
+	}
+	if len(listed) != len(declared) {
+		t.Errorf("AllKinds has %d entries, events.go declares %d Kind constants", len(listed), len(declared))
+	}
+}
+
+// TestAllKindsIsACopy holds the accessor to returning a copy. The catalog
+// is package-level state and the CLI renders it; a caller that sorted the
+// returned slice in place would reorder it for every later caller.
+func TestAllKindsIsACopy(t *testing.T) {
+	first := AllKinds()
+	if len(first) == 0 {
+		t.Fatal("AllKinds returned nothing")
+	}
+	original := first[0]
+	first[0] = Kind("mutated")
+	if second := AllKinds(); second[0] != original {
+		t.Errorf("AllKinds()[0] = %q after a caller mutated an earlier result, want %q", second[0], original)
+	}
+}
+
+func TestIsKnownKind(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"control-plane kind", string(KindSessionCrashed), true},
+		{"agent kind", string(KindAgentToolCall), true},
+		{"plausible typo", "session.crash", false},
+		{"adapter vocabulary without the agent prefix", "tool.call", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsKnownKind(tt.in); got != tt.want {
+				t.Errorf("IsKnownKind(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -142,6 +142,77 @@ const (
 	KindAgentError               Kind = "agent.error"
 )
 
+// allKinds is every kind the ring can carry, in declaration order:
+// control-plane first, agent stream second. It backs `marvel events
+// --list-kinds`, which exists because `--kind` on a name that does not
+// exist returns an empty result rather than an error, so a typo and "this
+// never happened" are the same output.
+//
+// A hand-maintained list drifts. TestAllKindsCoversEveryDeclaredConstant
+// parses this file and fails when a declared Kind constant is missing
+// here, so the catalog cannot fall behind the constants it describes.
+var allKinds = []Kind{
+	KindSessionCreated,
+	KindSessionDeleted,
+	KindSessionCrashed,
+	KindSessionRestarted,
+	KindSessionFailed,
+	KindHealthCheckFailed,
+	KindCrashLoopBackoff,
+	KindShiftStarted,
+	KindShiftCompleted,
+	KindShiftTimedOut,
+	KindShiftRoleReady,
+	KindRoleSaturated,
+	KindRoleRemoved,
+	KindPolicyProjected,
+	KindContextLimitUnresolved,
+	KindAdmissionRefused,
+	KindAdmissionCleared,
+	KindAdmissionUnmeasured,
+	KindReconcileAdopted,
+	KindReconcileKilled,
+	KindHeartbeatRefused,
+	KindHeartbeatUnbound,
+	KindReconcileLeft,
+	KindAgentSessionStarted,
+	KindAgentSessionEnded,
+	KindAgentTurnStarted,
+	KindAgentTurnCompleted,
+	KindAgentMessageDelta,
+	KindAgentMessageCompleted,
+	KindAgentToolCall,
+	KindAgentToolResult,
+	KindAgentPermissionRequested,
+	KindAgentAuthRequired,
+	KindAgentHealthHeartbeat,
+	KindAgentError,
+}
+
+// AllKinds returns every kind the ring can carry, in declaration order.
+// The returned slice is a copy: the catalog is read by a CLI command, and
+// a caller sorting it in place would reorder it for everyone.
+func AllKinds() []Kind {
+	out := make([]Kind, len(allKinds))
+	copy(out, allKinds)
+	return out
+}
+
+// IsKnownKind reports whether name is a kind this build declares.
+//
+// Callers use it to tell an empty filter result apart from a misspelled
+// filter. It is deliberately not wired into `--kind` as a hard rejection:
+// a client can be older than the daemon it talks to, and refusing a kind
+// the daemon knows about would turn version skew into a broken command.
+func IsKnownKind(name string) bool {
+	for _, k := range allKinds {
+		if string(k) == name {
+			return true
+		}
+	}
+	return false
+}
+
 // Severity mirrors the kubernetes Warning/Normal distinction. Lets
 // operators filter `marvel events --severity warning` for the things
 // that need attention.


### PR DESCRIPTION
An operator reading marvel's docs today cannot turn on CTX% for interactive claude, learns a column name the code stopped printing, is told to wait 35 seconds for something that takes 62, and has no way to find out what `--kind` accepts. Four gaps, one PR, plus the one small code change that keeps the largest of them from reopening.

## The sessions table (aae-orc-nrrv)

`docs/user-guide.md` printed `... DESK AGENT`. The code prints `... DESK RUNTIME LLM`, and the rename from AGENT to RUNTIME was the 2026-08-01 ruling that `runtime` names the harness and never the agent. The guide was still teaching the conflation the ruling rejects, so this is not a cosmetic header fix. The header now matches `renderSessionTable`, and new prose says what RUNTIME, LLM and AGENT NAME each are, and why the agent is none of them.

The example's codex row also showed `?` for CTX%, which that harness cannot produce without the hook. It now reads `-`.

## The claude context feed (aae-orc-qaq5)

PR #110 shipped the statusline feed and touched no file under `docs/`. Its sibling codex channel has a full setup section; this one had a passing mention inside a demo act. New section, beside the codex one, covering the single manifest line, what marvel projects, the policy-wins merge rule, `refreshInterval = 15`, and the spawn-frozen caveat with shift as the migration path.

The section also states the asymmetry, because it is the thing an operator will otherwise read as inconsistency: claude is one manifest line because Claude Code takes a settings path marvel can own; codex is a hand-installed stanza because marvel does not write to `CODEX_HOME`.

## Two demo beats, measured (aae-orc-q0q7)

Both run against a live daemon in an isolated HOME on 2026-08-09.

Beat 1a said marvel applies a 30-second backoff and told the reader to `sleep 35`. The first crash charge computes `computeBackoff(2)`, which is 60 seconds; measured, the replacement arrived 62 seconds after the kill. Following the runbook literally showed an empty filter and looked like recovery had failed. The wait is now 75 seconds, the doubling is stated, and the beat says the crashed row is the only signal during it, since `health.crashloop-backoff` cannot fire on this path.

Beat 1c verified events and never looked at the table, so it never said what the three restart policies leave behind. Measured: `failstop` holds its row from the first failure; `capped` vanishes for about 60 seconds, returns, saturates, and then holds its row permanently as failed; `restarter` is absent for 60s, then 2m, then 4m, so at an arbitrary moment a healthy always-restart role is more likely missing than present. That is the post-state check `aae-orc-d0pt` asked for.

Act 2 also still said interactive codex was unmetered. PR #170 changed that.

## The event catalog (aae-orc-yi02)

`marvel events --kind` on a name that does not exist prints an empty table rather than an error, so a typo and "this never happened" are the same output. `marvel events --list-kinds` prints the 35 kinds the ring carries, grouped control-plane and agent, and needs no daemon. A `--kind` that matches nothing and is not a declared name now prints a note on stderr; stdout and the exit code are untouched, so a script sees no change.

I chose the runtime command over a hand-maintained doc list, per the ticket's own reasoning, but the ticket's premise that `internal/events/events.go` declares 47 kinds is wrong: it declares 35. The other 12 are `internal/runtime/events`, the adapter vocabulary that `bridge.go` lifts into the 12 `agent.*` ring kinds already counted. A catalog of 47 would have listed 12 names `--kind` can never match.

`allKinds` would drift like any hand-written list, so `TestAllKindsCoversEveryDeclaredConstant` parses `events.go` and fails when a declared constant is missing from it. Falsified: removing one entry fails the test naming the constant.

## Cost of merge

Docs, one additive flag, one stderr note on an already-empty result. No existing event, filter, or exit code changes. `--kind` deliberately does not hard-reject unknown names, because a client can be older than the daemon it talks to and refusing a kind the daemon knows would turn version skew into a broken command.

## Tests

`go test ./...` passes, 24 packages, exit 0. `just lint` reports 0 issues at CI's pinned version. Six tests added: three on the catalog's coverage, copy semantics and `IsKnownKind`, three on the rendered output's completeness, grouping and counts.

Refs: aae-orc-nrrv, aae-orc-qaq5, aae-orc-q0q7, aae-orc-yi02