### PR TITLE
finding(marvel): event-ring inventory — a well-typed ledger that nothing reads

### DIFF
--- a/_kos/findings/finding-028-event-ring-inventory.md
+++ b/_kos/findings/finding-028-event-ring-inventory.md
@@ -1,0 +1,303 @@
+# finding-028 — event-ring inventory: a well-observed, well-typed ledger that nothing reads
+
+Probe: recon task [A], commissioned in
+[ArcavenAE/aae-orc#242](https://github.com/ArcavenAE/aae-orc/issues/242).
+Operator: Claude (Opus 5), no human at the keyboard.
+Date: 2026-08-25 (13:33Z). **Spend: $0.00.**
+
+Binary: **`marvel 0.1.0-alpha.20260823.211648.2f76ccf`** (brew-installed,
+notarized, `Identifier=com.arcavenae.marvel`, `TeamIdentifier=XBGSVSJPD8`).
+Operator directive as of this task: prefer the signed install over the tree
+build, which is unsigned (`codesign: Internal requirements=none`).
+
+**Comparability with finding-027**, which used the tree build at `0c59baa`:
+the entire delta between that SHA and this binary's `2f76ccf` is one renovate
+commit touching `go.mod`, `go.sum`, `mise.toml` — dependency bumps, zero
+source changes. Verified with `git show --stat` rather than assumed. Prior
+results carry forward.
+
+**Measurement only.** No code changed, no fix proposed, no patch sketched.
+The comms/bus layer is explicitly the conductor's, not this probe's.
+
+Related: finding-027 (the truth table this instruments), ArcavenAE/marvel#201,
+#203.
+
+---
+
+## 1. The headline
+
+Marvel's event vocabulary is **larger and better-typed than expected**, and
+**structurally unable to inform the state machine**. Three separable facts,
+each measured:
+
+1. **35 event kinds**, every one with a live emit site. No dead vocabulary.
+2. **The ring's `Event` struct has no payload field.** Every kind-specific
+   fact survives only as prose in a 160-char `Message` string.
+3. **Nothing reads the ring.** Its single non-test reader serves
+   `marvel events` to a human terminal. No controller, no reconciler, no
+   health evaluator consults it.
+
+The gap finding-027 found is therefore not an observation gap. Marvel *sees*
+the distinction between a completed agent and a dead one. It types it
+correctly upstream, inspects it in passing, renders it to prose, and throws
+the structure away — then never reads the result.
+
+## 2. The ledger
+
+`marvel events --list-kinds`: **23 control-plane + 12 agent-stream = 35.**
+
+### Control plane (23) — what marvel did to a session
+
+| kind | emitted by |
+|---|---|
+| `session.created`, `session.deleted`, `session.crashed` | `internal/session` |
+| `session.restarted`, `session.failed` | `internal/team` |
+| `health.failed` (`KindHealthCheckFailed`), `health.crashloop-backoff` | `internal/team` |
+| `team.shift-started`, `team.shift-completed`, `team.shift-timed-out`, `team.shift-role-ready` | `internal/team` |
+| `role.saturated`, `role.removed` | `internal/team` |
+| `policy.projected` | `internal/session` |
+| `context.limit-unresolved` | `internal/usage` |
+| `admission.refused`, `admission.cleared` | `internal/team` |
+| `admission.unmeasured` | `internal/daemon` |
+| `reconcile.adopted`, `reconcile.killed`, `reconcile.left` | `internal/session` |
+| `heartbeat.refused`, `heartbeat.unbound` | `internal/daemon` |
+
+### Agent stream (12) — what the agent inside a session did
+
+`agent.session.started`, `agent.session.ended`, `agent.turn.started`,
+`agent.turn.completed`, `agent.message.delta`, `agent.message.completed`,
+`agent.tool.call`, `agent.tool.result`, `agent.permission.requested`,
+`agent.auth.required`, `agent.health.heartbeat`, `agent.error`.
+
+All lifted by `internal/session/bridge.go` from the adapter vocabulary in
+`internal/runtime/events`. They fire only for stream-capable launches; an
+interactive pane publishes no stream to parse.
+
+**Checked for dead vocabulary and found none.** Every kind above resolves to
+a non-test emit site. This is a ledger that is actually written.
+
+### The fields — for all 35 kinds, this is the entire set
+
+`internal/events/events.go:227`:
+
+```go
+type Event struct {
+    Seq        uint64    // ring-assigned monotonic, for --follow cursors
+    Timestamp  time.Time
+    Kind       Kind
+    Severity   Severity
+    Workspace  string
+    Team       string
+    Role       string
+    Session    string
+    Actor      string    // "pid=N socket=PATH", for two-daemon disambiguation
+    Generation int64     // when the event's subject is a whole generation
+    Message    string    // one line, capped at 160 chars (maxRingMessage)
+}
+```
+
+**There is no payload field.** Grepped for `Fields`, `Attrs`, `Data`,
+`Detail`, `map[string]` — none present. So exit codes, token counts, costs,
+tool names, pane ids, backoff durations all live in `Message` as prose or not
+at all.
+
+The 160-char cap (`maxRingMessage`) exists so one event renders on one
+terminal line, which tells you what the ring was designed for: **operator
+scanning.** That is a coherent design for a log. It is not one for a signal
+bus, and nothing in the code claims otherwise — the gap is that the state
+machine has no other source.
+
+## 3. The indictment
+
+### 3a. Upstream, the data is properly typed
+
+`internal/runtime/events/events.go` defines ten payload structs:
+`SessionStartedData{Model, Cwd, Resumed, Tools}`,
+**`SessionEndedData{Reason, ExitCode, Usage, Metering}`**, `TurnData`,
+`MessageData`, `ToolCallData`, `ToolResultData{OK}`,
+`PermissionRequestedData`, `AuthRequiredData`, `HealthHeartbeatData`,
+`ErrorData`.
+
+`SessionEndedData.ExitCode` is precisely the field that separates a completed
+one-shot from a death, and its own doc comment says so: *"ExitCode 0 =
+success; non-zero maps to Lift() → INFORM(alert)."* `Metering` carries
+`DurationMS`, `APIDurationMS`, `TTFTMS`, turn counts, cache accounting, and
+per-model breakdown, with an explicit discipline that a harness reporting
+none of it leaves the pointer nil *"so consumers can distinguish 'not
+reported' from 'zero'."*
+
+That is careful, deliberate typing. It reaches the bridge intact.
+
+### 3b. It dies at one assignment
+
+`internal/session/bridge.go:36`:
+
+```go
+return events.Event{
+    Kind: kind, Severity: sev,
+    Workspace: c.Workspace, Team: c.Team, Role: c.Role, Session: c.Session,
+    Message:   summarize(ev),      // <-- typed Data flattened to a string
+}
+```
+
+`summarize()` (`:83`) switches on the payload type and renders it:
+`SessionEndedData` becomes
+`"exit 0 (end_turn) tokens in=3 out=4 cost=$0.2076 turns=1 dur=2500ms ..."`.
+The struct is not stored anywhere. There is no field on `events.Event` that
+could hold it.
+
+**The sharpest detail: the bridge reads `ExitCode` twelve lines earlier and
+uses it for colour.** `ringKind()` at `:48`:
+
+```go
+case rtevents.KindSessionEnded:
+    if d, ok := ev.Data.(rtevents.SessionEndedData); ok && d.ExitCode != 0 {
+        return events.KindAgentSessionEnded, events.SeverityWarning
+    }
+    return events.KindAgentSessionEnded, events.SeverityInfo
+```
+
+So marvel inspects the exact field that answers "did this agent succeed or
+die," uses it to pick `info` vs `warning`, and then discards it. The severity
+is the only surviving trace, and severity is not consulted by the reap path.
+
+### 3c. And the ring is write-only
+
+Read surface: `Ring.Snapshot(Filter, n)` at `events.go:367`. Its only
+non-test caller is `internal/daemon/daemon.go:746`, inside the `events` RPC
+handler, which marshals the snapshot straight to the CLI.
+
+`internal/team/` and `internal/session/` call `Emit` and never read.
+Confirmed by grep across both packages.
+
+**So the path is: adapter → typed payload → prose string → ring → RPC →
+human's terminal.** There is no branch off that path into any decision.
+
+The ring is not a bus that the state machine is failing to use. It is a
+display log, and there is no bus.
+
+## 4. The three outcomes, measured live
+
+One team, two roles, generic adapter, **$0.00**: `/usr/bin/true` (completes
+immediately) and `sleep 3600` killed with `SIGKILL` (dies). Same reap path a
+headless claude one-shot takes — established equivalent in finding-027.
+
+```
+TIME      SEV      KIND             SESSION               MESSAGE
+13:33:20  info     session.created  ring/led-done-g1-0    pane %1
+13:33:20  info     session.created  ring/led-victim-g1-0  pane %2
+13:33:21  warning  session.crashed  ring/led-done-g1-0    pane %1 gone      <- SUCCEEDED
+13:33:37  warning  session.crashed  ring/led-victim-g1-0  pane %2 gone      <- KILLED
+13:33:37  warning  session.failed   ring/led-victim-g1-0  restart_policy=never, pane gone; role frozen
+```
+
+Filtered to the pair, which is the whole finding in two lines:
+
+```
+13:33:21  warning  session.crashed  ring/led-done-g1-0    pane %1 gone
+13:33:37  warning  session.crashed  ring/led-victim-g1-0  pane %2 gone
+```
+
+**Same kind, same severity, same message shape, opposite underlying truth.**
+The only differing field is which pane number vanished.
+
+### The indictment table
+
+| outcome | signal that COULD distinguish it | present on the ring? | reaches the state machine? |
+|---|---|---|---|
+| **completed** | `SessionEndedData.ExitCode=0`, `Reason="end_turn"` | prose in `Message` only; structure dropped at `bridge.go:36` | **no** — read at `:48` for severity, then discarded |
+| **died** | absence of any `agent.session.ended` before the reap | both facts present, but only as **two events needing correlation over time** | **no** — nothing correlates, because nothing reads |
+| **blocked** | nothing fires at all | **absent entirely** | n/a — the information does not exist in marvel |
+
+### The `died` row deserves emphasis
+
+Marvel could distinguish died from completed **today, with no new
+instrumentation**, by asking: *did an `agent.session.ended` arrive for this
+session before its pane vanished?* Both facts are already in the ring,
+already timestamped, already sequenced (`Seq` exists precisely to order
+them).
+
+Nothing joins them — not because the join is hard, but because **no code
+reads the ring at all.** That reframes finding-027's cell-1 gap: it is not
+"wire one field through," it is "there is no reader to wire it to."
+
+### A candidate for `blocked` that I had not seen before
+
+`agent.permission.requested` and `agent.auth.required` both exist, both are
+`warning` severity, and both mean *"the harness is waiting on a human."* So
+the vocabulary for blocked-on-a-human is **already half-built.**
+
+The limit: they fire only for stream-capable launches. An interactive TUI's
+first-run consent dialog — finding-027's cell 2 — publishes no stream, so
+neither fires. But this narrows the gap usefully: the concept exists on the
+side of the fence that has a stream, and cell 2 is the *interactive* case
+specifically, not a general absence of the idea.
+
+## 5. The instrument has no machine interface
+
+#242 frames this ledger as *"the instrument that makes every later metering
+run possible."* As it stands, the instrument is human-only.
+
+`marvel events` flags: `--follow`, `--kind`, `--lines`, `--list-kinds`,
+`--role`, `--session`, `--team`, `--warnings`, `--workspace`. **No
+`--output json`, no `-o`.**
+
+The daemon marshals `Event` structs to JSON over the RPC, then the CLI
+renders them into a fixed-width table. So an external consumer — a
+supervising agent, a metering script, tasks [C]/[D]/[B] of this campaign —
+must scrape padded columns. Fields the ring *does* carry (`Seq`, `Actor`,
+`Generation`) are not all rendered, so they are unreachable from outside the
+daemon without writing a client.
+
+For this campaign's own purposes that is the binding constraint: every later
+task's measurements come out of `grep` against a table, which is how I have
+been counting spawns and costs since run-01.
+
+## 6. What this changes about finding-027's conclusion
+
+finding-027 said the requirement is that state derive from what the agent
+reports, with pane liveness as fallback, and split the work into two gaps:
+cell 1's signal "exists and is unrouted," cell 2's "does not exist."
+
+This inventory **sharpens the first half and confirms the second**:
+
+- Cell 1 is not one unrouted field. It is a **typed payload with no
+  destination and no reader**. Two things are missing: somewhere on
+  `events.Event` to keep structure, and any consumer of the ring at all.
+  Adding `ExitCode` to a prose string would not help, because no code reads
+  the string either.
+- Cell 2 is confirmed absent, with the qualification above: the *concept*
+  ships for streamed sessions (`agent.permission.requested`,
+  `agent.auth.required`); only the interactive path lacks it.
+
+## 7. Method notes
+
+- Every ledger claim is from source (`internal/events`,
+  `internal/runtime/events`, `internal/session/bridge.go`,
+  `internal/daemon/daemon.go`) rather than from what one run happened to
+  emit, so kinds a trivial run never fires are still inventoried.
+- Live cells used the generic adapter deliberately: `/usr/bin/true` and a
+  killed `sleep` traverse the same reap path as a real harness at $0.00,
+  established in finding-027.
+- **The one paid turn I flagged as possible was cancelled.** I had budgeted a
+  trivial headless turn to capture `agent.*` payloads with cost fields
+  populated. Unnecessary: the payload structs are authoritative in source,
+  and finding-027 plus run-01 already recorded real `agent.session.ended`
+  lines with cost, tokens, turns, duration, api time and ttft. Re-observing
+  recorded facts would have been waste.
+- Ground truth for the live cells came from `tmux list-panes`, `ps`, and pane
+  capture, never marvel's rolled-up status.
+- Teardown verified: daemon stopped, no marvel tmux servers, scratch removed.
+
+## 8. Out of scope
+
+No fix, no patch, no proposed schema for a payload field, and specifically no
+comms-layer proposal — the bus is the conductor's. §6's restatement of the
+gap is a measurement consequence, not a design.
+
+**Not produced: the run-registry line** #242 asks for. critic is design-only
+— `charter.md`, `docs/run-marker-schema.md`, analysis prose; no code, no
+table, `critic/_kos` holds zero nodes. Inventing a registry format would
+pre-empt a live design decision (roadmap E1). Flagged on the issue for the
+third time; needs either a concrete interim path or the clause dropped until
+E1 ships.

--- a/_kos/nodes/frontier/question-event-ring-as-signal-bus.yaml
+++ b/_kos/nodes/frontier/question-event-ring-as-signal-bus.yaml
@@ -1,0 +1,149 @@
+id: question-event-ring-as-signal-bus
+type: question
+confidence: frontier
+title: "Should the event ring carry structure and be readable by the control plane, or stay a display log with a separate signal path?"
+tags:
+  - marvel
+  - observability
+  - events
+  - lifecycle
+content: |
+  Marvel's event ring is a well-populated, well-typed ledger that no
+  decision in marvel reads. This node holds the question of whether
+  that is the defect or the design.
+
+  MEASURED 2026-08-25 (finding-028, event-ring inventory, brew binary
+  0.1.0-alpha...2f76ccf; $0.00 spend). Three separable facts:
+
+  1. THE VOCABULARY IS LARGER AND HEALTHIER THAN EXPECTED. 35 kinds
+     (23 control-plane, 12 agent-stream), every one with a live
+     non-test emit site. No dead vocabulary. This is a ledger that is
+     actually written.
+
+  2. THE RING CANNOT HOLD STRUCTURE. `events.Event`
+     (internal/events/events.go:227) has exactly Seq, Timestamp, Kind,
+     Severity, Workspace, Team, Role, Session, Actor, Generation,
+     Message. No payload field — no Fields, Attrs, Data, Detail, or
+     map. Every kind-specific fact (exit code, tokens, cost, tool
+     name, pane id, backoff) survives only as prose inside Message,
+     capped at 160 chars (maxRingMessage) so one event renders on one
+     terminal line.
+
+  3. NOTHING READS IT. The one non-test caller of Ring.Snapshot
+     (events.go:367) is the `events` RPC at daemon.go:746, which
+     marshals to the CLI. internal/team and internal/session call
+     Emit and never read. Path: adapter → typed payload → prose string
+     → ring → RPC → human terminal, with no branch into any decision.
+
+  THE UPSTREAM TYPING IS GOOD, WHICH IS WHAT MAKES THE LOSS SHARP.
+  internal/runtime/events defines ten payload structs.
+  SessionEndedData{Reason, ExitCode, Usage, Metering} is exactly the
+  discrimination finding-027 needed, and its doc comment says so
+  ("ExitCode 0 = success"). Metering even distinguishes "not reported"
+  from "zero" via a nil pointer, deliberately.
+
+  It dies at one assignment, bridge.go:36, `Message: summarize(ev)`.
+  And twelve lines earlier, at :48, the bridge READS ExitCode — to
+  choose info vs warning severity. So marvel inspects the field that
+  answers "succeeded or died," uses it for colour, and discards it.
+  Severity is the only surviving trace and the reap path does not
+  consult severity.
+
+  THE MEASURED PAIR, generic adapter, one team, $0.00:
+
+      13:33:21  warning  session.crashed  ring/led-done-g1-0    pane %1 gone   <- /usr/bin/true, SUCCEEDED
+      13:33:37  warning  session.crashed  ring/led-victim-g1-0  pane %2 gone   <- sleep, SIGKILLED
+
+  Same kind, same severity, same message shape, opposite truth. Only
+  the pane number differs.
+
+  THIS REFRAMES finding-027's CELL-1 GAP. That finding called the
+  completion signal "present but unrouted," which implied wiring one
+  field. The inventory says otherwise: there is nowhere on
+  events.Event to put structure AND no reader to route it to. Adding
+  ExitCode to the prose would change nothing, because no code reads
+  the prose either.
+
+  DIED-VS-COMPLETED IS ALREADY DECIDABLE FROM THE RING AS IT STANDS,
+  which is the most actionable thing here. The question "did an
+  agent.session.ended arrive for this session before its pane
+  vanished?" is answerable from two events that both already exist,
+  both timestamped, both sequenced (Seq exists precisely to order
+  them). Nothing joins them — not because the join is hard, but
+  because nothing reads the ring at all.
+
+  BLOCKED-ON-A-HUMAN IS HALF-BUILT ALREADY. agent.permission.requested
+  and agent.auth.required both exist, both warning severity, both
+  meaning the harness is waiting on a person. They fire only for
+  stream-capable launches, so an interactive TUI's first-run consent
+  dialog (finding-027 cell 2) fires neither. The concept ships on the
+  side of the fence that has a stream; only the interactive path lacks
+  it. That is a narrower gap than "no vocabulary for blocked."
+
+  THE INSTRUMENT HAS NO MACHINE INTERFACE, and this binds the rest of
+  the recon campaign. `marvel events` has no --output json / -o flag
+  (only --follow, --kind, --lines, --list-kinds, --role, --session,
+  --team, --warnings, --workspace). The daemon marshals Event to JSON
+  over the RPC and the CLI renders a fixed-width table, so an external
+  consumer scrapes padded columns, and Seq/Actor/Generation are not
+  all rendered — unreachable from outside without writing a client.
+  Every measurement in this campaign so far has come from grep against
+  that table.
+
+  THE QUESTION, and it is genuinely open rather than rhetorical. The
+  ring's 160-char cap and one-line-per-event discipline are coherent
+  design for operator scanning. A log that is good at being a log is
+  not a bug. So which of these is right:
+
+  (a) The ring grows a typed payload field and gains readers, becoming
+      the control plane's signal path as well as its display log. Risk:
+      one structure serving two consumers with opposite requirements
+      (humans want one scannable line, state machines want complete
+      structure), which is how the Message field came to carry
+      everything in the first place.
+  (b) The ring stays a display log, and state observation gets its own
+      path from adapter to state machine that never round-trips
+      through prose. Risk: two parallel channels emitting from the same
+      call sites, which drift.
+  (c) The adapter's typed events become the primary artifact, with the
+      ring as one subscriber and the state machine as another. Neither
+      derives from the other's rendering.
+
+  Not proposing one. (c) is where the shape of internal/runtime/events
+  already points, since the typed payloads exist before either
+  consumer, but the decision belongs with whoever owns the director/bus
+  boundary — and per the campaign's standing rule, the bus is the
+  conductor's, not this probe's.
+
+  OPEN, beyond the (a)/(b)/(c) choice:
+
+  - Whether a payload field would breach the ring's bounded-memory
+    contract. The ring is fixed-size by design; arbitrary structure per
+    event is unbounded where a 160-char string is not.
+  - Whether non-stream adapters can participate at all. Generic and
+    interactive launches produce no typed payloads, so any
+    structure-carrying design has a permanent second class of session
+    that supplies nothing. This is the same constraint
+    question-session-state-observation raises from the state side.
+  - Whether --output json should exist independently of all of the
+    above. It is a small, separable change that would unblock external
+    metering without touching the ring's shape.
+
+  Provenance note: this node's evidence comes from an agent-operated
+  recon campaign (orc issues #239, #242) rather than a marvel session.
+  Scope was measurement only; no fix or schema was proposed.
+edges:
+  - target: question-session-state-observation
+    type: supports
+    note: "that node asks what state should derive FROM; this one inventories what is already emitted and finds the ledger unreadable, which sharpens its cell-1 gap from 'unrouted field' to 'no destination and no reader'"
+  - target: question-agent-communication-broker
+    type: derives
+    note: "the (a)/(b)/(c) choice is a bus-boundary question; recorded, deliberately not answered, since the comms layer is the conductor's"
+  - target: elem-agentic-resource-matrix
+    type: supports
+    note: "Metering payloads (cost, tokens, ttft, cache accounting) are matrix-row data that reaches a prose string and stops, so enforcement locus 2 has no structured feed today"
+provenance:
+  created_by: agent
+  session: marvel-recon-242-event-ring-2026-08-25
+  created_at: "2026-08-25"
+  discovered_from: finding-028-event-ring-inventory


### PR DESCRIPTION
## Why

Docs only — a finding plus its harvest node, no code change. Recon task [A] from ArcavenAE/aae-orc#242, **$0.00 spend**.

It is worth reading because it **inverts the expected result**. I went looking for a thin, under-instrumented event vocabulary and found the opposite: 35 kinds, every one with a live emit site, and careful typed payloads upstream — `SessionEndedData{Reason, ExitCode, Usage, Metering}`, with `Metering` deliberately using a nil pointer so consumers can tell "not reported" from "zero." The observation layer is in good shape.

The problem is one layer down, and it is structural rather than a missing field:

1. **The ring cannot hold structure.** `events.Event` (`internal/events/events.go:227`) has no payload field — no `Fields`, `Attrs`, `Data`, `Detail`, or map. Every kind-specific fact survives only as prose in `Message`, capped at 160 chars so one event renders on one terminal line.
2. **Nothing reads the ring.** The single non-test caller of `Ring.Snapshot` is the `events` RPC at `daemon.go:746`, serving the CLI. `internal/team` and `internal/session` call `Emit` and never read.

So the path is: adapter → typed payload → prose string → ring → RPC → human terminal, with no branch into any decision.

## The sharpest detail

`bridge.go:36` flattens the typed payload with `Message: summarize(ev)`. Twelve lines earlier, at `:48`, the bridge **reads `ExitCode`** — to choose `info` vs `warning` severity:

```go
case rtevents.KindSessionEnded:
    if d, ok := ev.Data.(rtevents.SessionEndedData); ok && d.ExitCode != 0 {
        return events.KindAgentSessionEnded, events.SeverityWarning
    }
```

Marvel inspects the exact field that answers "did this agent succeed or die," uses it for colour, and discards it. Severity is the only surviving trace, and the reap path does not consult severity.

Measured live, one team, generic adapter, `/usr/bin/true` beside a SIGKILLed `sleep`:

```
13:33:21  warning  session.crashed  ring/led-done-g1-0    pane %1 gone   <- SUCCEEDED
13:33:37  warning  session.crashed  ring/led-victim-g1-0  pane %2 gone   <- KILLED
```

Same kind, same severity, same message shape, opposite truth. Only the pane number differs.

## Two results that make the work smaller than feared

- **died-vs-completed is already decidable from the ring as it stands.** "Did an `agent.session.ended` arrive for this session before its pane vanished?" uses two events that both already exist, both timestamped, both sequenced (`Seq` exists to order them). Nothing joins them — not because the join is hard, but because nothing reads the ring at all.
- **blocked-on-a-human is half-built.** `agent.permission.requested` and `agent.auth.required` both exist, both `warning`, both meaning exactly that. They fire only for stream-capable launches, so an interactive TUI's first-run dialog fires neither. That is a much narrower gap than "no vocabulary for blocked."

This also reframes finding-027's cell-1 gap, which I had described as an unrouted field. It is not: adding `ExitCode` to the prose would change nothing, because no code reads the prose either. There is no destination *and* no reader.

## The node asks the question rather than answering it

`question-event-ring-as-signal-bus` records three options — (a) the ring grows a payload field and gains readers, (b) it stays a display log with a separate signal path, (c) adapter events become primary with the ring and state machine as peer subscribers — and does not pick one. The 160-char one-line-per-event discipline is coherent design for operator scanning; a log that is good at being a log is not a bug. Per the campaign's standing rule the bus is the conductor's, so the choice is recorded, not made.

Open sub-questions carried: whether arbitrary payloads breach the ring's bounded-memory contract; whether non-stream adapters become a permanent second class that supplies nothing; and whether `--output json` should ship independently of all of it.

## One incidental worth flagging for the reviewer

**`marvel events` has no `--output json`.** #242 frames this ledger as "the instrument that makes every later metering run possible," and as it stands the instrument is human-only: the daemon marshals `Event` to JSON over the RPC, then the CLI renders a fixed-width table. External consumers scrape padded columns, and `Seq`/`Actor`/`Generation` are not all rendered. Every measurement in this recon campaign so far has come from `grep` against that table.

## Notes

- Run on the **signed brew binary** `0.1.0-alpha.20260823.211648.2f76ccf` per operator directive (the tree build is unsigned: `codesign: Internal requirements=none`). Comparability with finding-027's `0c59baa` verified rather than assumed — the delta is one renovate commit touching `go.mod`/`go.sum`/`mise.toml`, zero source changes.
- Ledger claims come from source, not from what one run emitted, so kinds a trivial run never fires are still inventoried.
- A paid turn I had budgeted was **cancelled as unnecessary** — the payload structs are authoritative in source and prior findings already recorded real `agent.session.ended` lines with cost and token fields.
- Node hand-checked against `node.schema.yaml` (parse, filename/id match, directory/confidence match, edge-type enum, edge targets exist) because `kos validate` cannot be trusted from a subrepo — ArcavenAE/kos#102: it validates the kos repo's graph and reports success without reading marvel's nodes.

Not self-merging.

Refs: ArcavenAE/aae-orc#242, ArcavenAE/aae-orc#239, #201, #203