### PR TITLE
bound repeated heartbeat auth notices and name their cause

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -146,6 +146,16 @@ type Daemon struct {
 	// Always non-nil.
 	events *events.Ring
 
+	// Heartbeat auth notices repeat at the offending process's tick rate
+	// and never stop on their own, because nothing reaps an orphan. One
+	// line per refusal buried a daemon log in a live incident
+	// (aae-orc-k58k: 44 refusals in 90s from two orphans at a 2s tick).
+	// Throttled per (kind, session) so the condition still announces
+	// itself immediately and then stays quiet, reporting how many it
+	// swallowed when it next speaks.
+	hbAuthMu sync.Mutex
+	hbAuth   map[string]*heartbeatAuthNotice
+
 	// Per-session context and token accountant, fed by the adapter
 	// streams through the session manager. Always non-nil.
 	usage *usage.Accountant
@@ -1059,8 +1069,22 @@ func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 	auth, err := d.store.UpdateSessionHeartbeat(p.SessionKey, p.SessionToken, p.ContextPercent, p.Model)
 	if err != nil {
 		if errors.Is(err, api.ErrHeartbeatUnauthorized) {
-			d.emitHeartbeatAuth(events.KindHeartbeatRefused, p.SessionKey,
-				"refused: token does not match the session claimed")
+			// Two different faults reach this branch and they have
+			// opposite remedies, so they get different messages and
+			// throttle independently. Presenting NO token is a producer
+			// that was not updated to send one (the codex reader shipped
+			// exactly that, see #176). Presenting a WRONG token is a live
+			// process holding a credential minted for an earlier
+			// incarnation of this session key: an orphan from a previous
+			// daemon, which nothing reaps (aae-orc-k58k).
+			cause, msg := "no-token", "refused: this heartbeat presented no token while the session "+
+				"carries one, so its producer is not sending MARVEL_HEARTBEAT_TOKEN"
+			if p.SessionToken != "" {
+				cause, msg = "stale-token", "refused: token does not match the session claimed; an "+
+					"orphaned agent from an earlier daemon is still heartbeating for this key. "+
+					"Clear it with 'marvel reap --confirm', or start with 'marvel daemon --reclaim'"
+			}
+			d.emitHeartbeatAuth2(events.KindHeartbeatRefused, cause, p.SessionKey, msg)
 		}
 		return Response{Error: err.Error()}
 	}
@@ -1081,7 +1105,56 @@ func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 // The workspace/team/role coordinates come from the claimed session when
 // it exists, so a refusal can be filtered beside that session's other
 // events rather than only by kind.
+// heartbeatAuthInterval is how long a repeated heartbeat auth notice
+// stays quiet before it speaks again. A minute is long enough to stop a
+// 2s-tick orphan from owning the log and short enough that an operator
+// watching a fleet still sees the condition is ongoing.
+const heartbeatAuthInterval = time.Minute
+
+type heartbeatAuthNotice struct {
+	last       time.Time
+	suppressed int
+}
+
+// emitHeartbeatAuth reports a heartbeat that was refused or admitted
+// unbound. The first occurrence for a (kind, session) is always reported;
+// repeats inside heartbeatAuthInterval are counted and folded into the
+// next one, so a condition that cannot fix itself does not drown out
+// everything else in the log.
 func (d *Daemon) emitHeartbeatAuth(kind events.Kind, sessionKey, message string) {
+	d.emitHeartbeatAuth2(kind, "", sessionKey, message)
+}
+
+// emitHeartbeatAuth2 is emitHeartbeatAuth with a cause discriminator, so
+// two faults that share a kind and a session still each get reported
+// rather than one silencing the other.
+func (d *Daemon) emitHeartbeatAuth2(kind events.Kind, cause, sessionKey, message string) {
+	key := string(kind) + "|" + cause + "|" + sessionKey
+
+	d.hbAuthMu.Lock()
+	if d.hbAuth == nil {
+		d.hbAuth = make(map[string]*heartbeatAuthNotice)
+	}
+	n, seen := d.hbAuth[key]
+	if !seen {
+		n = &heartbeatAuthNotice{}
+		d.hbAuth[key] = n
+	}
+	now := time.Now()
+	if seen && now.Sub(n.last) < heartbeatAuthInterval {
+		n.suppressed++
+		d.hbAuthMu.Unlock()
+		return
+	}
+	swallowed := n.suppressed
+	n.suppressed = 0
+	n.last = now
+	d.hbAuthMu.Unlock()
+
+	if swallowed > 0 {
+		message = fmt.Sprintf("%s (%d more since the last notice)", message, swallowed)
+	}
+
 	ev := events.Event{
 		Kind:     kind,
 		Severity: events.SeverityWarning,

--- a/internal/daemon/heartbeat_throttle_test.go
+++ b/internal/daemon/heartbeat_throttle_test.go
@@ -1,0 +1,98 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+)
+
+// An orphaned agent heartbeats at its own tick rate and nothing stops it,
+// so the refusal repeats forever. The first one must always be reported
+// (the condition is real and an operator needs to see it), and the rest
+// must not own the log. See aae-orc-k58k.
+func TestHeartbeatAuthNoticeIsThrottledPerSession(t *testing.T) {
+	d := &Daemon{store: api.NewStore(), events: events.NewRing(events.DefaultCapacity)}
+
+	for range 20 {
+		d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+	}
+
+	got := d.events.Snapshot(events.Filter{}, 0)
+	if len(got) != 1 {
+		t.Fatalf("20 refusals for one session emitted %d events, want 1", len(got))
+	}
+	if got[0].Session != "ws/team-role-g1-0" {
+		t.Errorf("event session = %q, want ws/team-role-g1-0", got[0].Session)
+	}
+}
+
+// Throttling is per session, not global: a fleet with many orphans has to
+// name each of them, or the operator learns that something is wrong
+// without learning what.
+func TestHeartbeatAuthNoticeThrottlesEachSessionSeparately(t *testing.T) {
+	d := &Daemon{store: api.NewStore(), events: events.NewRing(events.DefaultCapacity)}
+
+	for range 5 {
+		d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+		d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-1", "refused: orphan")
+	}
+
+	got := d.events.Snapshot(events.Filter{}, 0)
+	if len(got) != 2 {
+		t.Fatalf("two orphaned sessions emitted %d events, want 2", len(got))
+	}
+	seen := map[string]bool{}
+	for _, ev := range got {
+		seen[ev.Session] = true
+	}
+	for _, want := range []string{"ws/team-role-g1-0", "ws/team-role-g1-1"} {
+		if !seen[want] {
+			t.Errorf("no event for session %s; got %v", want, seen)
+		}
+	}
+}
+
+// A suppressed run is reported rather than discarded, so the next notice
+// says how bad it has been. Without this the throttle would understate an
+// ongoing condition, which is the failure mode the throttle risks
+// introducing.
+func TestHeartbeatAuthNoticeReportsSuppressedCount(t *testing.T) {
+	d := &Daemon{store: api.NewStore(), events: events.NewRing(events.DefaultCapacity)}
+
+	d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+	for range 9 {
+		d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+	}
+
+	// Move the window into the past instead of sleeping a minute.
+	d.hbAuthMu.Lock()
+	d.hbAuth["heartbeat.refused||ws/team-role-g1-0"].last = time.Now().Add(-2 * heartbeatAuthInterval)
+	d.hbAuthMu.Unlock()
+
+	d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+
+	got := d.events.Snapshot(events.Filter{}, 0)
+	if len(got) != 2 {
+		t.Fatalf("emitted %d events, want 2 (first, then one after the window)", len(got))
+	}
+	if !strings.Contains(got[1].Message, "9 more since the last notice") {
+		t.Errorf("second notice = %q, want it to report 9 suppressed", got[1].Message)
+	}
+}
+
+// The two kinds are different conditions with different remedies, so one
+// must not silence the other for the same session.
+func TestHeartbeatAuthNoticeThrottlesPerKind(t *testing.T) {
+	d := &Daemon{store: api.NewStore(), events: events.NewRing(events.DefaultCapacity)}
+
+	d.emitHeartbeatAuth(events.KindHeartbeatRefused, "ws/team-role-g1-0", "refused: orphan")
+	d.emitHeartbeatAuth(events.KindHeartbeatUnbound, "ws/team-role-g1-0", "admitted unbound")
+
+	got := d.events.Snapshot(events.Filter{}, 0)
+	if len(got) != 2 {
+		t.Fatalf("refused + unbound for one session emitted %d events, want 2", len(got))
+	}
+}


### PR DESCRIPTION
A daemon log that scrolls one line per orphaned agent per tick is a log nobody can read during the incident that produced it. The operator hit this today: 20 orphaned drones at a 5s tick buried everything else. I reproduced it smaller, 44 refusals in 90 seconds from two orphans at a 2s tick.

Notices now throttle per (kind, cause, session). The first occurrence is always reported, because the condition is real and an operator needs to see it. Repeats inside a minute are counted, and the next notice reports how many it swallowed, so throttling cannot understate an ongoing fault.

While writing it, `TestHandleHeartbeatBindsToItsSession` failed, and it was right to. It asserts each outcome is reported rather than silent, and my first version collapsed two distinct faults into one notice. They turn out to have opposite remedies:

- **no token at all** means the producer is not sending `MARVEL_HEARTBEAT_TOKEN`. That is what the codex reader shipped and #176 fixed.
- **a token that does not match** means a live process is holding a credential minted for an earlier incarnation of the session key: an orphan from a previous daemon, which nothing reaps.

The old single message told both of them to run `marvel reap --confirm`, which is wrong advice for the first. They now get separate messages and throttle independently.

This does not fix the underlying condition. Nothing reaps an orphan, and whether marvel should kill one or only report it is a policy question that collides with the never-destroy-what-marvel-did-not-create rule. `aae-orc-k58k` carries that.

`go test -race ./...` exit 0, 24 packages ok. `just lint` exit 0, 0 issues. Four new tests cover throttling per session, per kind, the suppressed count, and that separate sessions each get named.

Refs: `aae-orc-k58k`.