### PR TITLE
fix(demo): require a running daemon before the demo acts

### DIFF
--- a/justfile
+++ b/justfile
@@ -72,6 +72,18 @@ _wait-ready:
     echo "marvel daemon did not answer within 10s; see ${HOME}/.marvel/log/daemon.log" >&2
     exit 1
 
+# Fail with the instruction, not a raw dial error, when no daemon is running.
+# The demo acts need a daemon but must NOT start one: a daemon reconciles
+# whatever the durable store already records, spawning live agent sessions
+# (see _store-warn and aae-orc-9uzk). Refuse and point at start-bg instead.
+_require-daemon:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! ./bin/marvel get workspaces >/dev/null 2>&1; then
+        echo "No marvel daemon is running. Start one first:  just start-bg" >&2
+        exit 1
+    fi
+
 # Stop the daemon and clean up all tmux sessions
 stop:
     ./bin/marvel stop --teardown || true
@@ -180,7 +192,7 @@ clean:
 # Each recipe assumes a running daemon (`just start-bg` first).
 
 # Act 1 — Recover: set up the pane-loss recovery team, print the next steps
-demo-act1: build
+demo-act1: build _require-daemon
     @echo "==> Act 1 (Recover). Loading the recovery team..."
     ./bin/marvel work examples/demo-act1-recovery.toml
     @sleep 5
@@ -204,7 +216,7 @@ demo-act1: build
     @echo "  ./bin/marvel events --kind role.removed"
 
 # Act 2 — Observe: run the harness matrix (-p headless + -t TUI), print the event-watch commands
-demo-act2: build
+demo-act2: build _require-daemon
     @echo "==> Act 2 (Observe). Loading the {claude, codex, opencode} matrix + a TUI claude..."
     @echo "    Role names carry the mode: -p = print/headless, -t = TUI (interactive)."
     @echo "    Needs the harness binaries and working auth for the agent stream."
@@ -222,7 +234,7 @@ demo-act2: build
     @echo "  ./bin/marvel get sessions   # -p rows: stream accountant · -t row: statusline feed"
 
 # Act 3 — Control plane: project a policy, then re-project live with no restart
-demo-act3: build
+demo-act3: build _require-daemon
     @echo "==> Act 3 (Control plane). Projecting reviewer-contract v1..."
     @echo "    Needs the claude binary on PATH (auth not required for the projection events)."
     ./bin/marvel work examples/policy-projection.toml


### PR DESCRIPTION
## Why

Running any `just demo-act{1,2,3}` without `just start-bg` first failed with a raw `dial unix ...: connect: no such file or directory` and a full flag dump. That output is actively misleading — it reads as "you passed the command wrong" when the command was fine and the daemon was simply absent. The daemon precondition existed only as a justfile *comment* nobody reads while running a recipe. This turns a confusing failure into an instruction.

## What

- Add a private `_require-daemon` recipe that probes `marvel get workspaces` and, on failure, prints `No marvel daemon is running. Start one first:  just start-bg` and exits 1.
- Add it as a dependency of `demo-act1`, `demo-act2`, `demo-act3` (after `build`, so the binary exists when it runs).

It deliberately does **not** auto-start a daemon: a daemon reconciles whatever the durable store already records, which would silently spawn a previous demo's fleet (the exact hazard `_store-warn` guards, verified in aae-orc-9uzk — one unflagged start produced 20 sessions plus live model calls).

## Verification

- `just --list` parses; `just build` clean.
- Failure path proven deterministically under a daemon-less `HOME`: prints the instruction and exits 1, starting nothing.

The wider fix — teaching `marvel work` itself to recognize a failed connect to the local socket and say so, fixing every entry point at once — is a larger change touching remote-cluster error handling and is left as a separate follow-on, per the ticket.

Refs: aae-orc-9uzk