### PR TITLE
fix(usage): warn when a learned window overrides the operator's manifest

### DIFF
--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -325,9 +325,9 @@ func NewResolver(t Table) *Resolver {
 // TestResolveAgreesWithTheLadder. In short: an in-STREAM declaration
 // outranks the operator override because it is what enforces compaction,
 // while a declaration on the statusline FEED ranks under it because a
-// side channel describes the session rather than governing it. Either one
-// contradicting the manifest is logged once, naming both and naming which
-// won.
+// side channel describes the session rather than governing it. Any rung
+// that contradicts the manifest is logged once, naming both and naming
+// which won.
 func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 	model := req.StreamModel
 	if model == "" {
@@ -347,6 +347,10 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 		w, ok := r.learned[NormalizeModel(model)]
 		r.mu.RUnlock()
 		if ok {
+			if req.ManifestLimit > 0 && req.ManifestLimit != w {
+				r.warnOnce("learned-override:"+model, "context window: %s declared %d for %q in a prior session, overriding the manifest's %d",
+					req.Harness, w, model, req.ManifestLimit)
+			}
 			return w, LimitLearned, model
 		}
 	}

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -1,6 +1,11 @@
 package usage
 
-import "testing"
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
 
 func TestNormalizeModel(t *testing.T) {
 	t.Parallel()
@@ -197,6 +202,67 @@ func TestResolveReadsModelFromArgsWhenStreamNamesNone(t *testing.T) {
 	}
 	if limit != 200_000 || src != LimitFromTable {
 		t.Errorf("limit = %d source = %q, want 200000/table", limit, src)
+	}
+}
+
+// A learned window outranks the operator's manifest (rung 2 over rung 3),
+// the same asymmetry the stream rung has at rung 1. The ordering is not in
+// dispute here; the SILENCE is. Both neighbouring rungs log when they
+// contradict the manifest (stream over manifest, and manifest over feed),
+// so the one rung that can silently beat the operator must say so too.
+// Regression for aae-orc-yfn2 / marvel#181.
+//
+// Not parallel: it redirects the standard logger's output, which is global.
+// Non-parallel tests run to completion before the parallel ones resume, so
+// the redirection is isolated.
+func TestResolveWarnsWhenLearnedContradictsManifest(t *testing.T) {
+	cases := []struct {
+		name          string
+		manifestLimit int
+		learnValue    int
+		wantWarn      bool
+	}{
+		{"learned overrides manifest → warns", 111_111, 222_222, true},
+		{"learned equals manifest → silent", 222_222, 222_222, false},
+		{"no manifest → silent", 0, 222_222, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			restore := log.Writer()
+			log.SetOutput(&buf)
+			defer log.SetOutput(restore)
+
+			r := NewResolver(Table{})
+			r.Learn("claude-haiku-4-5", c.learnValue)
+			limit, src, _ := r.Resolve(Request{
+				Harness:       "claude",
+				StreamModel:   "claude-haiku-4-5",
+				ManifestLimit: c.manifestLimit,
+			})
+
+			// The learned rung still wins — this ticket disputes the
+			// silence, not the ordering.
+			if limit != c.learnValue || src != LimitLearned {
+				t.Fatalf("resolution changed: limit = %d source = %q, want %d/learned", limit, src, c.learnValue)
+			}
+
+			got := buf.String()
+			if c.wantWarn {
+				if got == "" {
+					t.Fatal("learned window overrode the manifest silently; expected a warning naming which won")
+				}
+				// Names both numbers (winner and loser) and the model, in
+				// the shape of the neighbouring stream and feed warnings.
+				for _, want := range []string{"222222", "111111", "claude-haiku-4-5"} {
+					if !strings.Contains(got, want) {
+						t.Errorf("warning %q does not contain %q", got, want)
+					}
+				}
+			} else if got != "" {
+				t.Errorf("expected silence, got warning %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -252,9 +252,10 @@ func TestResolveWarnsWhenLearnedContradictsManifest(t *testing.T) {
 				if got == "" {
 					t.Fatal("learned window overrode the manifest silently; expected a warning naming which won")
 				}
-				// Names both numbers (winner and loser) and the model, in
-				// the shape of the neighbouring stream and feed warnings.
-				for _, want := range []string{"222222", "111111", "claude-haiku-4-5"} {
+				// Names the winner (learned) and the manifest as the value
+				// being overridden — the role, not just the presence, so an
+				// argument swap cannot pass — plus the model.
+				for _, want := range []string{"222222", "overriding the manifest's 111111", "claude-haiku-4-5"} {
 					if !strings.Contains(got, want) {
 						t.Errorf("warning %q does not contain %q", got, want)
 					}


### PR DESCRIPTION
## Why

In `internal/usage/limits.go`, `Resolve` walks the context-window ladder and, at three different rungs, can settle on a window that contradicts the operator's `runtime.context_window`. Two of those rungs say so; one does not.

The learned rung outranks the manifest (rung 2 over rung 3) — deliberate, and documented on `limitLadder`; this PR does **not** dispute that ordering. It disputes the **silence**. Both neighbouring branches `warnOnce` when they overrule the manifest:

- stream over manifest — `"context window: %s declared %d for %q, overriding the manifest's %d"`
- manifest over feed — `"...the manifest's %d wins, because a side channel does not outrank an operator override"`

The learned branch performed no comparison against `ManifestLimit` and logged nothing. So the one rung that can silently beat the operator was the only silent one — and the principle it violates is already written into the message of the branch immediately below it. `#181` carries this as the worse of its two sites (the resolver at rung 2, ahead of the table at rung 5).

Learn is reached today only by `claude` (the sole harness declaring a window in a stream marvel reads), and there is one Resolver per daemon, so the learned rung is fleet-wide across sessions — making the silent override operator-invisible wherever it fires.

## What

One `warnOnce` in the learned branch, guarded on an actual contradiction (`ManifestLimit > 0 && ManifestLimit != w`) exactly like both neighbours, naming both numbers and which won, in the stream branch's shape. Plus a one-line comment fix so `Resolve`'s doc no longer says only "either" of two rungs logs.

- **No** key change, **no** ladder change, **no** reordering. The learned rung still wins; it just says so now.

## Tests

Red/green. New table-driven `TestResolveWarnsWhenLearnedContradictsManifest` in `internal/usage/limits_test.go`:

- learned overrides manifest → a warning fires naming both windows and the model (this subcase failed before the fix, for want of the warning)
- learned equals manifest → silent
- no manifest set → silent

It also asserts the resolution itself is unchanged (learned still wins, `LimitLearned`). The test redirects the standard logger and is deliberately non-parallel so the global redirection stays isolated from the parallel tests.

`go build ./...`, `go vet ./internal/usage/`, `gofmt`, and `go test ./...` all clean.

Refs: #181, aae-orc-yfn2