### PR TITLE
docs: make the demo runbook default to a scratch layout

### DIFF
--- a/_kos/findings/finding-025-home-isolation-breaks-harness-auth.md
+++ b/_kos/findings/finding-025-home-isolation-breaks-harness-auth.md
@@ -84,12 +84,18 @@ teardown).
 
 - The Act 3 extension in `docs/demo.md` was verified end to end on this
   recipe and is now written.
-- `docs/demo.md`'s prerequisites still tell a reader to `rm -f
+- `docs/demo.md`'s prerequisites told a reader to `rm -f
   ~/.marvel/state/marvel.bolt` and run `marvel daemon` against the default
-  home. That is correct only if the `rm` precedes the daemon. PR #184
-  added a justfile warning for the reverse order. Whether the runbook
-  should recommend the scratch-layout recipe as its default is an open
-  operator call, not taken here.
+  home, which is correct only if the `rm` precedes the daemon. PR #184
+  added a justfile warning for the reverse order. RULED 2026-08-09: the
+  runbook defaults to the scratch layout, with the default home kept as
+  the labelled operate-your-real-fleet case. Shipped in PR #188.
 - The four flags are documented individually in `marvel daemon --help`.
   Nothing documents them as a set, which is why the obvious lever (`HOME`)
-  is the one that gets reached for.
+  is the one that gets reached for. `aae-orc-7t7d` carries the ask for one
+  selector that sets them coherently, since five flags is four-fifths of
+  an isolation an operator can get wrong.
+- The health-surface half of this is `aae-orc-9box`: marvel reported the
+  session `running` and `healthy` for the entire time its agent sat at a
+  login prompt. Expired credentials, revoked tokens and an unreachable
+  model all present the same way.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -24,18 +24,66 @@ so at that beat rather than papering over it.
   working auth for each. The per-session CPU and RSS columns populate without
   auth; the `agent.*` token and cost events need a real model turn.
 
-Start each act from a clean daemon. Marvel persists state to
-`~/.marvel/state/marvel.bolt`; to avoid one act's sessions bleeding into the
-next, tear down and clear state between acts:
+### Run the acts on a scratch layout
+
+Run the demo on its own layout, not on the one your real fleet uses. Every
+piece of marvel's state has a flag, and the tmux namespace has an env var:
 
 ```sh
-./bin/marvel stop --teardown        # end the daemon and every agent
-rm -f ~/.marvel/state/marvel.bolt   # forget persisted resources
-./bin/marvel daemon &               # fresh daemon
+D=/tmp/marvel-demo-layout; mkdir -p "$D"
+MARVEL_TMUX_SOCKET=marvel-demo-layout ./bin/marvel daemon \
+  --socket     "$D/m.sock" \
+  --state-bolt "$D/marvel.bolt" \
+  --log-file   "$D/daemon.log" \
+  --pidfile    "$D/daemon.pid" &
+
+export MARVEL_SOCKET="$D/m.sock" MARVEL_TMUX_SOCKET=marvel-demo-layout
+```
+
+Export those two in every shell that drives the acts, including the
+`just demo-watch` panes, or the client talks to a different daemon than the
+one you started.
+
+`--state-bolt` at a fresh path is the load-bearing one. An empty store has no
+desired state to rehydrate, so the daemon adopts nothing and spawns nothing on
+its first tick. Pointed at a populated store instead, a daemon reconciles
+whatever it finds, which can mean real agent processes and real model spend
+you did not ask for.
+
+`MARVEL_TMUX_SOCKET` is the one to not skip. The tmux server name is otherwise
+derived from the layout's home, so a daemon started without it lands on the
+same tmux server your real sessions live on, where its reconcile pass meets
+panes it does not own.
+
+Do not reach for `HOME` to get this. It moves marvel's layout and the
+harness's credential lookup together: the daemon is isolated, and the claude
+it spawns cannot log in, while `marvel get sessions` reports the session
+`running` and `healthy` throughout. See
+`_kos/findings/finding-025-home-isolation-breaks-harness-auth.md`.
+
+Between acts, start clean so one act's sessions do not bleed into the next:
+
+```sh
+./bin/marvel stop --teardown   # end the daemon and every agent
+rm -rf "$D" && mkdir -p "$D"   # forget persisted resources
+# then the daemon command above again
 ```
 
 `marvel events` reads a bounded in-memory ring, so it is empty on a fresh
 daemon and fills as the act runs.
+
+### Running against your real fleet instead
+
+If you are demonstrating on the fleet you actually operate, drop the flags and
+run `./bin/marvel daemon` on the default `~/.marvel` layout. Then the
+between-acts reset above is destructive to real work, so do not use it: the
+teardown ends every agent in every workspace, and clearing
+`~/.marvel/state/marvel.bolt` discards the desired state they came from.
+
+The two modes are easy to mix up in a terminal you have been pasting into.
+`./bin/marvel config tmux-server` tells you which one you are on: the scratch
+layout answers with the name you exported, the real one answers
+`marvel-<hash>`.
 
 ## Watching live
 
@@ -518,10 +566,22 @@ demonstrates a settled layer rather than a moving one.
 
 ## Cleanup
 
+On the scratch layout from Prerequisites, cleanup is the daemon plus the
+directory that held all of its state:
+
 ```sh
 ./bin/marvel stop --teardown
-rm -f ~/.marvel/state/marvel.bolt
+rm -rf /tmp/marvel-demo-layout
+unset MARVEL_SOCKET MARVEL_TMUX_SOCKET
 ```
+
+`unset` matters as much as the `rm`. A leftover `MARVEL_SOCKET` in your shell
+points every later `marvel` command at a socket that no longer exists, and the
+connection error that produces looks nothing like its cause.
+
+On the default layout, the equivalent is `./bin/marvel stop --teardown` and
+`rm -f ~/.marvel/state/marvel.bolt`. That second command discards the desired
+state of your real fleet, so run it only if that is what you mean.
 
 `just clean` also removes `bin/` and the default socket, but it only kills the
 `marvel-demo` tmux session; `stop --teardown` is what ends every agent across


### PR DESCRIPTION
The runbook told readers to run the acts on the layout their real fleet uses, and to reset between acts by tearing down every agent and deleting the persisted store. That sequence is safe only if you execute it in order. Read out of order, or pasted into a terminal you thought was the demo one, it ends running work. The operator hit the adjacent version of this today.

## What changes

The demo gets a layout of its own. Every piece of marvel's state already has a flag, so no code was needed:

```sh
D=/tmp/marvel-demo-layout; mkdir -p "$D"
MARVEL_TMUX_SOCKET=marvel-demo-layout ./bin/marvel daemon \
  --socket "$D/m.sock" --state-bolt "$D/marvel.bolt" \
  --log-file "$D/daemon.log" --pidfile "$D/daemon.pid" &
export MARVEL_SOCKET="$D/m.sock" MARVEL_TMUX_SOCKET=marvel-demo-layout
```

`--state-bolt` at a fresh path is what makes the between-acts reset harmless. An empty store has no desired state to rehydrate, so the daemon adopts nothing and spawns nothing on its first tick, and cleanup becomes deleting a directory instead of deleting a live fleet's desired state.

`MARVEL_TMUX_SOCKET` is the one not to skip, and the only piece that is not a flag. The tmux server name is otherwise derived from the layout's home, so a demo daemon started without it lands on the same tmux server the real sessions live on, where its reconcile pass meets panes it does not own.

## What stays

The default-home path is still documented, as the operate-your-real-fleet case and labelled as such, with its destructive reset called out rather than presented as routine. The two modes are easy to confuse after a few minutes of pasting, so `marvel config tmux-server` is offered as the discriminator: the scratch layout answers with the name you exported, the real one answers `marvel-<hash>`.

Cleanup now also says to `unset` the two env vars, because a leftover `MARVEL_SOCKET` points every later command at a socket that no longer exists and the resulting connection error looks nothing like its cause.

## One warning added

`HOME` is the obvious lever and the wrong one. It moves marvel's layout and the harness's credential lookup together, so the daemon is isolated and the claude it spawns cannot log in, while `marvel get sessions` reports the session `running` and `healthy` the whole time. Measurement in `finding-025`, and the health-surface half of it is `aae-orc-9box`.

## Verification

Both the recipe and its cleanup were run verbatim as written, before this landed: daemon up on the scratch layout, zero `AdoptOrLeave` lines, `demo-act1-recovery` applied and healthy, then torn down and the directory removed. `~/.marvel/state/marvel.bolt` and `~/.marvel/log/daemon.log` were checked before and after and are unchanged at the operator's own earlier teardown.

## Cost of merge

Docs only. No code, no flags added, nothing about the default-home path stops working.

Refs: aae-orc-cxdf, aae-orc-7t7d