### PR TITLE
feat(daemon): report orphaned agents from the refused-heartbeat signal

### DIFF
--- a/_kos/findings/finding-026-shared-golangci-cache-cross-session-phantom.md
+++ b/_kos/findings/finding-026-shared-golangci-cache-cross-session-phantom.md
@@ -1,0 +1,37 @@
+# finding-026: the shared golangci-lint cache reports phantom findings from other sessions' checkouts
+
+**Symptom.** `just lint` / the `lefthook` pre-commit `lint` step failed with
+one errcheck issue against a file that does not exist in this checkout:
+
+```
+../../../../../private/tmp/.../6cd4c178-.../scratchpad/arms/codex-pt8k/internal/runtime/codex/rollout.go:116:15:
+  Error return value of `f.Close` is not checked (errcheck)
+```
+
+Two `level=warning` lines above it say golangci-lint could not read that
+file at all ("no such file or directory") yet still reported the issue.
+The path is a *different* concurrent session's marvel checkout (session
+`6cd4c178`, under its own scratchpad `arms/codex-pt8k/`), not this tree.
+
+**Why it happens.** golangci-lint caches results in a machine-global
+directory (`~/Library/Caches/golangci-lint`), keyed in a way that is not
+isolated per working tree. When two sessions on kinu both lint module
+`github.com/arcavenae/marvel` from different checkouts, a finding cached
+by one surfaces in the other's run, and persists after the originating
+file is gone. `go build`, `go vet`, and `go test ./...` are unaffected —
+only the golangci cache carries the phantom.
+
+**Workaround.** `golangci-lint cache clean` before re-linting clears the
+stale entry; the real tree then lints clean. This is cache maintenance,
+not a gate bypass — the flagged file is not in the repo, and `--no-verify`
+is never the answer (global rule).
+
+**Class, not a one-off.** Any two concurrent sessions building the same Go
+subrepo on this host can cross-contaminate. If it recurs outside marvel,
+promote to an orc-level finding; the cache is machine-global, so the class
+is fleet-wide even though it bit here first. Candidate durable fixes (not
+taken here): a per-checkout `GOLANGCI_LINT_CACHE`, or `cache clean` wired
+into the lint recipe's preflight.
+
+Refs: `.claude/rules/tooling-friction.md` (capture before workaround);
+aae-orc-m4of (the change whose commit this blocked).

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -149,6 +149,7 @@ func main() {
 	root.AddCommand(stopCmd())
 	root.AddCommand(eventsCmd())
 	root.AddCommand(reapCmd())
+	root.AddCommand(orphansCmd())
 	root.AddCommand(newCtxForwardCmd())
 	root.AddCommand(newCodexCtxCmd())
 
@@ -694,15 +695,16 @@ func reapCmd() *cobra.Command {
 			}
 
 			var result struct {
-				Reaped     bool     `json:"reaped"`
-				Killed     int      `json:"killed"`
-				Candidates []string `json:"candidates"`
+				Reaped     bool                  `json:"reaped"`
+				Killed     int                   `json:"killed"`
+				Candidates []string              `json:"candidates"`
+				Orphans    []daemon.OrphanRecord `json:"orphans"`
 			}
 			if err := json.Unmarshal(resp.Result, &result); err != nil {
 				return fmt.Errorf("parse reap result: %w", err)
 			}
 
-			if len(result.Candidates) == 0 {
+			if len(result.Candidates) == 0 && len(result.Orphans) == 0 {
 				fmt.Println("Nothing to reap: every marvel tmux session is in the daemon's records.")
 				return nil
 			}
@@ -712,17 +714,111 @@ func reapCmd() *cobra.Command {
 			}
 			if result.Reaped {
 				fmt.Printf("\nReaped %d.\n", result.Killed)
-				return nil
+			} else if len(result.Candidates) > 0 {
+				fmt.Printf("\n%d unrecorded item(s), left running. Re-run with --confirm to destroy them.\n",
+					len(result.Candidates))
+				fmt.Println("These may belong to another running daemon. Check before confirming.")
 			}
-			fmt.Printf("\n%d unrecorded item(s), left running. Re-run with --confirm to destroy them.\n",
-				len(result.Candidates))
-			fmt.Println("These may belong to another running daemon. Check before confirming.")
+
+			// Orphans are reported, never reaped: a stale-token presenter is
+			// a process the operator owns (aae-orc-m4of). Naming it here so
+			// reap accounts for processes as well as panes.
+			if len(result.Orphans) > 0 {
+				fmt.Printf("\n%d orphaned agent(s) heartbeating against keys this daemon owns "+
+					"(reported, not reaped) — see 'marvel orphans'.\n", len(result.Orphans))
+			}
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&confirm, "confirm", false,
 		"actually destroy the listed state (without this, reap only lists)")
 	return cmd
+}
+
+// orphansCmd reports the orphaned agents heartbeating against session keys
+// the daemon owns — a live process presenting a token minted for an
+// earlier incarnation of the key. It is the positive, self-announcing
+// counterpart to `reap`'s pane scan: the orphan names itself on the
+// daemon's own socket (aae-orc-m4of, k58k).
+//
+// Read-only by design. Marvel reports orphans and never kills them
+// (operator ruling 2026-08-09); an orphan is a process the operator owns,
+// and the never-destroy-what-marvel-did-not-create rule stands. Stop one
+// yourself, or clear its pane with `marvel reap --confirm` once no live
+// session depends on it.
+func orphansCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "orphans",
+		Short: "List agents heartbeating against session keys this daemon owns with a stale token",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := send(daemon.Request{Method: "orphans"})
+			if err != nil {
+				return err
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+
+			var result struct {
+				Orphans []daemon.OrphanRecord `json:"orphans"`
+			}
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				return fmt.Errorf("parse orphans result: %w", err)
+			}
+
+			if len(result.Orphans) == 0 {
+				fmt.Println("No orphaned agents: every heartbeat is from a session this daemon minted.")
+				return nil
+			}
+
+			now := time.Now()
+			w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "SESSION\tWORKSPACE\tTEAM\tROLE\tFIRST SEEN\tLAST SEEN\tREFUSALS")
+			for _, o := range result.Orphans {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\n",
+					o.SessionKey,
+					orDash(o.Workspace), orDash(o.Team), orDash(o.Role),
+					relTime(now, o.FirstSeen), relTime(now, o.LastSeen), o.Count)
+			}
+			if err := w.Flush(); err != nil {
+				return err
+			}
+			fmt.Printf("\n%d orphaned agent(s), reported not reaped. These are processes you own; "+
+				"stop them yourself, or clear a freed pane with 'marvel reap --confirm'.\n",
+				len(result.Orphans))
+			return nil
+		},
+	}
+}
+
+// orDash renders an empty coordinate as a dash so a column never collapses.
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// relTime renders t as a short "Ns ago" relative to now, the form an
+// operator reads for freshness. A last-seen a few seconds old means the
+// orphan is still beating; minutes old means it has likely stopped.
+func relTime(now, t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	}
 }
 
 func workCmd() *cobra.Command {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -156,6 +156,11 @@ type Daemon struct {
 	hbAuthMu sync.Mutex
 	hbAuth   map[string]*heartbeatAuthNotice
 
+	// orphans accumulates stale-token heartbeat refusals into queryable
+	// inventory: the positive, self-announcing orphan signal (aae-orc-m4of,
+	// k58k). Always non-nil. Marvel reports orphans, it never kills them.
+	orphans *orphanRegistry
+
 	// Per-session context and token accountant, fed by the adapter
 	// streams through the session manager. Always non-nil.
 	usage *usage.Accountant
@@ -286,6 +291,7 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 		logs:     buf,
 		events:   evRing,
 		usage:    acct,
+		orphans:  newOrphanRegistry(),
 		reexec:   syscall.Exec,
 	}
 	// The controller evaluates count-shaped admission clauses on its own
@@ -669,6 +675,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleLogs(req.Params)
 	case "events":
 		return d.handleEvents(req.Params)
+	case "orphans":
+		return d.handleOrphans()
 	default:
 		return Response{Error: fmt.Sprintf("unknown method: %s", req.Method)}
 	}
@@ -1082,7 +1090,12 @@ func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 			if p.SessionToken != "" {
 				cause, msg = "stale-token", "refused: token does not match the session claimed; an "+
 					"orphaned agent from an earlier daemon is still heartbeating for this key. "+
-					"Clear it with 'marvel reap --confirm', or start with 'marvel daemon --reclaim'"
+					"See 'marvel orphans'. Clear it with 'marvel reap --confirm', or start with "+
+					"'marvel daemon --reclaim'"
+				// A stale-token refusal is a positive orphan sighting: record
+				// it so the condition is queryable, not only a throttled log
+				// line that ages out of the ring (aae-orc-m4of).
+				d.orphans.observe(p.SessionKey, time.Now())
 			}
 			d.emitHeartbeatAuth2(events.KindHeartbeatRefused, cause, p.SessionKey, msg)
 		}
@@ -1397,6 +1410,38 @@ func stopMode(params json.RawMessage) (teardown bool, mode string, err error) {
 // lose. Confirmation is the caller's explicit flag, never inferred, so
 // the destructive branch cannot be reached by a command that merely
 // looks like a query.
+type orphansResult struct {
+	Orphans []OrphanRecord `json:"orphans"`
+}
+
+// orphanRecords snapshots the orphan registry and decorates each key with
+// its workspace/team/role from the current session record, so the report
+// filters beside that session's other state. Resolving at read time keeps
+// the coordinates fresh across shifts that reuse a key.
+func (d *Daemon) orphanRecords() []OrphanRecord {
+	records := d.orphans.snapshot(time.Now())
+	for i := range records {
+		if sess, err := d.store.GetSession(records[i].SessionKey); err == nil {
+			records[i].Workspace = sess.Workspace
+			records[i].Team = sess.Team
+			records[i].Role = sess.Role
+		}
+	}
+	return records
+}
+
+// handleOrphans reports session keys with a live orphan presenter — a
+// process heartbeating with a token minted for an earlier incarnation of
+// the key. Read-only: marvel reports orphans and never kills them
+// (aae-orc-m4of; the never-destroy rule from PRs #123, #132 stands).
+func (d *Daemon) handleOrphans() Response {
+	data, err := json.Marshal(orphansResult{Orphans: d.orphanRecords()})
+	if err != nil {
+		return Response{Error: fmt.Sprintf("marshal orphans: %v", err)}
+	}
+	return Response{Result: data}
+}
+
 func (d *Daemon) handleReap(params json.RawMessage) Response {
 	var p struct {
 		Confirm bool `json:"confirm"`
@@ -1412,10 +1457,17 @@ func (d *Daemon) handleReap(params json.RawMessage) Response {
 		return Response{Error: err.Error()}
 	}
 
+	// Orphans ride along as evidence, not as reap targets: a stale-token
+	// presenter is a process marvel will not kill (aae-orc-m4of), distinct
+	// from the unrecorded panes reap destroys. Naming both is candidate 1
+	// of m4of — reap names processes as well as panes.
+	orphans := d.orphanRecords()
+
 	if !p.Confirm {
 		result, _ := json.Marshal(map[string]any{
 			"reaped":     false,
 			"candidates": found,
+			"orphans":    orphans,
 		})
 		return Response{Result: result}
 	}
@@ -1428,6 +1480,7 @@ func (d *Daemon) handleReap(params json.RawMessage) Response {
 		"reaped":     true,
 		"killed":     killed,
 		"candidates": found,
+		"orphans":    orphans,
 	})
 	return Response{Result: result}
 }

--- a/internal/daemon/orphans.go
+++ b/internal/daemon/orphans.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// orphanRegistry accumulates the positive orphan signal — stale-token
+// heartbeat refusals — into queryable inventory.
+//
+// A stale-token refusal (see handleHeartbeat) is a live process presenting
+// a credential minted for an earlier incarnation of a session key this
+// daemon owns: an orphan from a previous daemon that nothing reaps
+// (aae-orc-k58k). It is better evidence than the pane scan
+// (session.Manager.UnrecordedTmuxState), which infers orphans from the
+// outside. The orphan announces itself on the daemon's own socket, names
+// the exact session key, and needs no scan to be found (aae-orc-m4of).
+//
+// Marvel REPORTS orphans and never kills them (operator ruling
+// 2026-08-09): an orphan is a process the operator owns, and the
+// never-destroy-what-marvel-did-not-create rule (PRs #123, #132) stands.
+// This registry is the reporting half; nothing here stops a holder.
+//
+// Entries prune once their most recent sighting ages past orphanTTL, so a
+// reaped or dead orphan drops off on its own and the inventory does not
+// grow without bound. An orphan heartbeats at its tick rate (2-5s), so a
+// key unseen for orphanTTL is almost certainly gone.
+type orphanRegistry struct {
+	mu  sync.Mutex
+	obs map[string]*orphanSighting
+}
+
+// orphanTTL is how long after its last sighting an orphan key is kept.
+// Generous relative to any heartbeat tick so an active orphan is never
+// pruned between beats, bounded enough that a cleared one does not linger.
+const orphanTTL = 10 * time.Minute
+
+type orphanSighting struct {
+	first time.Time
+	last  time.Time
+	count int
+}
+
+// OrphanRecord is one session key with a live orphan presenter, as
+// reported by the orphans RPC and `marvel orphans`. Times are UTC.
+type OrphanRecord struct {
+	SessionKey string    `json:"session_key"`
+	Workspace  string    `json:"workspace,omitempty"`
+	Team       string    `json:"team,omitempty"`
+	Role       string    `json:"role,omitempty"`
+	FirstSeen  time.Time `json:"first_seen"`
+	LastSeen   time.Time `json:"last_seen"`
+	Count      int       `json:"count"`
+}
+
+func newOrphanRegistry() *orphanRegistry {
+	return &orphanRegistry{obs: make(map[string]*orphanSighting)}
+}
+
+// observe records one stale-token refusal for a session key at now, and
+// opportunistically prunes keys unseen for orphanTTL. FirstSeen is stable
+// across repeats; LastSeen and Count advance with every observation.
+func (r *orphanRegistry) observe(sessionKey string, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.obs[sessionKey]
+	if !ok {
+		s = &orphanSighting{first: now}
+		r.obs[sessionKey] = s
+	}
+	s.last = now
+	s.count++
+	r.pruneLocked(now)
+}
+
+// snapshot returns the live orphan keys sorted by first sighting (ties
+// broken by key), dropping any unseen for orphanTTL. Coordinates are left
+// blank; the daemon fills them from the session store at read time so they
+// track the current record for the key rather than a stale copy.
+func (r *orphanRegistry) snapshot(now time.Time) []OrphanRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked(now)
+	out := make([]OrphanRecord, 0, len(r.obs))
+	for key, s := range r.obs {
+		out = append(out, OrphanRecord{
+			SessionKey: key,
+			FirstSeen:  s.first,
+			LastSeen:   s.last,
+			Count:      s.count,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].FirstSeen.Equal(out[j].FirstSeen) {
+			return out[i].SessionKey < out[j].SessionKey
+		}
+		return out[i].FirstSeen.Before(out[j].FirstSeen)
+	})
+	return out
+}
+
+// pruneLocked drops keys whose last sighting is older than orphanTTL. The
+// caller holds r.mu.
+func (r *orphanRegistry) pruneLocked(now time.Time) {
+	for key, s := range r.obs {
+		if now.Sub(s.last) > orphanTTL {
+			delete(r.obs, key)
+		}
+	}
+}

--- a/internal/daemon/orphans_test.go
+++ b/internal/daemon/orphans_test.go
@@ -1,0 +1,145 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/events"
+)
+
+// TestOrphanRegistryObserveAndSnapshot is the core contract: an observed
+// key is reported, repeats keep FirstSeen and advance LastSeen and Count,
+// and the snapshot is ordered by first sighting.
+func TestOrphanRegistryObserveAndSnapshot(t *testing.T) {
+	r := newOrphanRegistry()
+	base := time.Date(2026, 8, 9, 3, 23, 0, 0, time.UTC)
+
+	// Two keys, first observed at different times, so order is decidable.
+	r.observe("ws/squad-worker-g1-0", base)
+	r.observe("ws/squad-worker-g1-1", base.Add(2*time.Second))
+	// The first key beats again: FirstSeen stays, LastSeen and Count move.
+	r.observe("ws/squad-worker-g1-0", base.Add(4*time.Second))
+
+	got := r.snapshot(base.Add(4 * time.Second))
+	if len(got) != 2 {
+		t.Fatalf("snapshot len = %d, want 2", len(got))
+	}
+
+	// Sorted by FirstSeen: g1-0 (base) before g1-1 (base+2s).
+	if got[0].SessionKey != "ws/squad-worker-g1-0" || got[1].SessionKey != "ws/squad-worker-g1-1" {
+		t.Fatalf("order = [%s, %s], want [g1-0, g1-1]", got[0].SessionKey, got[1].SessionKey)
+	}
+
+	a := got[0]
+	if !a.FirstSeen.Equal(base) {
+		t.Errorf("FirstSeen = %v, want %v (repeats must not move it)", a.FirstSeen, base)
+	}
+	if !a.LastSeen.Equal(base.Add(4 * time.Second)) {
+		t.Errorf("LastSeen = %v, want %v", a.LastSeen, base.Add(4*time.Second))
+	}
+	if a.Count != 2 {
+		t.Errorf("Count = %d, want 2", a.Count)
+	}
+}
+
+// TestOrphanRegistryPrunesStale proves a reaped or dead orphan drops off
+// on its own once its last sighting ages past orphanTTL, so the inventory
+// does not lie or grow without bound.
+func TestOrphanRegistryPrunesStale(t *testing.T) {
+	r := newOrphanRegistry()
+	base := time.Date(2026, 8, 9, 3, 23, 0, 0, time.UTC)
+	r.observe("ws/squad-worker-g1-0", base)
+
+	// Still present just before the TTL boundary.
+	if got := r.snapshot(base.Add(orphanTTL)); len(got) != 1 {
+		t.Fatalf("at TTL boundary len = %d, want 1", len(got))
+	}
+	// Gone once its last sighting is older than the TTL.
+	if got := r.snapshot(base.Add(orphanTTL + time.Second)); len(got) != 0 {
+		t.Fatalf("past TTL len = %d, want 0 (stale orphan should prune)", len(got))
+	}
+}
+
+// TestHandleHeartbeatRecordsOrphan is the end-to-end contract: a wrong-token
+// heartbeat (a live orphan) becomes a reported orphan carrying the key's
+// coordinates, while a no-token heartbeat (a broken producer, #176) does
+// not — those are opposite faults and must not be conflated (aae-orc-m4of).
+func TestHandleHeartbeatRecordsOrphan(t *testing.T) {
+	d := newHandlerDaemon(t)
+
+	selfKey, _ := registerSession(t, d, "agent-0", true)
+	_, peerToken := registerSession(t, d, "agent-1", true)
+
+	// A wrong (peer's) token against selfKey is an orphan presenter.
+	resp := d.handleHeartbeat(mustMarshal(t, heartbeatParams{
+		SessionKey: selfKey, SessionToken: peerToken, ContextPercent: 61,
+	}))
+	if resp.Error == "" {
+		t.Fatal("stale-token heartbeat should be refused")
+	}
+
+	recs := d.orphanRecords()
+	if len(recs) != 1 {
+		t.Fatalf("orphan records = %d, want 1", len(recs))
+	}
+	if recs[0].SessionKey != selfKey {
+		t.Errorf("orphan key = %q, want %q", recs[0].SessionKey, selfKey)
+	}
+	// Coordinates come from the live session record, so the report filters
+	// beside that session's other events.
+	if recs[0].Workspace != "ws" || recs[0].Team != "squad" || recs[0].Role != "worker" {
+		t.Errorf("orphan coords = %s/%s-%s, want ws/squad-worker",
+			recs[0].Workspace, recs[0].Team, recs[0].Role)
+	}
+	if recs[0].Count != 1 {
+		t.Errorf("orphan count = %d, want 1", recs[0].Count)
+	}
+
+	// A no-token refusal is a broken producer, not an orphan: it must not
+	// appear in the orphan inventory.
+	d.handleHeartbeat(mustMarshal(t, heartbeatParams{
+		SessionKey: selfKey, SessionToken: "", ContextPercent: 61,
+	}))
+	if got := len(d.orphanRecords()); got != 1 {
+		t.Fatalf("orphan records after no-token heartbeat = %d, want still 1", got)
+	}
+}
+
+// TestHandleOrphansRPC covers the read verb: empty when nothing is orphaned,
+// and carrying the recorded key once one is.
+func TestHandleOrphansRPC(t *testing.T) {
+	d := newHandlerDaemon(t)
+
+	empty := d.handleOrphans()
+	if empty.Error != "" {
+		t.Fatalf("orphans error = %q, want none", empty.Error)
+	}
+	var res orphansResult
+	if err := json.Unmarshal(empty.Result, &res); err != nil {
+		t.Fatalf("unmarshal orphans: %v", err)
+	}
+	if len(res.Orphans) != 0 {
+		t.Fatalf("orphans on a fresh daemon = %d, want 0", len(res.Orphans))
+	}
+
+	selfKey, _ := registerSession(t, d, "agent-0", true)
+	_, peerToken := registerSession(t, d, "agent-1", true)
+	d.handleHeartbeat(mustMarshal(t, heartbeatParams{
+		SessionKey: selfKey, SessionToken: peerToken, ContextPercent: 12,
+	}))
+
+	got := d.handleOrphans()
+	if err := json.Unmarshal(got.Result, &res); err != nil {
+		t.Fatalf("unmarshal orphans: %v", err)
+	}
+	if len(res.Orphans) != 1 || res.Orphans[0].SessionKey != selfKey {
+		t.Fatalf("orphans RPC = %+v, want one record for %q", res.Orphans, selfKey)
+	}
+
+	// The refusal is also on the event ring under the stale-token cause, so
+	// the transient signal and the durable inventory agree.
+	if n := len(d.events.Snapshot(events.Filter{Kind: events.KindHeartbeatRefused}, 0)); n == 0 {
+		t.Error("expected a heartbeat.refused event alongside the orphan record")
+	}
+}


### PR DESCRIPTION
When a daemon stops leaving agents running, the reconciler mints fresh sessions on the same keys with new tokens, and the old processes keep heartbeating with stale ones. Since the token binding (#185) those refusals are cleanly discriminated as `stale-token`, but they were thrown away after throttling, so an orphan was visible only as a transient log line that aged out of the ring. This surfaces that signal as durable, queryable inventory, so an operator can see which session keys have a competing presenter without reading the scrollback or running a pane scan.

A stale-token refusal is better evidence than the existing `UnrecordedTmuxState` pane scan: the orphan announces itself on the daemon's own socket, names the exact session key, and needs no scan to be found.

## What this adds
- An in-memory **orphan registry** (`internal/daemon/orphans.go`) accumulating stale-token refusals per session key: first seen, last seen, refusal count. Entries prune once their last sighting ages past 10m, so a reaped or dead orphan drops off on its own and the inventory stays bounded and honest.
- An **`orphans` RPC verb** and a **`marvel orphans`** command listing each key's coordinates (resolved from the live session record), first/last-seen as relative times, and the refusal count.
- **`marvel reap`** now names orphan processes alongside the unrecorded panes it reports, so reap accounts for processes as well as panes.

## What this deliberately does NOT do
Reporting only. Marvel does not kill orphans (operator ruling 2026-08-09): an orphan is a process the operator owns, and the never-destroy-what-marvel-did-not-create rule (#123, #132) stands. `marvel reap --confirm` still destroys only unrecorded panes, unchanged. A no-token refusal is a broken producer (#176), not an orphan, and is excluded from the inventory.

## Scope
Additive: a new read verb, a new command, and one extra field in `reap`'s response. No existing behavior changes. Closes the reporting half of aae-orc-m4of; the kill-or-report policy question (aae-orc-k58k) was ruled REPORT, so no open design remains for this path.

## Tests
Four new tests in `internal/daemon/orphans_test.go`: registry observe/snapshot ordering and FirstSeen stability, TTL pruning, the end-to-end handler path (wrong-token records an orphan with coordinates; no-token does not), and the `orphans` RPC. `go test -race ./...` passes (24 packages); `just lint` clean.

Also carries finding-026: a machine-shared golangci-lint cache surfaced a phantom errcheck from another concurrent session's checkout of the same module, which blocked the commit until `golangci-lint cache clean`.

Refs: aae-orc-m4of, aae-orc-k58k, #185, #186