### PR TITLE
finding(marvel): status truth table — one missing input channel, not three bugs

### DIFF
--- a/_kos/findings/finding-027-status-truth-table.md
+++ b/_kos/findings/finding-027-status-truth-table.md
@@ -1,0 +1,236 @@
+# finding-027 — status truth table: what marvel reports vs what is true
+
+Probe: recon measurement commissioned in
+[ArcavenAE/aae-orc#239](https://github.com/ArcavenAE/aae-orc/issues/239#issuecomment-5389440000)
+(the truth-table brief). Operator: Claude (Opus 5), no human at the keyboard.
+Date: 2026-08-24 (00:27–00:49Z). Binary: tree build at `0c59baa` (`marvel dev`),
+chosen so results are directly comparable to run-01's evidence.
+Machine: MacBookPro17,1, macOS 26.3, tmux 3.6a, claude 2.1.241 on Bedrock.
+
+**This is a measurement, not a fix.** No code changed, no PR opened. Scope was
+one row per cell, per-cell evidence, no blurring of cases, and deliberately no
+conclusion that names a fix. The one structural claim below (§5) is the
+requirements statement the brief asked for, not a proposed patch.
+
+Related: orc `docs/runs/marvel-run-01/run-01.md` and `run-01b.md`;
+ArcavenAE/marvel#201, #202, #203.
+
+---
+
+## 1. The question
+
+marvel infers a session's state from whether its process is alive, not from what
+the agent did. run-01 (a finished agent reported `crashed`, respawned, re-paid)
+and run-01b (a stuck agent reported `running`) looked like two defects. The
+hypothesis under test: they are one defect in two coats.
+
+Four columns per cell: reported state and the signal it came from; real process
+state; real work state; did spend continue.
+
+## 2. The truth table
+
+| | **Cell 3 — process dies** (control) | **Cell 1 — one-shot completes** | **Cell 2 — blocked on modal dialog** |
+|---|---|---|---|
+| **reported state** | `failed` / `unhealthy` | `crashed` / `unhealthy` | **`running`** / `unknown` |
+| **signal inferred from** | pane absence | **pane absence (identical)** | pane presence |
+| **real process state** | dead (SIGKILL) | finished, `exit 0 (end_turn)` | alive, idle at a modal prompt, CPU 0.0% |
+| **real work state** | never finished | **done** | **never started** |
+| **spend continued** | n/a (no model) | **yes — full re-pay per cycle** | **no — $0.00** |
+| **verdict** | **truth** | **inverted** | **inverted** |
+
+Detection latency, cell 3: ~2s. Cell 1: reap ~2s after exit. Cell 2: never — the
+state is stable indefinitely.
+
+## 3. Cell 3 (control) — marvel reports truth
+
+`sleep 3600`, generic adapter, `restart_policy = never`, killed `SIGKILL` from
+outside marvel.
+
+```
+00:27:21  session.created  cell3/control-victim-g1-0  pane %1
+00:27:39  session.crashed  cell3/control-victim-g1-0  pane %1 gone
+00:27:39  session.failed   restart_policy=never, pane gone; role frozen
+```
+
+Ground truth agreed at every 4s sample for 16s: `ps` reported no such pid, tmux
+listed no pane, marvel said `failed`/`unhealthy`.
+
+**The control passes, and that is what makes the finding precise.** The
+inference mechanism is not broken in general. What is broken is that
+pane-absence is the *only* input, so it cannot distinguish outcomes that share
+it.
+
+Blemish: the corpse's row kept reporting `RSS 1.1M` for the full 16s with no
+pane and no process. Reproduces run-01's 22:52:36 observation.
+
+## 4. Cell 1 — a completed one-shot, measured twice
+
+Run in two variants deliberately: an unpaid one to measure the *cadence* for
+free, and a paid one to answer only the question the unpaid variant cannot.
+
+### 4a. Unpaid variant — cadence and terminal state (cost: $0.00)
+
+`/usr/bin/true` under the generic adapter: exits 0 immediately, the cheapest
+possible "work done, process gone." Same reap-and-respawn path, no model.
+
+Observed over an 8-minute externally-bounded window:
+
+```
+00:28:15  session.created  pane %1     <- initial
+00:28:15  session.crashed  pane %1 gone
+00:29:17  session.created  pane %2     <- respawn 1, +62s
+00:31:21  session.created  pane %3     <- respawn 2, +124s
+00:35:25  session.created  pane %4     <- respawn 3, +244s
+```
+
+Backoff from the daemon log: `restart #1 → 59.99s`, `#2 → 1m`, `#3 → 3m`,
+`#4 → 4m`. **4 spawns in 8 minutes**, doubling toward the documented 5-minute
+ceiling.
+
+**`succeeded` never appears.** Grepped the whole ring across the window: zero
+occurrences. The state is in the documented lifecycle (`pending → running →
+succeeded/failed`, CLAUDE.md Resource Model) and nothing reaches it.
+
+The loop does not converge. It settles at one respawn per 5-minute ceiling —
+**~12/hour, ~288/day, indefinitely.**
+
+### 4b. Paid variant — does each respawn re-pay? (cost: $0.4830)
+
+The one question the free variant cannot answer. Real headless claude, `haiku`,
+prompt `"Reply with exactly the word: ok"`. External kill-switch armed *before*
+starting: a `sleep 420` in a detached subshell that runs `marvel stop
+--teardown` regardless of anything marvel or my own logic does. It fired on
+schedule at 00:44:22Z.
+
+Positive control first, per the brief: confirmed the agent actually completes
+and is reaped before trusting any loop result.
+
+```
+00:37:26  agent.session.ended  exit 0 (end_turn) tokens in=3 out=4 cost=$0.2076 turns=1
+```
+
+Three completions inside the window, each a *separate billed model turn*:
+
+| cycle | tokens | cost |
+|---|---|---|
+| 1 | in=3 out=4 | $0.2076 |
+| 2 | in=3 out=4 | $0.1377 |
+| 3 | in=3 out=4 | $0.1377 |
+
+**Answer: full re-pay, not a cached retry.** Identical token counts (3 in, 4
+out) with three separate non-zero charges. Cycle 1 costs more than 2 and 3,
+which is consistent with cold-cache overhead on the first turn; cycles 2 and 3
+are identical, so **$0.1377 is the steady-state per-cycle cost** of this
+trivial prompt.
+
+```
+runs=3   necessary=$0.2076   actual=$0.4830   waste=$0.2754   multiple=2.33x
+steady-state per cycle = $0.1377
+```
+
+Projected at the 5-minute ceiling, for this 7-token prompt:
+
+| window | cycles | cost |
+|---|---|---|
+| 1 hour | 12 | **$1.65** |
+| 24 hours | 288 | **$39.66** |
+
+That is the floor, not a worst case: a real task's prompt and output are far
+larger than 7 tokens. run-01's real summarization task cost $0.0661–$0.1151 per
+cycle at 476–1289 output tokens.
+
+## 5. What the three cells establish together
+
+The hypothesis holds. **Cells 1 and 3 emit the same event, from the same signal,
+with opposite underlying truth:**
+
+```
+cell 3 (died):      session.crashed  "pane %1 gone"
+cell 1 (succeeded): session.crashed  "pane %1 gone"
+```
+
+Nothing downstream of that event can recover the distinction, because the
+distinction was discarded at the point of observation. Cell 2 is the same defect
+from the other side: pane *presence* is read as work happening.
+
+So the defect is not three bugs and not a missing state. It is **one missing
+input channel**: marvel observes the pane and infers the agent. The information
+it needs exists — cell 1's `agent.session.ended  exit 0 (end_turn)` lands on
+marvel's own ring 2 seconds *before* the reap — but it does not reach the state
+machine. Cell 2's information does not exist anywhere in marvel at all.
+
+Stated as the requirement rather than the fix: **a session's state needs to be
+derivable from what the agent reports about its own work, with pane liveness as
+a fallback rather than the primary signal.** Cell 3 shows the fallback is sound.
+Cells 1 and 2 show it is insufficient alone.
+
+Corollary worth recording, because it closes off the obvious cheap answer: a
+`process-alive` healthcheck cannot catch cell 2. `internal/team/controller.go:636`
+— "process-alive is handled by ReapDead. Pane exists → healthy." The pane *is*
+alive. A blocked agent is healthy under every healthcheck marvel currently has,
+and `heartbeat` does not help either, since an interactive claude session emits
+none unless `context_feed` is configured.
+
+## 6. Method notes, including one thing I got wrong
+
+**Cell 2 needed a second attempt, and the first attempt was a false negative I
+caused.** My first cell-2 run pointed the daemon at the aae-orc root and the
+dialog never fired: `~/.claude.json` showed `hasTrustDialogAccepted: true` for
+that path, because **my own `marvel inject "" -e` during run-01 permanently
+granted trust there.** Marvel reported `running` and the pane sat at an empty
+prompt — genuinely idle, but not blocked, so the row would have been wrong.
+
+Reproduced honestly by creating `/tmp/mv-truth/virgin/` with an `@`-import
+`CLAUDE.md`, verified absent from `~/.claude.json` first. The dialog then fired
+as expected (`❯ 1. Yes, I trust this folder`). Recorded because it is a general
+hazard for this class of test: **first-run gates are one-shot per scope, so a
+prior run can silently disarm the very thing a later run is trying to measure.**
+
+Also of note: the virgin directory is *still* absent from `~/.claude.json`
+after the run, because the dialog was never answered. So cell 2 left no trust
+residue, and the cell is repeatable as-is.
+
+**Controls that held:**
+
+- Kill-switch external to marvel (detached subshell, wall-clock), armed before
+  the paid cell started. Fired on schedule.
+- Cheap-first ordering: cell 3 and cell 1a produced the cadence, terminal-state,
+  and `succeeded`-never-fires results for $0.00. Only the re-pay question needed
+  real spend, bounded to 3 cycles.
+- `capture` on a timer, never once. Every "real process state" column is ground
+  truth from `ps`/`tmux`/pane content, never marvel's own report.
+- Positive control before trusting the loop result.
+
+**No sandbox or mock key exists on this machine** (auth is
+`CLAUDE_CODE_USE_BEDROCK` + `AWS_BEARER_TOKEN_BEDROCK`, a live billed path), so
+the wall-clock cap was the only available money bound. Stated for the record.
+
+## 7. Spend and wall-clock
+
+| Cell | Wall-clock | Spend |
+|---|---|---|
+| 3 (control) | ~2 min | $0.00 |
+| 1a (unpaid cadence) | ~9 min | $0.00 |
+| 1b (paid re-pay) | ~7 min (killswitch-bounded) | **$0.4830** |
+| 2 (blocked, incl. false-negative retry) | ~5 min | $0.00 |
+| **total** | **~23 min** | **$0.4830** |
+
+Within the run-01 range (~$0.48) as the brief predicted.
+
+## 8. Incidental observations
+
+- **Five dead tmux socket files** left behind, one per daemon, after each
+  `stop --teardown` reported success (`no server running on ...` for all five).
+  Fifth reproduction of marvel#203 item 6. Cleaned by hand.
+- **`$0.2076` for a 3-in / 4-out-token turn** is worth a second look by someone
+  who knows the Bedrock pricing path. It is the cold-cache first turn, and the
+  number is large relative to the work; run-01's much larger turns cost less.
+  Not this probe's question, so recorded rather than pursued.
+
+## 9. Out of scope by construction
+
+No fix, no PR, no severity ranking across cells, no merging one cell's story
+into another. Each row above stands on its own evidence. §5 states the
+requirement the table implies because the brief asked for the table to serve as
+a requirements document; it deliberately stops short of naming an
+implementation.

--- a/_kos/nodes/frontier/question-session-state-observation.yaml
+++ b/_kos/nodes/frontier/question-session-state-observation.yaml
@@ -1,0 +1,139 @@
+id: question-session-state-observation
+type: question
+confidence: frontier
+title: "What should a session's state be derived FROM, when pane liveness cannot distinguish finished from dead from blocked?"
+tags:
+  - marvel
+  - observability
+  - lifecycle
+  - session
+content: |
+  Marvel infers a session's state from whether its tmux pane exists.
+  That one signal is asked to answer three different questions, and it
+  can only answer one of them.
+
+  MEASURED 2026-08-24 (finding-027, status truth table, tree build
+  0c59baa). Three cells, each with marvel's reported state beside
+  ground truth sampled from outside marvel (ps, tmux, pane capture):
+
+  | cell | reported | real process | real work | spend |
+  |---|---|---|---|---|
+  | dies (SIGKILL) | failed/unhealthy | dead | never finished | n/a |
+  | one-shot completes | crashed/unhealthy | exited 0 (end_turn) | DONE | RE-PAYS |
+  | blocked on modal dialog | RUNNING/unknown | alive, idle, CPU 0.0% | NEVER STARTED | none |
+
+  THE DEFECT IS ONE MISSING INPUT, NOT THREE BUGS. Cells 1 and 3 emit
+  the same event from the same signal with opposite underlying truth:
+
+      cell 3 (died):      session.crashed  "pane %1 gone"
+      cell 1 (succeeded): session.crashed  "pane %1 gone"
+
+  Nothing downstream can recover the distinction because it was
+  discarded at the point of observation. Cell 2 is the same defect
+  inverted: pane PRESENCE read as work happening.
+
+  THE CONTROL IS WHAT MAKES THIS PRECISE. Cell 3 reports truth in ~2
+  seconds, so the inference mechanism is sound and the reap path is
+  correct for the case it was written for. What fails is that pane
+  liveness is the ONLY input. This is why the finding refuses to be
+  three tickets: fixing the crashed-vs-succeeded label without adding
+  an input leaves cell 2 exactly as wrong as before.
+
+  `succeeded` NEVER FIRES. Grepped the whole event ring across an
+  8-minute window: zero occurrences. The state is in the documented
+  lifecycle (pending → running → succeeded/failed, CLAUDE.md Resource
+  Model) and no code path reaches it. A satisfied one-shot role
+  therefore never terminates — the reconciler's desired-vs-actual
+  comparison cannot be satisfied by a process whose correct end state
+  is "not running."
+
+  THE RESPAWN FLOOR MATTERS INDEPENDENTLY OF THE DOLLAR, and this is
+  the part a spend fix would leave standing. Measured free with
+  /usr/bin/true (same reap path, no model): 4 spawns in 8 minutes,
+  backoff 60s → 1m → 3m → 4m toward the documented 5-minute ceiling.
+  It does not converge; it settles at ~12 respawns/hour indefinitely.
+  Even at zero model cost that is a role that never finishes.
+
+  EACH RESPAWN RE-PAYS IN FULL. Three cycles of a 7-token prompt,
+  identical in=3 out=4 every time, three separate charges: $0.2076 +
+  $0.1377 + $0.1377. Steady state $0.1377/cycle → $1.65/hour →
+  $39.66/day, and that is the FLOOR for seven tokens. Not a cached
+  retry. (Measured against Bedrock haiku; the cold-cache first turn
+  costs more than the steady state, which is the only variance.)
+
+  A BLOCKED SESSION IS HEALTHY UNDER EVERY HEALTHCHECK MARVEL HAS,
+  which closes off the obvious cheap answer. `process-alive` cannot
+  catch cell 2 — internal/team/controller.go:636, "process-alive is
+  handled by ReapDead. Pane exists → healthy" — because the pane IS
+  alive. `heartbeat` does not help either: an interactive claude
+  session emits none unless `context_feed` is configured, so the
+  staleness path never engages for the default interactive role.
+
+  TWO DIFFERENT SIZES OF GAP, and they should not be conflated:
+
+  1. Cell 1's information EXISTS AND IS UNROUTED. The stream-fed
+     adapter puts `agent.session.ended  exit 0 (end_turn)` on marvel's
+     own ring ~2 seconds BEFORE the reap. The state machine does not
+     consult it. This is a wiring question.
+  2. Cell 2's information DOES NOT EXIST anywhere in marvel. No
+     channel reports "this harness is waiting on a human." This is a
+     new-channel question, and it is the harder half.
+
+  THE REQUIREMENT, stated without naming an implementation: a
+  session's state should derive from what the agent reports about its
+  own work, with pane liveness as a FALLBACK rather than the primary
+  signal. Cell 3 shows the fallback is sound; cells 1 and 2 show it is
+  insufficient alone.
+
+  OPEN:
+
+  - Whether `replicas` on a headless role is a CONCURRENCY target or a
+    COMPLETION target. Marvel has Deployment semantics only; a
+    satisfied one-shot wants Job semantics. This is a resource-model
+    decision, not a bug fix, and it gates any terminal-state work.
+  - What reports cell 2. A first-turn readiness signal, a pane
+    quiescence heuristic (fragile), or treating harness consent
+    surfaces as a spawn-time provisioning obligation marvel
+    pre-satisfies. Only the last scales to unattended fleets and it is
+    the most invasive.
+  - Whether stale metrics on a dead session are the same disease.
+    Reproduced twice (run-01 22:52:36, finding-027 cell 3): RSS and
+    CPU outliving the process by one or more ticks. Metrics outliving
+    the process is state outliving the truth in a second place.
+  - Whether the non-stream adapters can participate at all. The
+    generic and interactive paths have no structured output, so
+    whatever channel answers cell 2 cannot assume a parseable stream.
+
+  METHOD HAZARD WORTH KEEPING, because it will recur on any consent
+  surface: first-run gates are ONE-SHOT PER SCOPE. Cell 2's first
+  attempt was a false negative — run-01's own `marvel inject "" -e`
+  had permanently set `hasTrustDialogAccepted` for the aae-orc path,
+  disarming the gate under test. Marvel reported `running` and the
+  pane sat at an empty prompt: genuinely idle, not blocked, so the row
+  would have been wrong. Reproduced in a directory verified absent
+  from ~/.claude.json first. A prior run can silently disarm what a
+  later run measures.
+
+  Provenance note: this node's evidence comes from an agent-operated
+  recon campaign (orc issue #239) rather than from a marvel session.
+  The runs it descends from are orc docs/runs/marvel-run-01/run-01.md
+  and run-01b.md; the defects filed from them are ArcavenAE/marvel#201
+  (re-pay), #202 (inject submit), #203 (papercuts, item 2 is cell 2's
+  reported-running gap). Scope was recon only: no fix was proposed and
+  the campaign explicitly reserved the comms/bus layer to the
+  conductor.
+edges:
+  - target: elem-agentic-resource-matrix
+    type: supports
+    note: "spend is a matrix row, and a role that re-buys finished work meters against it wrongly; enforcement locus 2 (runtime admission/metering) is the locus this lands on"
+  - target: question-agent-communication-broker
+    type: derives
+    note: "cell 2's missing channel is a state-observation channel; the bus question owns where such a report would travel, and finding-027 deliberately stops short of proposing it"
+  - target: question-channel-observation-cost
+    type: supports
+    note: "sibling shape: that node asks what a reading COSTS, this one asks what the state should be derived FROM; both find pane/harness signals answering questions they were not measuring"
+provenance:
+  created_by: agent
+  session: marvel-run-01-truth-table-2026-08-24
+  created_at: "2026-08-24"
+  discovered_from: finding-027-status-truth-table


### PR DESCRIPTION
## Why

Docs only — a finding in `_kos/findings/`, no code change and no fix. It is here because it converts three separately-filed defects into one measured root cause, which is cheaper to act on than three tickets.

#201 (a finished agent reaped as `crashed` and re-paid for) and #203 item 2 (a stuck agent reported `running`) have been filed as separate bugs. This measurement shows they are **one defect in two coats**, and pins the mechanism in a single line:

```
cell 3 (died):      session.crashed  "pane %1 gone"
cell 1 (succeeded): session.crashed  "pane %1 gone"
```

Same event, same signal, opposite underlying truth. Nothing downstream can recover the distinction because it was discarded at the point of observation. The control cell proves the inference mechanism itself is fine — a real death is reported accurately in ~2 seconds — so what fails is that pane liveness is the *only* input.

Commissioned as recon in ArcavenAE/aae-orc#239. Scope was explicitly measurement, not repair: one row per cell, per-cell evidence, no severity ranking, no proposed patch.

## The table

| | **Cell 3 — dies** (control) | **Cell 1 — completes** | **Cell 2 — blocked on dialog** |
|---|---|---|---|
| reported | `failed`/`unhealthy` | `crashed`/`unhealthy` | **`running`**/`unknown` |
| inferred from | pane absence | **pane absence (identical)** | pane presence |
| real process | dead | finished, `exit 0 (end_turn)` | alive, idle at modal prompt, CPU 0.0% |
| real work | never finished | **done** | **never started** |
| spend continued | n/a | **yes, full re-pay** | **no, $0.00** |
| verdict | **truth** | **inverted** | **inverted** |

## The numbers worth having

**`succeeded` never fires.** Grepped the entire event ring across an 8-minute window: zero occurrences. The state is in the documented lifecycle and nothing reaches it.

**Cadence, measured for $0.00** using `/usr/bin/true` as a stand-in one-shot (same reap path, no model): 4 spawns in 8 minutes, backoff `60s → 1m → 3m → 4m` toward the 5-minute ceiling. It does not converge — it settles at ~12 respawns/hour indefinitely.

**Each respawn re-pays in full**, which was the open question in #201. Three cycles of a 7-token prompt, identical `in=3 out=4` each time, three separate charges: `$0.2076 + $0.1377 + $0.1377`. Steady state is **$0.1377/cycle → $1.65/hour → $39.66/day** — and that is the *floor*, for a prompt of seven tokens. Not a cached retry.

**Cell 2 accrues no spend** while hung, which is the one piece of good news in the table.

**`process-alive` cannot catch cell 2**, which closes off the obvious cheap fix: `internal/team/controller.go:636` — "process-alive is handled by ReapDead. Pane exists → healthy." The pane *is* alive. `heartbeat` does not help either, since interactive claude emits none without `context_feed`.

## The requirement, stated without naming an implementation

A session's state needs to derive from what the agent reports about its own work, with pane liveness as a **fallback** rather than the primary signal. Cell 3 shows the fallback is sound; cells 1 and 2 show it is insufficient alone.

Cell 1's `agent.session.ended  exit 0 (end_turn)` already lands on marvel's own ring **2 seconds before the reap** — the information exists and does not reach the state machine. Cell 2's information does not exist in marvel at all. Those are two different sizes of gap and the finding keeps them separate.

## Method, including a false negative I caused

Cell 2's first attempt silently failed: the dialog never fired because **run-01's own `marvel inject "" -e` had permanently set `hasTrustDialogAccepted` for that path**, disarming the gate under test. Marvel reported `running` and the pane sat idle — genuinely idle, not blocked, so the row would have been wrong. Reproduced properly in a directory verified absent from `~/.claude.json` first.

Recorded in the finding because it generalizes: **first-run gates are one-shot per scope, so a prior run can silently disarm what a later run is trying to measure.**

Controls: kill-switch external to marvel (marvel is under test, so it cannot be its own dead-man switch — a detached wall-clock subshell, fired on schedule); cheap-first ordering so only the re-pay question cost money; `capture` on a timer with `ps`/`tmux` as ground truth rather than marvel's own report; positive control before trusting any loop result. No sandbox or mock key exists on this host, so wall-clock was the only available money bound — stated for the record.

Wall-clock ~23 min, spend $0.4830, within the run-01 range.

Not self-merging.

Refs: ArcavenAE/aae-orc#239, #201, #203