### PR TITLE
docs: write the Act 3 extension, verified end to end

### DIFF
--- a/_kos/findings/finding-025-home-isolation-breaks-harness-auth.md
+++ b/_kos/findings/finding-025-home-isolation-breaks-harness-auth.md
@@ -1,0 +1,95 @@
+# finding-025: overriding HOME isolates marvel and de-authenticates the harness
+
+Date: 2026-08-09
+Scope: marvel operations, demo verification
+Status: measured
+
+## Symptom
+
+Running a marvel daemon under an overridden `HOME` is the standing advice
+for keeping a test daemon away from the operator's populated
+`~/.marvel/state/marvel.bolt` (the rehydrate-and-spawn hazard,
+`aae-orc-cxdf`). It works for marvel. It also silently breaks the harness.
+
+An interactive claude session spawned by such a daemon reports:
+
+```
+❯ say only the word ready
+  ⎿  Not logged in · Please run /login
+```
+
+The session spawns, the pane is healthy, `marvel get sessions` shows
+`running`, and the agent can do nothing. Nothing in marvel's output says
+why, because from marvel's side nothing is wrong.
+
+## Mechanism
+
+Marvel derives its whole layout from `Layout.Home`, which comes from
+`os.UserHomeDir()`, which reads `$HOME`. Overriding `HOME` moves
+`~/.marvel` and, since #128, the tmux server name with it.
+
+The harness reads `$HOME` too. On macOS Claude Code keeps no
+`.credentials.json` (verified absent on this machine); credentials resolve
+through the login Keychain, and the lookup does not survive the override.
+
+Symlinking `$MHOME/.claude -> ~/.claude` and `$MHOME/.claude.json` is NOT
+sufficient. Tried, still "Not logged in".
+
+Discriminator, run to rule out the tmux/session-context explanation: the
+same `claude` binary in a plain tmux pane on a scratch socket, under the
+real `HOME`, comes up authenticated at a normal prompt. `HOME` is the
+variable.
+
+## Consequence
+
+Every demo beat that needs a real model turn is unverifiable under HOME
+isolation. That is the whole CTX% surface, the Act 3 extension, Act 2's
+`agent.*` stream, and any future metering act. The two constraints, "do
+not touch the default home" and "verify against a live agent", are
+unsatisfiable together by that route.
+
+## The shape that works
+
+Keep `HOME` real so the harness authenticates, and move every piece of
+marvel state off it individually. All four are existing flags, plus one
+existing env var for the namespace that is not a flag:
+
+```sh
+D=/tmp/mvl-scratch; mkdir -p "$D"
+MARVEL_TMUX_SOCKET=mvl-scratch marvel daemon \
+  --socket    "$D/m.sock" \
+  --state-bolt "$D/marvel.bolt" \
+  --log-file   "$D/daemon.log" \
+  --pidfile    "$D/daemon.pid" &
+export MARVEL_SOCKET="$D/m.sock" MARVEL_TMUX_SOCKET=mvl-scratch
+```
+
+`--state-bolt` at a fresh path is the one that neutralizes `cxdf`: an
+empty store has no desired state to rehydrate, so the daemon logs no
+`AdoptOrLeave` line at all and spawns nothing.
+
+`MARVEL_TMUX_SOCKET` is the load-bearing one for safety. The tmux server
+name is otherwise derived from `Layout.Home`, so a real `HOME` would put
+this daemon on the same tmux server as the operator's, where
+`AdoptOrLeave` meets their panes. With the override the two daemons cannot
+see each other's tmux state at all.
+
+Verified 2026-08-09 across a full Act 3 extension run: claude
+authenticated, two real turns taken, CTX% populated, and
+`~/.marvel/state/marvel.bolt` plus `~/.marvel/log/daemon.log` both
+untouched throughout (mtime unchanged at the operator's own earlier
+teardown).
+
+## Aftermath
+
+- The Act 3 extension in `docs/demo.md` was verified end to end on this
+  recipe and is now written.
+- `docs/demo.md`'s prerequisites still tell a reader to `rm -f
+  ~/.marvel/state/marvel.bolt` and run `marvel daemon` against the default
+  home. That is correct only if the `rm` precedes the daemon. PR #184
+  added a justfile warning for the reverse order. Whether the runbook
+  should recommend the scratch-layout recipe as its default is an open
+  operator call, not taken here.
+- The four flags are documented individually in `marvel daemon --help`.
+  Nothing documents them as a set, which is why the obvious lever (`HOME`)
+  is the one that gets reached for.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -17,7 +17,9 @@ so at that beat rather than papering over it.
 - `just build` (produces `bin/marvel` and `bin/simulator`).
 - Act 1 and Act 3 need no model auth. Act 1 uses only `sleep`; Act 3 needs the
   `claude` binary on PATH (the projection events fire whether or not claude is
-  authenticated, because marvel writes the settings file itself).
+  authenticated, because marvel writes the settings file itself). The Act 3
+  extension is the exception: CTX% only appears once a session takes a real
+  turn, so that beat needs working claude auth and spends two short turns.
 - Act 2 needs the three harness binaries (`claude`, `codex`, `opencode`) and
   working auth for each. The per-session CPU and RSS columns populate without
   auth; the `agent.*` token and cost events need a real model turn.
@@ -419,20 +421,90 @@ Roles whose harness has no Claude Code settings surface (codex, opencode,
 generic) log the policy as advisory and are not projected. Nothing is dropped
 silently.
 
-### Act 3 extension — shift onto a new metering contract (PLANNED, not written)
+### Act 3 extension: shift onto a new metering contract
 
-The intended beat: apply a team without `context_feed`, confirm the TUI
-session's CTX% is `-`, add `context_feed = "statusline"` to the manifest,
-re-apply, then `marvel shift` the team — generation 2 spawns with the feed
-and CTX% appears on the fresh sessions.
+Policy content re-projects onto a running session. A runtime field does not.
+This beat shows the difference, and shows `marvel shift` as the migration
+path for the half that cannot be retrofitted. Verified end to end on
+2026-08-09; it needs claude auth and spends two short model turns.
 
-Why shift and not just re-apply: a session's runtime is frozen at spawn.
-Re-projection reads `context_feed` from the SESSION's runtime copy, so a
-manifest change reaches only sessions created after it — the live
-re-projection that works for policy content does not retrofit the feed onto
-running sessions. Tracked as a known wrinkle (bd: frozen-runtime
-re-projection); this beat is not in the runbook until either the wrinkle is
-fixed or the shift-based sequence is verified end to end.
+Start a team whose interactive claude role has no `context_feed`, and give
+it a turn so the `-` means something:
+
+```sh
+./bin/marvel work examples/context-feed-off.toml
+sleep 8
+./bin/marvel inject feed/watch-watcher-g1-0 "say only the word ready" -e
+sleep 30
+./bin/marvel get sessions   # CTX% is "-", LLM is "-"
+./bin/marvel capture feed/watch-watcher-g1-0   # the pane's own line has both
+```
+
+That contrast is the whole motivation. In the verified run the pane reported
+14% and $1.18 on its own status line while marvel's CTX% cell stayed `-`. The
+harness is metering itself and printing the figure to the human, and marvel
+cannot see any of it.
+
+Now add the feed and re-apply. Nothing happens, and nothing is supposed to:
+
+```sh
+./bin/marvel work examples/context-feed.toml
+sleep 6
+./bin/marvel get sessions                        # still GEN 1, still "-"
+./bin/marvel events --kind policy.projected      # "no events"
+```
+
+A session's runtime is frozen at spawn, and re-projection reads
+`context_feed` from the session's copy rather than the role's, so a manifest
+change reaches only sessions created after it. The live re-projection that
+works for policy content does not retrofit the feed. Tracked as
+`aae-orc-mjrm`; until it is fixed, a shift is the migration path, and the
+`no events` above is how you tell the wrinkle from a typo in your manifest.
+
+Shift, and the new generation spawns with the feed:
+
+```sh
+./bin/marvel shift feed/watch
+sleep 25
+./bin/marvel events --kind policy.projected   # "projected at spawn" for g2
+./bin/marvel get sessions                      # GEN 2, CTX% still "-" (no turn yet)
+./bin/marvel inject feed/watch-watcher-g2-0 "say only the word ready" -e
+sleep 35
+./bin/marvel get sessions                      # CTX% populated, LLM populated
+```
+
+A verified run produced this event sequence in five seconds, and the g2 row
+then read `CTX% 14%` with `LLM Opus 5 (1M context)`. It ran against an
+equivalent manifest pair in workspace `act3`, so the keys below read
+`act3/meter-watcher-*` where the commands above give you
+`feed/watch-watcher-*`:
+
+```
+team.shift-started     act3/meter               gen 1→2 roles=[watcher]
+policy.projected       act3/meter-watcher-g2-0  policy "" projected at spawn: ...
+session.created        act3/meter-watcher-g2-0  pane %2
+team.shift-role-ready  act3/meter               gen 2 ready, gate=running, draining gen 1
+session.deleted        act3/meter-watcher-g1-0  session deleted
+team.shift-completed   act3/meter               gen 2 active
+```
+
+Note `policy "" projected at spawn`. The role declares no policy, so the
+projected file is the feed and nothing else. That empty policy name is the
+signal that `context_feed` alone caused the projection.
+
+Two things worth expecting before you run this in front of anyone.
+
+**Marvel's status line replaces yours in that pane.** The projected
+`--settings` file wins over your own `~/.claude/settings.json` for the
+`statusLine` key, so the g2 pane shows marvel's format (`Opus 5 (1M context)
+· CTX 14% · $1.18 · acct ...`) where g1 showed whatever you have configured.
+Nothing outside the pane changes, and your settings file is not touched.
+
+**`ContextLimit` stays 0 on a fed session.** `marvel describe session` shows
+`ContextPercent` and `ContextModel` populated with `ContextLimit: 0` and an
+empty `ContextLimitSource`, because the feed hands over a percentage the
+harness already computed rather than tokens for marvel to divide. A blank
+limit here is the feed working, not a resolution failure.
 
 ### Act 5 — Meter (PLANNED, not written)
 

--- a/examples/context-feed-off.toml
+++ b/examples/context-feed-off.toml
@@ -1,0 +1,30 @@
+# Marvel example: the same team as context-feed.toml, without the feed.
+#
+# This is the "before" half of the Act 3 extension in docs/demo.md: apply
+# it, take a turn, and watch CTX% stay "-" while the pane's own status
+# line shows the harness knows its context perfectly well. That is the
+# gap context_feed closes.
+#
+# Apply context-feed.toml over this one and nothing happens to the
+# running session, because a session's runtime is frozen at spawn. The
+# feed reaches generation 2, which is what `marvel shift` is for.
+#
+# Setup:
+#   just build
+#   ./bin/marvel daemon &
+#   ./bin/marvel work examples/context-feed-off.toml
+
+[workspace]
+name = "feed"
+
+[[team]]
+name = "watch"
+
+  [[team.role]]
+  name = "watcher"
+  replicas = 1
+  permissions = "plan"
+
+    [team.role.runtime]
+    image = "claude"
+    command = "claude"

--- a/examples/demo-act1-health.toml
+++ b/examples/demo-act1-health.toml
@@ -20,9 +20,9 @@
 #   ./bin/marvel daemon &
 #   ./bin/marvel work examples/demo-act1-health.toml
 #
-# Watch the health path (heartbeat timeout is 6s, threshold 2, so the first
-# action lands ~10s after spawn; capped saturates ~30s later after one
-# backoff window):
+# Watch the health path (heartbeat timeout is 6s, threshold 1, so the first
+# action lands ~7s after spawn; capped saturates ~70s later, after one
+# backoff window and a second staleness. Measured 2026-08-09):
 #   ./bin/marvel events --workspace health --warnings
 #   ./bin/marvel events --kind session.restarted
 #   ./bin/marvel events --kind session.failed


### PR DESCRIPTION
The Act 3 extension had two exits: fix the frozen-runtime wrinkle, or verify the shift-based sequence. I verified the sequence, so the beat is writable with `aae-orc-mjrm` still open, and the wrinkle turns into something the act demonstrates rather than something that blocks it.

## The beat

Measured 2026-08-09 against a live daemon and a real claude, three steps and two short model turns.

A team without `context_feed` keeps `CTX%` at `-` through a real turn while the pane's own status line reports 14 percent and $1.18. That contrast is the motivation, and it needs the turn: without one, `-` proves nothing.

Adding `context_feed` and re-applying changes nothing and emits no `policy.projected`. That is `aae-orc-mjrm` reproducing on demand, and the `no events` is now the documented way to tell the wrinkle from a typo in your manifest.

A shift projects the feed at spawn for generation 2, six events in five seconds, and a turn there populates `CTX%` and `LLM`. The projected file contains exactly the two hooks and nothing else, because the role declares no policy. The act points at that empty policy name as the signal that `context_feed` alone caused the projection.

`examples/context-feed-off.toml` is the "before" half, in the shape `policy-projection.toml` and its v2 already use.

## Two things an operator meets on the first run

Both are in the beat because both look like bugs and are not.

Marvel's projected `--settings` wins over the reader's own `~/.claude/settings.json` for the `statusLine` key, so the pane's status line changes appearance mid-demo. Nothing outside the pane changes and the settings file is not touched.

`ContextLimit` stays 0 on a fed session with `ContextPercent` and `ContextModel` populated, because the feed supplies a percentage the harness already computed rather than tokens for marvel to divide. A blank limit there is the feed working, not a resolution failure.

## Also here, both small

`demo-act1-health.toml`'s header comment claimed threshold 2 and a ~10s first action while the manifest sets `failure_threshold = 1`. Measured, the first action lands at about 7 seconds and `capped` saturates about 70 seconds after that. A reader following the comment computed the wrong timing for the beat below it.

`finding-025` records why the obvious way to run a test daemon does not work, because it cost me an hour and will cost the next person the same. Overriding `HOME` moves marvel's layout and the harness's credential lookup together, so an isolated daemon spawns a claude that reports "Not logged in" while marvel reports the session `running` and `healthy` throughout. Symlinking `.claude` does not fix it; on macOS the credentials are in the Keychain, not in a file. The discriminator run is in the finding.

The shape that works keeps `HOME` real and moves marvel's state off it with flags that already exist: `--socket`, `--state-bolt`, `--log-file`, `--pidfile`, plus `MARVEL_TMUX_SOCKET` for the tmux namespace, which is the one that is not a flag and the one that matters most for safety. `--state-bolt` at a fresh path is what neutralizes `aae-orc-cxdf`: an empty store has nothing to rehydrate and logs no `AdoptOrLeave` line at all. That recipe is what made this verification possible without going near the default home, and `~/.marvel` was verified untouched before and after.

## Cost of merge

Docs, one new example manifest, one corrected comment, one finding. No code.

## Tests

`go test ./...` exit 0, 24 packages. `just lint` exit 0, 0 issues. Both unchanged by this PR, which touches no Go.

Refs: aae-orc-mjrm, aae-orc-u12d, aae-orc-iywb