### PR TITLE
feat(runtime): stamp per-agent BEADS_ACTOR into the spawn environment

### DIFF
--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -23,6 +23,15 @@
 // directory's .crushrc as bash at config load, ahead of any permission
 // list, and marvel workspaces are checkouts of arbitrary repositories.
 // Measured firing on `crush run` with no trust prompt (finding-020 §9).
+//
+// Identity stamping: baseEnv sets BEADS_ACTOR for every session, so a
+// marvel-managed agent writes the beads tracker as itself rather than
+// as the human default. The spawner stamps attribution because a
+// harness cannot derive its own identity from inside the pane (orc
+// finding-123; callbook findings 005 and 006). The per-session value
+// also beats any machine-global BEADS_ACTOR the pane would inherit
+// from the operator's shell, which is the point: per-agent identity
+// over one shared name.
 package runtime
 
 import (
@@ -182,6 +191,14 @@ func baseEnv(ctx *LaunchContext) map[string]string {
 		"MARVEL_ROLE":      ctx.Role.Name,
 		"MARVEL_TEAM":      ctx.Team.Name,
 		"MARVEL_WORKSPACE": ctx.Workspace.Name,
+		// The same identity, stamped for the beads tracker. Session
+		// names are <team>-<role>-g<generation>-<index>, so the value
+		// is deterministic and unique per agent session. The map is
+		// the override seam: an adapter, or a future manifest env
+		// surface, that sets its own value after baseEnv returns wins.
+		// The rig column is deliberately not set here; its semantics
+		// are gated on the bd HEAD survey (aae-orc-usohe).
+		"BEADS_ACTOR": "marvel/" + ctx.Workspace.Name + "/" + ctx.Session.Name,
 	}
 	if ctx.SocketPath != "" {
 		env["MARVEL_SOCKET"] = ctx.SocketPath

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -433,6 +433,53 @@ func TestNewStreamParserRejectsUnknownFormat(t *testing.T) {
 // agent can prove about itself is what marvel put there. An adapter that
 // forwards MARVEL_SOCKET without the token hands its agent a channel it
 // cannot authenticate on, and the daemon refuses every beat.
+func TestBaseEnvStampsBeadsActor(t *testing.T) {
+	t.Parallel()
+
+	env := baseEnv(testContext())
+	want := "marvel/acme/squad-worker-g1-0"
+	if got := env["BEADS_ACTOR"]; got != want {
+		t.Errorf("BEADS_ACTOR = %q, want %q", got, want)
+	}
+}
+
+func TestAdaptersStampBeadsActor(t *testing.T) {
+	t.Parallel()
+
+	const want = "marvel/acme/squad-worker-g1-0"
+
+	for _, a := range []Adapter{&Forestage{}, &Claude{}, &Codex{}, &OpenCode{}, &Simulator{}, &Generic{}} {
+		t.Run(a.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testContext()
+			ctx.Session.Runtime.Name = a.Name()
+			ctx.Session.Runtime.Command = "/usr/local/bin/" + a.Name()
+
+			result, err := a.Prepare(ctx)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+			if got := result.Env["BEADS_ACTOR"]; got != want {
+				t.Errorf("BEADS_ACTOR = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBaseEnvBeadsActorOverrideSeam(t *testing.T) {
+	t.Parallel()
+
+	// The returned map is the override seam: an adapter, or a future
+	// manifest env surface, that writes its own value after baseEnv
+	// returns must win over the composed default.
+	env := baseEnv(testContext())
+	env["BEADS_ACTOR"] = "operator/explicit"
+	if got := env["BEADS_ACTOR"]; got != "operator/explicit" {
+		t.Errorf("override lost: %q", got)
+	}
+}
+
 func TestAdaptersInjectHeartbeatToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Every marvel-managed agent currently writes the shared bd board as the operator: panes inherit the machine-global BEADS_ACTOR, so claims and audit rows all resolve to one human, and the board cannot say which agent holds which bead. This stamps a per-agent actor at the one seam all six adapters share (baseEnv in internal/runtime/adapter.go), closing that hole at spawn time.

- Actor grammar: marvel/<workspace>/<session-name>. Session names already carry team-role-g<generation>-<index>, so the value is deterministic and collision-free per agent session.
- Stamping is unconditional so the per-pane value beats the inherited machine-global default; the returned env map is the override seam (documented, pinned by test).
- rig is deliberately not set; gated on the bd HEAD agent-surface survey (aae-orc-usohe).

Additive only: no existing env keys change. Three new tests; full suite and race suite pass.

Refs: aae-orc-a4nq3, callbook findings 005/006.