### PR TITLE
question(marvel): question-marvel-service-provider-shape — service-provider plane, fabric, and resource design

### DIFF
--- a/_kos/nodes/frontier/question-marvel-service-provider-shape.yaml
+++ b/_kos/nodes/frontier/question-marvel-service-provider-shape.yaml
@@ -1,0 +1,154 @@
+id: question-marvel-service-provider-shape
+type: question
+confidence: frontier
+title: "Marvel as a service provider — the plane, fabric, and resource shape"
+content: |
+  Speculative. Nothing here is proven; this node anchors a design session
+  (2026-08-14/15) whose full prose set lives at
+  docs/design/service-provider/ (README, 01-brief-prd, 02-architecture,
+  03-probes-and-roadmap). This is the AUTHORITATIVE home: marvel is the
+  subject. An orc copy under the same id exists as a mis-file from the
+  session and is marked relocation-pending there (see finding-131 id
+  collision, finding-132 move-with-forwarding, finding-133 cross-graph
+  awareness in aae-orc/_kos; the orc copy is retained as a pointer until the
+  move primitive exists).
+
+  THE QUESTION. How should marvel be structured so it can extend services
+  (message bus, vault, knowledge graph, code graph, inference routing,
+  retrieval, evaluation, task tracking) to agents and teams of agents in
+  workspaces, over the control plane and a service plane, easy to adapt as
+  the space evolves and easy to swap one provider for a better one tomorrow,
+  without marvel becoming a monolith that owns and trusts everything.
+
+  THE SHAPE (speculative). Marvel is a theater: it runs the house; agents are
+  the company; sideshow packs are the script; the work can be anything. The
+  analogy names rooms; it never wires them (function first, analogy as
+  annotation).
+
+  Planes (outward seams) vs fabrics (inward wiring):
+  - Planes: control (operator to marvel, exists), service (agent to marvel,
+    mostly unbuilt; Endpoint is name-only and waits on director), event
+    (push not poll; the ring exists, durable form is external NATS), trust
+    (identity minting and credential brokering, not a catalog service).
+  - Fabrics: the BACKPLANE (marvel's internal parts fabric — register,
+    route, supervise, meter — the floor under what marvel already built; the
+    reconciler, adapters, and event ring are its first citizens, hardcoded to
+    one part kind, a tmux session; bd aae-orc-b64o) and the MEASUREMENT
+    FABRIC (its dual: parts emit observations; the meter function is the
+    producer; the ring is a proto form). The service and event planes are
+    facades over the backplane.
+
+  Resource model (marvel already has most nouns; the work is naming and
+  decomposing):
+  - Split: the built Role struct is really a CASTING (slot cast with a
+    persona and identity, provisioned with runtime and tools, N replicas);
+    keep B14 Role as the job. Move BUDGET out to a QoS resource; policy to
+    Projection; permissions to a Sandbox profile. Rename plus extraction, not
+    a bedrock redefinition; touches B14 wording and forestage. Evolve, not
+    big-bang. (Naming relates to the built-resource-naming work; see the
+    marvel naming decisions.)
+  - Split: Endpoint (service registration and discovery, once) vs Binding
+    (scope attachment and resolution — route, trust exchange, projection,
+    policy — bound to many scopes).
+  - Merge: Policy projection is one MODE of a general PROJECTION primitive
+    (readonly, writeblock, inject, redirect, redact-and-mint); write
+    dispositions are a closed set (passthrough, redirect, block, capture).
+    Marvel describes writes; it does not become a filesystem. Shared vs
+    isolated working tree is a declared Volume mode; VFS stays study-first.
+  - Merge: internal / managed / external are three registration modes on the
+    one backplane, and one Service resource plus a provider field, not three
+    types.
+
+  Capability class (interface: coordination pattern plus delivery semantics)
+  vs provider (driver) vs service (configured instance). Swap the provider,
+  keep the class contract; provider extras are opt-in by name and forfeit
+  portability by design.
+
+  Catalog filed by lifecycle:
+  - Runtime services (agent requests via the dropbox): bd (task-graph), kos
+    (knowledge-graph, read surface is the vision Gap 0), flyloft (retrieval),
+    critic (evaluation), code-graph (missing; marvel is also a consumer for
+    reconciler invalidation), NATS (message-bus).
+  - Provisioning capabilities (shape the workspace before the agent):
+    sideshow (behavior packs), callbook (provider standup and identity
+    enrollment), curtain (sandbox profile). Conflating the two lifecycles is
+    a category error.
+
+  Credential boundary: marvel is not the long-term secret store, but it
+  brokers access, holds session state on the agent's behalf (for example the
+  OAuth or Claude-backend session), and connects agents to a vault that mints
+  short-lived scoped credentials. The one thing crossing the wall from the
+  agent side is its minted, attenuable identity; token exchange at the
+  binding boundary. Corrects SOUL section 3 (too narrow); bd aae-orc-dqhf.
+
+  Absence has two honest projections: unprovisioned (invisible in the agent's
+  world) vs bound-but-down (honest unavailable). Component-independence at the
+  agent's eye level.
+
+  Buy, do not build: the backplane transport (light, embeddable, portable Go
+  to Rust; embedded NATS a lead) and the measurement store (OTEL seam,
+  observability-pipeline family). Marvel emits, routes, consumes; never the
+  store.
+
+  Hard constraint (ADR-007): inference informs any plane; inference never
+  enforces on a plane. The caretaker (majordomo) proposes; a deterministic
+  gate executes. Verbs are deterministic and human-authored or
+  human-ratified; the learning loop terminates in a kos finding or a sideshow
+  pack, not in a marvel runtime that mines and mints macros.
+
+  THE PROVING VERTICAL. bd ready, through a minted identity, one Binding, the
+  task-graph provider, returning go/no-go plus a handle, result as a
+  completion event. Exercises every plane; nothing speculative in the parts.
+  bd aae-orc-166h (meter-and-admit) + aae-orc-aaj5 (coordinate).
+
+  PROBE TICKETS (the doing that produces findings): aae-orc-b64o (backplane),
+  aae-orc-1oaz (transport benchmark), aae-orc-zsd5 (push-vs-poll),
+  aae-orc-ytz6 (projection overhead), aae-orc-b56ja (capability-class swap);
+  token-savings delta folded into aae-orc-166h; reference work-unit folded
+  into aae-orc-hfc0.
+
+  OPEN SUB-QUESTIONS (detail in 03-probes-and-roadmap.md): A backplane
+  transport survey; B measurement one fabric or several; C reference
+  work-unit; D language direction (marvel is pure Go today, the "largely
+  Rust" statement contradicts the 2026-08-01 ruling); E resource-model slim
+  timing; F service-plane wire contract reconciled with the director
+  envelope; G capability-class contract boundary; H shared-tree write path.
+
+  DISSENTS PRESERVED: caretaker-with-authority (ruled against), value-per-seat
+  now (deferred), learned-verb-assembly by inference (ruled against),
+  one-bus-vs-two (open, A decides).
+
+  PROMOTION SIGNAL: the proving vertical runs end to end (bd ready through the
+  seam). Then the seam is evidence, not hypothesis.
+edges:
+  - target: elem-agentic-resource-matrix
+    type: derives
+    note: "The governing frame; the service plane and backplane meter feed the matrix."
+  - target: elem-k8s-resource-model
+    type: derives
+    note: "The resource model this extends (Casting, Binding, Projection, Service)."
+  - target: question-agent-communication-broker
+    type: supports
+    note: "The agent message bus is one part on the backplane."
+  - target: question-permission-model
+    type: supports
+    note: "Projection and sandbox modes are the enforcement surface."
+  - target: question-pack-integration
+    type: supports
+    note: "Provisioning-vs-runtime lifecycle cut; sideshow is a provisioning capability."
+provenance:
+  created_by: human
+  session: "2026-08-14-marvel-service-provider"
+  created_at: "2026-08-15"
+  reviewed_by: null
+tags:
+  - service-provider
+  - backplane
+  - architecture
+  - agent-contract
+notes: >
+  Authoritative home (marvel is the subject, per the corrected subject test in
+  aae-orc CLAUDE.md Multi-Repo Probes). Full prose: docs/design/service-provider/.
+  Related bd: aae-orc-dqhf, aae-orc-vxn8, aae-orc-b64o and the probe tickets
+  above. The aae-orc copy of this id is a mis-file, relocation-pending; this
+  copy is authoritative.

--- a/docs/design/service-provider/01-brief-prd.md
+++ b/docs/design/service-provider/01-brief-prd.md
@@ -1,0 +1,194 @@
+# Marvel as a Service Provider: Brief and PRD
+
+Status: speculative design. Nothing here is committed. Captured from a design
+session (2026-08-14/15). See [README.md](README.md) for the set and cross-links,
+and [02-architecture.md](02-architecture.md) for the structure this brief
+motivates.
+
+Last updated: 2026-08-15
+
+---
+
+## Why this exists
+
+Marvel today is a control plane that launches and supervises agent sessions. The
+next thing it is being asked to be is a service provider to those agents: the
+place an agent goes to get work done that it should not spend its own tokens and
+its own context doing. An agent that carries credentials, polls for status, parses
+walls of tool output, and re-runs the same seven-call sequence forty times a day
+is burning the scarce resource (tokens and context) on plumbing. Marvel can hold
+that plumbing behind a small request seam and hand the agent back a result.
+
+The prize is not one service. It is the right structure for adding most services:
+a message bus today, a different bus tomorrow, a vault, a knowledge graph, a code
+graph, an inference router, a retrieval substrate, an evaluation service. The
+design question is the shape that makes these pluggable, swappable, and safe,
+without marvel becoming a monolith that owns everything and trusts everything.
+
+---
+
+## The framing
+
+Marvel is a theater. It provides the building; the company performs the show; the
+show can be about anything. The value of stating it this way is that it keeps the
+scope honest: marvel runs the house, it does not write the play. The work an
+agent team performs (software, security operations, research, simulation,
+roleplay) is the playwright's and the company's business, carried in as sideshow
+packs (the script). Marvel provides the stage, the wiring, the dressing rooms,
+the booth, so any company can mount any show. The analogy names the rooms; it
+never drives the technical design (guardrail per vision value 11; bd
+`aae-orc-vxn8` tracks adopting this framing in the vision and README docs).
+
+---
+
+## Actors
+
+Five actors, unequal, each with a different way to adapt the system. Naming them
+is what keeps the design honest about who needs what.
+
+| Actor | What they do | How they adapt the system |
+|---|---|---|
+| Maintainer | Writes a new provider driver for a capability class | Code |
+| Administrator | Wires a workspace to a service | Manifests and bindings, no code |
+| User | Defines a verb, sets a budget | Config, lua, budgets |
+| Workload agent (the company) | Files a capability request at runtime and gets a result | The service-plane dropbox |
+| Caretaker (the majordomo) | Keeps the cluster in its desired state; serves no actor | Behind the wall; deliberately dull; out of scope for this brief except as a boundary |
+
+The workload agent is the actor the system is most for and, until this design,
+the one it was designed around rather than for. This brief centers the agent's
+request.
+
+---
+
+## Jobs to be done
+
+Stated from the agent's point of view, because that is the actor the seam serves.
+
+1. **Do this for me without spending my tokens.** Run a task off the agent's
+   process and return a small result (go/no-go plus a handle), with full detail
+   cached and read only on failure.
+2. **Tell me when it is done; do not make me wait or poll.** Long work returns
+   as a completion event the agent already subscribes to.
+3. **Do not make me handle credentials.** The agent presents who it is; access is
+   brokered on its behalf; the secret never enters its world.
+4. **Give me the same command everywhere.** `bd ready` means dolt-A in one
+   workspace and dolt-B in another; the agent does not learn the difference.
+5. **Do not show me a capability I cannot use, and do not lie when one is down.**
+   Unprovisioned is invisible; bound-but-down is an honest unavailable.
+6. **Let me combine the sequence I run constantly into one verb.** One call
+   prepares a PR and updates the bd ticket, returns go/no-go, caches the rest.
+
+Two jobs belong to the operator and the maintainer, and they shape the same seam:
+
+7. **Let me swap a provider for a better one tomorrow** without touching the
+   agents or the bindings above it.
+8. **Let me meter what every part costs** so the house can eventually be run on
+   value, not motion.
+
+---
+
+## The proving vertical
+
+The whole design should be validated by one thin slice before it is generalized.
+The slice: `bd ready`, run through a minted identity, one Binding, the task-graph
+provider (dolt-A), returning go/no-go plus a handle, with the result arriving as
+a completion event. It exercises every plane (identity crosses the wall, the
+binding routes and does the token exchange, the projection redirects the bare
+command, the service seam takes the request, the event plane returns the result).
+None of it is speculative: bd exists, dolt exists, the event catalog exists. If
+`bd ready` works end to end through that stack for one agent in one workspace, the
+architecture is validated and the rest is more drivers. If it cannot, the elegance
+was a trap. This slice maps onto Track V1 and the demo's Meter-and-Admit and
+Coordinate acts in the roadmap.
+
+---
+
+## Capabilities, and what each should and should not be
+
+The service catalog is filed by lifecycle. Full structural detail is in the
+architecture doc; this is the product view of what each capability is for.
+
+### Runtime services (requested during the show)
+
+- **Task-graph (bd)**: the agent's work ledger. Should be a redirected bare
+  command resolved per workspace to a Dolt provider. Should not require the agent
+  to know which Dolt instance it is on.
+- **Knowledge-graph (kos)**: orient and query decided bedrock, open frontier, and
+  ruled-out graveyard. Should gain a read and query surface (this is the vision's
+  Gap 0). Should not be summarized in place; artifacts stay verbatim.
+- **Retrieval (flyloft)**: curated, provenance-carrying context at the right
+  distance. Should be a query the agent makes and gets ranked results with
+  provenance. Should not be an uncurated dump.
+- **Evaluation (critic)**: the instrument that tells you whether a team structure
+  produces value. Should be non-optional foundation, not a late add. Should not be
+  the thing that gates promotion automatically (promotion stays a human act,
+  ADR-007).
+- **Code-graph (missing)**: compiler-grade symbol and reachability facts. Should
+  be a queryable capability and a marvel-internal input (reconciler
+  invalidation). Should not be a new graph database marvel operates; it is an
+  ingest pipeline into existing stores.
+- **Message-bus (NATS)**: the coordination fabric for a team. Should be defined by
+  coordination pattern plus delivery semantics. Should not leak a provider's
+  peculiarities into the agent's assumptions.
+
+### Provisioning capabilities (shape the house before the company arrives)
+
+- **Behavior packs (sideshow)**: install skills, commands, rules, hooks into a
+  workspace. Should run at setup with real provenance (signed packs). Should not
+  be a runtime API an agent calls.
+- **Provider standup and identity enrollment (callbook)**: stand up the Dolt
+  provider and enroll humans and agents under durable names. Should feed the
+  trust plane. Should not be conflated with the runtime task-graph service that
+  uses the provider.
+- **Sandbox profile (curtain)**: install the kernel-enforced containment a
+  workspace runs under. Should be declared per role or workspace and enforced by
+  the kernel. Should not put the policy language in the trusted path.
+
+---
+
+## Cross-cutting requirements
+
+- **Credential handling**: agents do not handle credentials; marvel brokers and
+  holds session state on the agent's behalf; durable custody is delegated to a
+  vault service. Corrects SOUL section 3 (bd `aae-orc-dqhf`).
+- **Identity**: agents get a minted, attenuable identity. Token exchange at the
+  binding boundary turns identity into scoped downstream access.
+- **Budget, QoS, throttling**: a production-budget concern on the workspace or
+  team, not a property of a role or a job. Admission (PR #101) is its embryo.
+- **Measurement**: marvel emits, routes, and consumes observations; it is never
+  the store. A calibrated reference work-unit (a fixed task-set, the "official
+  kilogram") is a prerequisite for measuring velocity, and is a foundation stone,
+  not this quarter's work.
+- **Swappability**: capability class (interface) versus provider (driver) versus
+  service (configured instance). Swap the provider, keep the class contract.
+
+---
+
+## Non-goals
+
+- **Marvel is not a credential store.** It brokers and holds session state;
+  custody is the vault's.
+- **Marvel does not write the play.** The work is the company's; marvel is
+  workload-agnostic.
+- **Marvel does not build its own message bus, metrics store, or log store.** It
+  buys the category and keeps the seam generic.
+- **The caretaker (majordomo) is not in scope here** beyond being a boundary. It
+  is deliberately dull, behind the wall, and never extended into services.
+- **No runtime verb-learning by inference.** Verbs are deterministic and
+  human-authored or human-ratified.
+- **No general union or overlay filesystem now.** Projection describes writes with
+  a closed set of dispositions; VFS is study-first.
+
+---
+
+## What this brief depends on being true
+
+Stated so it can be checked rather than assumed:
+
+- Marvel's existing resource model can be extended (rename Role to Casting,
+  extract budget, add Binding) without a rewrite. The architecture doc argues
+  this is a rename plus extraction, not a bedrock change.
+- A light, embeddable, language-portable transport for the backplane exists to be
+  bought. This is a survey probe, not a proven fact.
+- The proving vertical can be built on today's marvel plus bd plus the event
+  catalog. This looks true from the built-state review but has not been built.

--- a/docs/design/service-provider/02-architecture.md
+++ b/docs/design/service-provider/02-architecture.md
@@ -1,0 +1,413 @@
+# Marvel as a Service Provider: Architecture
+
+Status: speculative design. Nothing here is committed. Captured from a design
+session (2026-08-14/15) and written to be argued with, not built from as-is.
+See [README.md](README.md) for the document set and cross-links.
+
+Last updated: 2026-08-15
+
+Companion knowledge node (the speculative, kos-native form):
+`_kos/nodes/frontier/question-marvel-service-provider-shape.yaml` and
+`_kos/ideas/marvel-service-provider-architecture.md`.
+
+---
+
+## The one-paragraph shape
+
+Marvel is a theater. It provides the house, the stage, the wiring behind the
+walls, the dressing rooms, the fly loft, and the control booth. sideshow packs
+are the script; the agents are the company; the work performed on the stage can
+be anything (software engineering, security operations, research, simulation,
+roleplay). Marvel's job is to run the building so any company can mount any
+show. The architecture below is the building's structure. The analogy names the
+rooms; it does not wire them (see the naming-register guardrail in vision value
+11, and bd `aae-orc-vxn8`).
+
+---
+
+## Planes and fabrics
+
+Two ideas that are easy to conflate but must stay distinct: a **plane** is a
+protocol seam (a surface something talks across); a **fabric** is internal
+wiring that carries traffic between marvel's own parts. Planes face outward
+(operators, agents). Fabrics face inward.
+
+### Agent-facing and operator-facing planes
+
+- **Control plane** (operator to marvel). Apply a manifest, inspect state,
+  rotate a shift, administer remotely over `mrvl://`. This exists today
+  (`internal/api`, `internal/daemon`, the embedded SSH server on port 6785).
+- **Service plane** (agent to marvel). An agent files a capability request at a
+  front-office dropbox and gets an answer. This is the load-bearing new seam and
+  it is mostly unbuilt (marvel's `Endpoint` is a name-only record that "waits on
+  director"; F12 is unbuilt).
+- **Event plane** (push, not poll). Notifications, watchdog alerts, timers, and
+  the completion signal for long work. Marvel owns an event ring today
+  (12 `agent.*` kinds, non-durable). The agent-facing durable form is an
+  external NATS bus supervised by marvel as a declared workload (ruled
+  2026-08-01).
+- **Trust plane** (identity minting and credential brokering). Deliberately not
+  a service in the catalog: it is the surface where an agent's minted identity is
+  exchanged for scoped access. See the credential boundary below.
+
+### The two fabrics (the pieces built without their footings)
+
+- **The backplane** (internal parts fabric). How marvel's own parts, its managed
+  workloads, and its external integrations register, route to each other, stay
+  healthy, and get metered. This is not the agents' message bus. It is more core
+  than that: it is the floor the rest stands on. It is described in its own
+  section below.
+- **The measurement fabric** (internal observation fabric). The dual of the
+  backplane: the backplane carries requests between parts; the measurement fabric
+  carries observations about parts. Also described below. Less settled than the
+  backplane.
+
+The service plane and the event plane are facades over the backplane. An agent
+sees a uniform "marvel service"; underneath, the backplane routes the request to
+the right part, whether that part is compiled in, a supervised process, or a
+remote integration.
+
+---
+
+## The backplane
+
+### What it is
+
+Marvel already does four things for agent sessions: it **registers** them
+(the session/team model), **routes** control to them (tmux, adapters),
+**supervises** them (the reconciler, healthchecks, shift), and **meters** them
+(the usage accountant, admission). The backplane is those same four functions,
+generalized from "a tmux session" to "any part."
+
+- **Register**: a part declares its class, its provider, its locality
+  (in-process, managed workload, or external integration), a health endpoint,
+  and a meter hook.
+- **Route**: deliver a typed capability request to the bound part, carrying the
+  caller's minted identity, and return a small result (go/no-go plus a handle).
+- **Supervise**: liveness and lifecycle. This is the existing Shift primitive
+  applied to a part, so rolling a NATS 1.9 to 2.0 upgrade is the same mechanic
+  as rotating an agent.
+- **Meter**: what the part cost. This is the producer side of the measurement
+  fabric.
+
+### Why it was invisible
+
+Marvel already built parts of the backplane without recognizing them. The
+reconciler registering sessions, the healthcheck loop, the control routing
+through tmux, and the event ring are backplane behavior hardcoded to one kind of
+part. The building has a stage sitting on a floor that was never poured
+separately, and it held because nothing heavy stood on it yet. Adding a vault
+process, a dolt process, a retrieval server, or an inference router is the
+heavy thing. Those need the same floor the tmux sessions already stand on.
+
+The practical consequence for building it: do not grow a backplane in a corner.
+Extract it from what the reconciler already does. The session registry becomes
+the part registry, the control routing becomes the request router, the health
+loop becomes part supervision, and the accountant becomes the meter. The four
+functions exist; they are specialized to a tmux session, and the work is to
+generalize the part.
+
+### What it must be, and must not be
+
+- It **must** be dumb, authenticated, metered, and auditable. It is the most
+  trusted path in the system, so it is the least clever. A part registering on
+  the backplane is a trust event (this process may now receive routed requests
+  carrying minted identity), not a config reload.
+- It **must not** have inference anywhere in it. Inference informs planes; it
+  never enforces on a plane. A hallucinating router is worse than a hallucinating
+  agent.
+- It **must** treat internal, managed, and external parts as three registration
+  modes on one fabric, not three different systems.
+
+### Transport: buy, do not build
+
+The backplane needs a transport: an in-process path for internal parts and a
+light wire for out-of-process parts. This is a category decision, not a vendor
+marriage, the same way "it is SQL" lets one move between MySQL, MariaDB, and
+Postgres. The minimum shape a candidate must satisfy:
+
+1. Register and deregister a part with class, provider, and locality.
+2. Route a typed request carrying minted identity; return go/no-go plus a handle.
+3. Report part liveness into supervision.
+4. Expose a meter hook into the measurement fabric.
+5. Run in-process for internal parts and over a light wire for out-of-process
+   parts.
+6. Be embeddable, light (not Kafka-weight or Spark-weight), and portable across
+   a future Go to Rust move.
+
+Anything an order of magnitude heavier than marvel itself is too mature for this
+use; the target is a light dependency that can be replaced later, not a platform
+to build the product around. First place to look in a survey: embedded NATS in
+library mode, possibly serving both the internal backplane transport and the
+agent-facing message bus over different subjects and accounts (one dependency,
+two logical planes). That is a lead for the survey probe, not a decision. See
+[03-probes-and-roadmap.md](03-probes-and-roadmap.md).
+
+---
+
+## The measurement fabric
+
+### What it is, and how it relates to the backplane
+
+Every part receives requests over the backplane and emits observations into the
+measurement fabric. The backplane's meter function is the producer into it. The
+event ring is a proto-measurement-fabric today: it already collects signals, and
+they die in it. Marvel's adapters already know a great deal (session status,
+CPU, RSS, context pressure, which model, which harness, which version); that
+data currently has nowhere to flow.
+
+### The stance
+
+Marvel's role is to emit, to route, and to consume; it is never the store.
+Admission throttles on context percentage, the caretaker watches, and critic
+scores, all as consumers. The store is bought, not built (the OTEL seam as the
+emit contract, and the observability-pipeline family as the store).
+
+### The honest open question
+
+It is not yet settled whether measurement is one fabric or several. Logs are
+streaming text and behave like messages; metrics are numeric time series;
+traces are a third shape. These are different levels of adaptation and a single
+fabric may be the wrong unification. This is recorded as open, not resolved. See
+the probe guide.
+
+---
+
+## The resource model
+
+Marvel already has most of the nouns. The work is naming and decomposing, not
+inventing. Three families, plus config and state.
+
+### Where the built model is right
+
+`Workspace`, `Session`, `Runtime` (the harness, correctly separated from the
+agent), `Team`, `Host`, `Healthcheck`, and the event ring exist. `Vault`,
+`Pack`, `Volume`, `Schedule`, and `Gateway` are modeled but not built.
+Admission (`internal/admission`, PR #101) already refuses over-budget work at
+operator verbs, which is the embryo of runtime metering. `Policy` projection is
+live: a per-session settings file that re-projects and emits `policy.projected`.
+
+### One word was hiding several: Role becomes Role plus Casting
+
+forestage's B14 (bedrock) defines five primitives: Persona (the costume), Theme
+(the roster), Identity (the lens), Role (the job: responsibilities, procedures,
+outputs, authority), and Process (the game). Composition is
+`Agent = Persona + Identity + Role(s) + LLM + Tools` inside
+`Team = Agents + Roles + Process`.
+
+Marvel's built `Role` struct is not B14's Role. It carries name, replicas,
+runtime, restart policy, permissions, policy, persona, identity, and budget.
+That is not a job; it is a casting decision (this slot, filled by this persona,
+wearing this identity, running this harness, at N replicas). The proposal:
+
+- Keep B14's Role exactly as bedrock defines it (the job).
+- Rename marvel's struct to **Casting** (name is a bikeshed: Casting, Billet, or
+  Slot). It references a Role (the job), a Persona and Identity (B14 ingredients),
+  a Runtime, and Tools, at N replicas with a restart policy.
+- Move **budget** out entirely. Budget is a QoS and admission concern on the
+  workspace or team (the production budget, never the actor's or the part's).
+- Route **policy** to Projection and **permissions** to a Sandbox profile.
+
+This is a rename plus an extraction, not a redefinition of bedrock. It touches
+forestage and the charter B14 wording, so it is flagged, not slipped in. It can
+be built as Casting-holds-everything today and decomposed under pressure as the
+seam lands (evolve, do not big-bang).
+
+### One word was hiding two: Endpoint versus Binding
+
+- **Endpoint** is service registration and discovery: a service named X, of
+  class C, exists and is reachable. Registered once.
+- **Binding** is a scope attachment and resolution: workspace alpha may use X,
+  resolved as provider P, with this identity exchange, this projection, and this
+  policy. Bound to many scopes.
+
+Register once, bind many. Marvel's current name-only `Endpoint` is the
+registration half; the Binding (the resolution half) is unbuilt.
+
+### Two words were one: Policy is a mode of Projection
+
+Projection is the general primitive: everything an agent touches is a
+marvel-controlled view (files, service endpoints, credentials, the team roster,
+settings). `Policy` projection is the single mode marvel built first
+(settings-inject). The modes:
+
+- **readonly**: present, do not allow writes.
+- **writeblock**: present, reject writes with an honest error.
+- **inject**: place a file or directory that is not in the working tree.
+- **redirect**: present a bare command (for example `bd ready`) and route it to
+  the resolved provider (dolt-A here, dolt-B there).
+- **redact-and-mint**: hide the secret, present a working tool (the credential
+  case).
+
+Curtain is the kernel enforcer of these; the projection layer describes them.
+Settings management and sandboxing are the same primitive in different modes.
+
+### The write path (an edge worth stating)
+
+Reads are settled. For writes, each projection carries a declared
+write-disposition chosen at bind time, from a closed set:
+
+- **passthrough**: the write lands in the real working tree.
+- **redirect**: the write lands in the agent's private overlay directory, not
+  shared.
+- **block**: the write is rejected honestly.
+- **capture**: the write lands in a marvel-held staging area for a later gate
+  (used sparingly).
+
+Marvel describes the write; it does not become a filesystem. Whether a working
+tree is shared or isolated is a declared Volume mode, not an invented concurrency
+engine. Collisions on a shared tree are git's already-solved problem. A general
+union or overlay filesystem is deliberately out of scope for now (VFS and slotefs
+are "study first, not committed" in the roadmap).
+
+### The Verb
+
+A Verb is a named, versioned, deterministic composition of capability requests
+with a declared contract (inputs, the bindings it touches, a go/no-go plus handle
+result). Its body is a lua utility orchestrating requests; no model is in its
+execution path. It is authored by a user, or proposed by the caretaker and
+ratified by a human (the automation boundary, ADR-007). A ratified verb
+terminates in a durable artifact (a kos finding or a sideshow pack) that teaches
+future agents. The learning loop ends in the knowledge and behavior planes, not
+in a marvel runtime that mines and mints macros on its own.
+
+### Lua, scoped
+
+Lua is a utility scripting layer, in the spirit of an n8n workflow but in the
+Rust and Go world rather than Node. It describes deterministic process
+(schedules, loops, conditionals) and, where authorized, calls into the control
+plane and services. It is not how marvel is extended, and it is not the
+caretaker's judgment. It runs the boring loop so a model does not pay tokens to
+count.
+
+---
+
+## The service catalog, filed by lifecycle
+
+The cut that organizes the whole catalog is provisioning-time versus
+runtime-request.
+
+### Runtime services (an agent requests these during the show, via the dropbox)
+
+- **bd** (task-graph): Dolt-backed issue and work tracking. The reference
+  service; the proving vertical runs through it.
+- **kos** (knowledge-graph): orient, query the decided bedrock, open frontier,
+  and ruled-out graveyard. Read surface is unbuilt today (this is Gap 0 in the
+  vision).
+- **flyloft** (retrieval): curated, provenance-carrying, distance-appropriate
+  context over MCP. Skeleton today.
+- **critic** (evaluation): run registry and arena; the instrument that tells you
+  whether a team structure produces value. Pre-code.
+- **code-graph** (missing): compiler-grade symbol and reachability facts. Marvel
+  is also a consumer: changed-symbol reachability tells the reconciler which
+  sessions to invalidate.
+- **message-bus** (NATS): publish, subscribe, request-reply, durable consume.
+
+### Provisioning capabilities (these shape the house before the company arrives)
+
+- **sideshow** (behavior packs): installs skills, commands, rules, and hooks into
+  a workspace. The agent never calls sideshow; it runs at setup.
+- **callbook** (task-graph provider standup and identity enrollment): stands up
+  the Dolt service shape and enrolls humans and agents under durable names. Feeds
+  the trust plane.
+- **curtain** (sandbox profile install): installs the kernel-enforced containment
+  profile a workspace's agents run under.
+
+Conflating the two lifecycles is a category error: do not build a runtime API for
+a thing that runs once at setup, and do not let an agent re-provision its own
+enclosure.
+
+### Capability class, provider, service
+
+A capability class is an interface defined by the coordination pattern and the
+delivery semantics the agent depends on, not by a provider's API. For a message
+bus the class carries the pattern (fire-and-forget, work-queue, request-reply,
+broadcast) and the semantics (ordering, at-least-once, at-most-once,
+exactly-once, durability). A provider is a driver of a class (NATS and RabbitMQ
+both provide message-bus; dolt-A and dolt-B both provide task-graph). A service
+is a configured provider instance. Provider-specific extras are exposed only
+through an explicit, opt-in door the agent knocks on by provider name, and
+knocking forfeits portability by design. Swapping a provider changes the driver;
+the class contract, and every binding above it, is untouched.
+
+The three service "types" (internal, managed workload, external) are not three
+types. They are one Service resource with a provider field describing how much of
+the service marvel runs, and three registration modes on the one backplane.
+
+---
+
+## The credential boundary
+
+Marvel does not become the long-term secret store. It does broker access, hold
+session state on the agent's behalf (for example the OAuth session for a backend
+service such as the Claude backend, so the agent does not handle the token), and
+run credential-handling services that connect agents to a vault that mints
+short-lived scoped credentials. Durable custody is delegated to the vault
+service.
+
+The one thing that crosses the wall from the agent's side is its minted identity:
+an attenuable token (biscuit-shaped or SPIFFE-shaped). At the binding boundary, a
+token exchange trades that identity for a short-lived scoped downstream
+credential. The plaintext secret never enters the agent's world.
+
+This corrects SOUL.md section 3, whose "never manages credentials" wording was
+too narrow and foreclosed brokering and session-holding by accident. The
+single-user versus multi-user routing boundary in section 3 still stands. Tracked
+as bd `aae-orc-dqhf`.
+
+---
+
+## Absence has two honest projections
+
+When a capability is not available to an agent, the two cases must not look the
+same:
+
+- **Unprovisioned**: the capability is invisible in the agent's world. It is not
+  on the roster, the verb is absent, and the agent never forms the intention. You
+  cannot miss what was never in your world.
+- **Bound but down**: an honest go/no-go result of "unavailable, retry," which
+  the agent or the caretaker acts on.
+
+This is the component-independence principle (SOUL section 2, ADR-005) at the
+agent's eye level: an unprovisioned capability is invisible, not broken; a
+bound-but-down capability is honestly unavailable, not silently wrong.
+
+---
+
+## Module sketch (language-agnostic)
+
+The seam maps onto packages regardless of implementation language. Names are
+indicative:
+
+- `identity`: the issuer. Mint, attenuate, verify. Marvel is an issuer here, not
+  a name registry.
+- `capability`: the class interfaces and provider drivers.
+- `binding`: the resolution (route, trust exchange, projection shape, policy).
+- `projection`: the one-hat mechanism and its modes; hands curtain the
+  kernel-enforcement spec.
+- `service`: the registry and the request dropbox (the seam itself).
+- the **backplane**: register, route, supervise, meter, extracted from the
+  existing reconciler rather than grown separately.
+
+A standing flag: marvel is pure Go today (module `github.com/arcavenae/marvel`,
+go 1.25.4, zero Rust). The stated direction of "largely Rust" contradicts both
+the current tree and the 2026-08-01 "Go through the push, Rust as satellites"
+ruling. The structure above is language-agnostic (each item is a trait or an
+interface either way), but the language direction needs reconciliation on paper
+before this becomes a build plan. See the probe guide.
+
+---
+
+## What is genuinely new here (against the built model)
+
+- The backplane as an explicit fabric extracted from the reconciler, carrying
+  internal, managed, and external parts uniformly.
+- The measurement fabric as its dual.
+- The service plane (dropbox) with a go/no-go-plus-handle return contract, where
+  long results arrive as completion events (the service plane and event plane are
+  the two ends of one interaction).
+- Binding as a distinct resource from Endpoint.
+- Minted identity as an issued, attenuable token, and token exchange at the
+  binding boundary.
+- Projection generalized beyond settings, with a closed set of read modes and
+  write dispositions.

--- a/docs/design/service-provider/03-probes-and-roadmap.md
+++ b/docs/design/service-provider/03-probes-and-roadmap.md
@@ -1,0 +1,204 @@
+# Marvel as a Service Provider: Probes, Open Questions, and Roadmap Draft
+
+Status: speculative design. Nothing here is committed. Captured from a design
+session (2026-08-14/15). See [README.md](README.md), the
+[brief and PRD](01-brief-prd.md), and the [architecture](02-architecture.md).
+
+Last updated: 2026-08-15
+
+This document holds what is not settled: the open questions the design must state
+honestly, the buy-not-build surveys, the dissenting views worth preserving, and a
+sequencing draft against marvel's real roadmap tracks. It is a guide to next-step
+probes, not a plan of record.
+
+---
+
+## Open questions (load-bearing, unresolved)
+
+### Q1. The backplane transport (buy, do not build)
+
+The single biggest undecided thing. The backplane needs an in-process path for
+internal parts and a light wire for out-of-process parts. The decision is a
+category choice, replaceable later, not a marriage. The minimum shape is in
+the architecture doc. The probe is a market survey against that shape.
+
+- Candidates to survey by category: an embeddable pub/sub or RPC library, a light
+  message transport, an actor or channel runtime. First lead worth checking:
+  embedded NATS in library mode possibly serving both the backplane transport and
+  the agent bus over separate subjects and accounts.
+- Disqualifier: anything an order of magnitude heavier than marvel (Kafka, Spark).
+- Constraint: portable across a future Go to Rust move; embeddable; light.
+- This is a survey probe. It is captured here rather than filed as a bd ticket,
+  per the three-layer capture rubric (local first; escalate to a work-queue item
+  only when committing to close it on a timeframe).
+
+### Q2. Is measurement one fabric or several?
+
+Logs (streaming text, message-like), metrics (numeric time series), and traces are
+different levels of adaptation. A single measurement fabric may be the wrong
+unification. Probe: sketch the emit contract (OTEL) and the consumer needs
+(admission throttling, caretaker watch, critic scoring) and see whether one
+pipeline or several fall out. Relates to the vision's measurement gap and to
+usher's telemetry vision.
+
+### Q3. The reference work-unit (the "official kilogram")
+
+Velocity is unmeasurable without a unit. A calibrated, fixed task-set that a team
+runs so that "this config does N reference-units per token" becomes a real
+sentence. Probe: define a first reference task-set. Foundation stone; not this
+quarter. Value-per-seat depends on this and is deferred behind it.
+
+### Q4. Language direction (Go versus Rust)
+
+Marvel is pure Go today (module `github.com/arcavenae/marvel`, go 1.25.4, zero
+Rust). The stated direction "largely Rust" contradicts both the tree and the
+2026-08-01 ruling ("Go through the push; Rust as satellites; VFS or slotefs
+first"). The architecture is language-agnostic, but this needs reconciliation on
+paper before a build plan. Decision, not a probe: the operator reconciles the
+ruling.
+
+### Q5. How much to slim the resource model now versus later
+
+Renaming Role to Casting and extracting budget, policy, and permissions is agreed
+in direction. Marvel ships Role-as-god-struct today. Open: refactor before
+building the seam, or build the seam alongside and let the struct decompose under
+pressure. The session's lean was evolve, not big-bang: ship Casting-holds-
+everything, extract under pressure. Touches forestage and charter B14 wording;
+flag before doing.
+
+### Q6. The service-plane request contract on the wire
+
+The dropbox seam is designed at the level of "go/no-go plus a handle, completion
+as an event." Unspecified: the concrete request envelope, the handle format, the
+relationship to the director envelope draft (which owns `sender.principal`,
+correlation id, and a FIPA-ACL performative). Probe: reconcile the service-plane
+request with the director envelope so they are one envelope family, not two.
+
+### Q7. The capability-class contract boundary
+
+Swapping a provider invisibly requires the class contract to carry coordination
+pattern plus delivery semantics (ordering, at-least-once, at-most-once,
+exactly-once, durability), not just method names. Open: where exactly the line
+sits between the class contract and provider-specific extras, and how the opt-in
+"by provider name, forfeits portability" door is expressed.
+
+### Q8. The write path through a shared working tree
+
+Reads and the closed set of write dispositions are settled in direction. Open:
+the concrete behavior when two workspaces share a Volume and both write, beyond
+"it is git's problem." Probe when a real shared-tree case appears; do not build a
+concurrency engine speculatively.
+
+---
+
+## Dissenting and minority views (preserved on purpose)
+
+- **The caretaker with authority.** The maximalist view wanted an
+  inference-backed majordomo that takes actions (restart the stuck agent), not
+  only proposes them. The room ruled against it: inference informs any plane;
+  inference never enforces on a plane; the caretaker proposes and a deterministic
+  gate executes. Recorded because the pressure to let the caretaker act to save a
+  human an interruption will recur, and the ruling should be re-read when it does.
+- **Value-per-seat now.** One view wanted value measurement designed in from the
+  first preview. The counter (which held): there are too many leaps to value-per-
+  seat today; lay the measurement foundation (make adapter signals flow) and the
+  reference work-unit first. Value-per-seat is the cathedral bell, hung after the
+  tower stands.
+- **Learned verb-assembly by inference.** The ambitious view wanted marvel to
+  observe traces and mint macros on its own. The ruling: verbs are deterministic
+  and human-authored or human-ratified; the learning loop terminates in a kos
+  finding or sideshow pack, not in a marvel runtime. Recorded because the demo
+  appeal of self-learning verbs is real and will be argued again.
+- **One bus.** It is not settled whether the internal backplane transport and the
+  agent-facing message bus are one embedded dependency (NATS, two subjects and
+  accounts) or two. The session leaned toward exploring one; Q1 decides.
+
+---
+
+## Sequencing draft (against the real roadmap tracks)
+
+This maps the design onto the adopted roadmap (rev 3, 2026-08-01) tracks M
+(marvel), P (packs), V (integrating build), K (knowledge), E (evaluation). It is
+a draft ordering, not a commitment, and it defers to the roadmap where they
+differ.
+
+1. **Prove the vertical (Track V1, demo Meter-and-Admit then Coordinate).** Build
+   `bd ready` through minted identity, one Binding, the task-graph provider,
+   returning go/no-go plus a handle, result as a completion event. This validates
+   the seam with a capability that already exists.
+2. **Extract the backplane from the reconciler (Track M).** Generalize the part
+   beyond a tmux session: part registry, request router, part supervision (Shift
+   applied to a part), meter hook. Do not grow it in a corner. This underlies M3
+   (self-lifecycle) and M4 (auto shift triggers).
+3. **Settle the transport (Q1 survey), then the bus (Track M2).** The bus is an
+   external NATS workload supervised by marvel; if the survey lands on embedded
+   NATS for the backplane too, one dependency serves both planes.
+4. **Name the resource model (Q5).** Rename Role to Casting, extract budget to a
+   QoS resource, add Binding as distinct from Endpoint, generalize Policy into
+   Projection. Evolve, do not big-bang.
+5. **Reconcile the credential boundary (bd `aae-orc-dqhf`).** Rewrite SOUL section
+   3; specify token exchange at the binding boundary; keep the single-user versus
+   multi-user routing boundary.
+6. **Make measurement flow (Track E foundation, Q2).** Route adapter signals out
+   of the event ring over an OTEL seam to a bought store; wire admission, the
+   caretaker, and critic as consumers. Critic (E1) is the early unblock.
+7. **Then the wider catalog.** kos read surface (Gap 0), flyloft phase 0,
+   code-graph ingest, each as a provider behind its capability class.
+
+Foundation stones deferred behind the above: the reference work-unit (Q3) and
+value-per-seat.
+
+Gates carried from the roadmap: M5 and M6 (multi-host, local model runtimes) stay
+behind the bet tripwire (2026-10); nothing here changes that.
+
+---
+
+## Documents, code, and nodes to evaluate for updates
+
+Cross-references that this design bears on, each of which may need updating to fit
+(flagged, not yet changed):
+
+- **SOUL.md section 3** (auth delegation): too narrow; redefine per bd
+  `aae-orc-dqhf`.
+- **vision.md** (the "city of agents" framing): the theater framing reads better;
+  revise per bd `aae-orc-vxn8`. Keep vision value 11 (function first, analogy as
+  annotation).
+- **marvel/charter.md**: stale in the built-state review (still says "three
+  adapters," still leads with the k8s mapping). B14 wording is touched by the Role
+  to Casting rename. F8 (Gateway), F10 (permission model), F11 (stream
+  attachment), F12 (agent communication) all bear on the seam and the backplane.
+- **docs/roadmap.md** (rev 3): the sequencing draft above should be reconciled
+  into Tracks M, P, V, K, E rather than kept separate.
+- **decisions/adr-008** (pack management phased sideshow and marvel) and
+  **adr-002** (superseded): the provisioning-versus-runtime cut and sideshow's
+  place as a provisioning capability should be checked against these.
+- **decisions/adr-007** (automation boundary): the "inference informs, never
+  enforces" line and human-ratified verbs are instances of this ADR; cross-link.
+- **decisions/adr-005** (component independence): the two honest projections of
+  absence are this ADR at the agent's eye level; cross-link.
+- **Component charters**: critic, sideshow, callbook, flyloft, and kos each get
+  placed as a capability (runtime) or a provisioning capability here; their
+  charters should carry a back-reference.
+- **docs/research/2026-08-08-code-graph-briefing.md**: code-graph is placed here
+  as a missing runtime capability and a marvel-internal input; reconcile with its
+  open questions.
+- **The agentic-resource-matrix idea** (`_kos/ideas/marvel-agentic-resource-
+  matrix.md`): budget-as-QoS, measurement, and the enforcement loci connect
+  directly.
+- **bd tickets**: `aae-orc-dqhf` (SOUL section 3), `aae-orc-vxn8` (theater
+  framing docs). Further probes (Q1 transport survey, Q2 measurement fabric, Q6
+  envelope reconciliation) are captured here and become bd items only when work is
+  committed to a timeframe, per the capture rubric.
+
+---
+
+## kos companions
+
+The speculative knowledge from this design lives in kos as a frontier question
+and an idea, not as findings (nothing here is proven):
+
+- `_kos/nodes/frontier/question-marvel-service-provider-shape.yaml`
+- `_kos/ideas/marvel-service-provider-architecture.md`
+
+When a probe here produces evidence, it becomes a finding and the frontier node is
+updated or partially resolved.

--- a/docs/design/service-provider/README.md
+++ b/docs/design/service-provider/README.md
@@ -1,0 +1,91 @@
+# Marvel as a Service Provider (design set)
+
+Status: speculative design. Nothing in this set is committed or proven. It was
+captured from a design session (2026-08-14/15) and is written to be argued with.
+Where it conflicts with the graph (`_kos/nodes/`) or the roadmap, those win.
+
+Last updated: 2026-08-15
+
+## The question this set answers
+
+How should marvel be structured so it can become a flexible service provider to
+agents and teams of agents: extending services (a message bus, a vault, a
+knowledge graph, a code graph, an inference router, retrieval, evaluation, task
+tracking) into workspaces, over the control plane and a service plane, in a way
+that is easy to adapt as this space evolves, and easy to swap one provider for a
+better one tomorrow, without marvel becoming a monolith that owns and trusts
+everything.
+
+## The three documents
+
+1. **[01-brief-prd.md](01-brief-prd.md)** — why this exists, the theater framing,
+   the five actors, the agent's jobs-to-be-done, the proving vertical, the service
+   catalog with what each capability should and should not be, cross-cutting
+   requirements, and non-goals.
+2. **[02-architecture.md](02-architecture.md)** — the structure: planes and
+   fabrics, the backplane, the measurement fabric, the resource model with its
+   splits (Role into Role plus Casting; Endpoint versus Binding) and merges
+   (Policy as a mode of Projection), the credential boundary, projection modes and
+   write dispositions, the catalog filed by lifecycle, and a language-agnostic
+   module sketch.
+3. **[03-probes-and-roadmap.md](03-probes-and-roadmap.md)** — the open questions,
+   the buy-not-build surveys, the dissenting views preserved on purpose, a
+   sequencing draft against the real roadmap tracks, and the list of documents,
+   code, and nodes that may need updating to fit.
+
+Read them as brief then architecture then probes, or jump to the one that matches
+your role: an administrator or user wants the brief; a maintainer wants the
+architecture; anyone deciding what to build next wants the probes.
+
+## The shape in one screen
+
+- Marvel is the theater: it runs the house; the company (agents) performs the show
+  (sideshow packs, the script); the work can be anything. The analogy names the
+  rooms; it never wires them.
+- Two outward planes exist or are near: control (operator to marvel) and the
+  beginnings of service and event planes (agent to marvel). Two inward fabrics are
+  the pieces built without their footings: the **backplane** (parts register,
+  route, are supervised, and are metered) and the **measurement fabric** (parts
+  emit observations). The service and event planes are facades over the backplane.
+- The backplane is not the agents' message bus. It is more core: the floor under
+  what marvel already built. The reconciler, adapters, and event ring are its
+  first citizens, already doing register, route, and health for one kind of part
+  (a tmux session). The work is to generalize the part and extract the fabric.
+- Marvel already has most of the resource nouns. The work is naming and
+  decomposing: rename the built Role struct to Casting (keep B14's Role as the
+  job), split Endpoint (registration) from Binding (scoped resolution), and
+  recognize Policy as one mode of a general Projection primitive. Budget moves out
+  to a QoS resource.
+- The catalog is filed by lifecycle: runtime services an agent requests (bd, kos,
+  flyloft, critic, code-graph, NATS) versus provisioning capabilities that shape
+  the workspace before the agent exists (sideshow, callbook, curtain).
+- Marvel does not store credentials, but it brokers them, holds session state on
+  the agent's behalf, and connects agents to a vault that mints short-lived
+  credentials. The one thing that crosses the wall from the agent is its minted
+  identity.
+- Buy, do not build, the transport and the measurement store. Keep the seam
+  generic, the way "it is SQL" keeps a database swappable.
+
+## Companion knowledge in kos
+
+This is speculative, so in the graph it lives as a frontier question and an idea,
+not as findings:
+
+- `_kos/nodes/frontier/question-marvel-service-provider-shape.yaml`
+- `_kos/ideas/marvel-service-provider-architecture.md`
+
+If a probe here produces evidence, it becomes a finding and the frontier node is
+updated. The overlap between this doc set and the kos artifacts is intentional
+and reinforcing.
+
+## Related material (may need updating to fit; see 03 for the full list)
+
+- Platform: `vision.md` (theater framing, bd `aae-orc-vxn8`), `SOUL.md` section 3
+  (credential boundary, bd `aae-orc-dqhf`), `docs/roadmap.md` (rev 3),
+  `decisions/adr-005`, `adr-007`, `adr-008`.
+- marvel: `marvel/charter.md` (B14 wording; F8, F10, F11, F12), the built model in
+  `internal/` (api, events, runtime, admission, usage, session, team, daemon).
+- Components: `critic/charter.md`, `sideshow/charter.md`, `callbook/charter.md`,
+  `flyloft/charter.md`, `kos/KOS-charter.md`, and
+  `docs/research/2026-08-08-code-graph-briefing.md`.
+- Open bd: `aae-orc-dqhf`, `aae-orc-vxn8`.


### PR DESCRIPTION
Marvel already has most of the nouns to become a service provider to agents and teams; what it lacks is a stated shape for how services reach a workspace without marvel becoming a monolith that owns and trusts everything. This harvests the 2026-08-14/15 design session into marvel's own graph so the direction is captured before it decays, and gives the probe tickets a home to report findings against.

## What this adds

- The authoritative frontier node `question-marvel-service-provider-shape` (marvel is the subject per the corrected subject test; the aae-orc copy is marked relocation-pending and points here).
- `docs/design/service-provider/` (README, 01-brief-prd, 02-architecture, 03-probes-and-roadmap) as the reinforcing long form: planes vs internal fabrics, the backplane, the Casting/Binding/Projection/Service resource splits, the runtime-vs-provisioning catalog cut, the credential boundary, and the proving vertical (bd ready through the seam).

## Cost of merge

Additive: one new node plus a docs directory. No code, no existing node changed. Speculative until the probe tickets (aae-orc-b64o/1oaz/zsd5/ytz6/b56ja) return evidence.