### PR TITLE
fix(marvel): session-listing / generation-counting join — the read/write-model split

### DIFF
--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -88,6 +89,9 @@ func cloneTeam(t *Team) Team {
 	}
 	if len(t.Shift.Roles) > 0 {
 		out.Shift.Roles = slices.Clone(t.Shift.Roles)
+	}
+	if len(t.Shift.Drained) > 0 {
+		out.Shift.Drained = maps.Clone(t.Shift.Drained)
 	}
 	return out
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -153,6 +153,13 @@ type Session struct {
 	RestartCount    int          `toml:"-"`
 	LastHealthCheck time.Time    `toml:"-"`
 	CreatedAt       time.Time    `toml:"-"`
+	// Reason is a projection-only annotation: empty on every real session
+	// row, filled by the read-path join (team.Controller.ProjectHeldRoleRows)
+	// on the synthetic rows it invents for a role held down with no live
+	// session — e.g. "restart #N, backoff until T". json omitempty keeps it
+	// out of every persisted and real-row payload (so no bolt schema bump),
+	// and toml:"-" keeps it out of manifests. See aae-orc-prhx.
+	Reason string `json:"reason,omitempty" toml:"-"`
 	// HeartbeatToken is the secret marvel mints at spawn and injects into
 	// the session's process environment. It binds a heartbeat to the
 	// session that claims it: the RPC takes a session key off the wire,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -324,6 +324,15 @@ type ShiftState struct {
 	RoleIndex     int      // index into Roles (shift order)
 	Roles         []string // role names in shift order (supervisor last)
 	StartedAt     time.Time
+	// Drained counts, per role name, the old-generation sessions this shift
+	// actually deleted while draining that role. It lets shiftDrain tell a
+	// completed drain (Drained[role] > 0) from advancing through a role
+	// whose old generation was already empty (Drained[role] == 0), which
+	// len(oldGen)==0 alone cannot. Status, not spec — same treatment as the
+	// rest of ShiftState (the whole field is toml:"-" on Team); it persists
+	// to bolt with the shift and resets to nil when the shift clears. See
+	// aae-orc-094e.
+	Drained map[string]int
 }
 
 // Team declares desired state: a cohesive unit of agents with heterogeneous roles.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -845,7 +845,12 @@ func (d *Daemon) handleGet(params json.RawMessage) Response {
 	var result any
 	switch p.ResourceType {
 	case "sessions", "session":
-		result = d.store.ListSessions()
+		// Join the two truths marvel keeps about a role: live session rows
+		// plus synthetic rows for any declared role held down with no live
+		// session (crash-looping in its backoff window). Without the join a
+		// restart_policy=always role is absent from the table for the whole
+		// backoff window rather than shown as held. See aae-orc-prhx.
+		result = append(d.store.ListSessions(), d.teamCtrl.ProjectHeldRoleRows(d.store)...)
 	case "teams", "team":
 		result = d.store.ListTeams()
 	case "workspaces", "workspace":

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -51,8 +51,17 @@ const (
 	// orc finding-018, which had to poll the session table at 50 Hz to
 	// timestamp this instant because the ring did not carry it.
 	KindShiftRoleReady Kind = "team.shift-role-ready"
-	KindRoleSaturated  Kind = "role.saturated"
-	KindRoleRemoved    Kind = "role.removed"
+	// KindShiftDrainedEmpty records that a shift advanced past a role whose
+	// old generation was already empty when draining began — it drained
+	// nothing. An empty old generation is ambiguous: it is both the state
+	// after every predecessor has drained and the state when there was
+	// never anything to drain (a mis-tagged or early-deleted generation, or
+	// an intentional 0→N scale-up). The shift advances either way — this is
+	// surface, not judge — but the event lets an operator or a test tell the
+	// two apart, which len(oldGen)==0 alone could not. See aae-orc-094e.
+	KindShiftDrainedEmpty Kind = "team.shift-drained-empty"
+	KindRoleSaturated     Kind = "role.saturated"
+	KindRoleRemoved       Kind = "role.removed"
 	// KindPolicyProjected records that marvel wrote (or rewrote) a
 	// session's projected Claude Code settings file — the observable
 	// signal of a policy landing at spawn and of live re-projection after
@@ -163,6 +172,7 @@ var allKinds = []Kind{
 	KindShiftCompleted,
 	KindShiftTimedOut,
 	KindShiftRoleReady,
+	KindShiftDrainedEmpty,
 	KindRoleSaturated,
 	KindRoleRemoved,
 	KindPolicyProjected,

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -268,10 +268,11 @@ func (c *Controller) ReconcileOnce() {
 	//
 	// The charge is per role per tick, not per lost replica: see
 	// noteReapedCrash.
-	charged := make(map[string]bool)
+	charged := make(map[string]*reapCharge)
 	for _, r := range c.sessMgr.ReapDead() {
 		c.noteReapedCrash(r, charged)
 	}
+	c.emitReapAccounting(charged)
 	c.evaluateHealth()
 
 	teams := c.store.ListTeams()
@@ -299,7 +300,20 @@ func (c *Controller) ReconcileOnce() {
 // cause-agnostic: bound the blast radius of one event instead of guessing
 // at its cause. Flapping still escalates, because flapping repeats across
 // ticks. See aae-orc-4bz2.
-func (c *Controller) noteReapedCrash(r session.ReapedSession, charged map[string]bool) {
+// reapCharge accumulates one role's crash accounting across a single tick's
+// reap loop, so the tick can emit ONE accounting event per role rather than
+// one per lost replica (or none, as when the accounting was log-only). See
+// emitReapAccounting and aae-orc-m8n0.
+type reapCharge struct {
+	workspace, team, role string
+	suppressed            int       // same-role reaps folded into the one charge
+	saturated             bool      // the charge hit max_restarts (noteCrashAndBackoff == false)
+	restartCount          int       // RestartCount after the charge
+	backoffUntil          time.Time // BackoffUntil after the charge
+	maxRestarts           int
+}
+
+func (c *Controller) noteReapedCrash(r session.ReapedSession, charged map[string]*reapCharge) {
 	t, err := c.store.GetTeam(r.Workspace + "/" + r.Team)
 	if err != nil {
 		return
@@ -339,19 +353,57 @@ func (c *Controller) noteReapedCrash(r session.ReapedSession, charged map[string
 		})
 		return
 	}
-	if charged[roleKey] {
+	if acc, ok := charged[roleKey]; ok {
+		acc.suppressed++
 		log.Printf("reap: session %s crashed with the rest of role %s in one tick; already charged",
 			r.Key, roleKey)
 		return
 	}
-	charged[roleKey] = true
+	acc := &reapCharge{workspace: r.Workspace, team: r.Team, role: r.Role, maxRestarts: role.MaxRestarts}
+	charged[roleKey] = acc
 	if c.noteCrashAndBackoff(r.Workspace, r.Team, r.Role, role.MaxRestarts) {
 		rh := c.roleHealth[roleKey]
+		acc.restartCount = rh.RestartCount
+		acc.backoffUntil = rh.BackoffUntil
 		log.Printf("reap: session %s crashed (role %s restart #%d, next backoff=%s)",
 			r.Key, roleKey, rh.RestartCount, time.Until(rh.BackoffUntil))
 	} else {
+		acc.saturated = true
+		acc.restartCount = c.roleHealth[roleKey].RestartCount
 		log.Printf("reap: session %s crashed but role %s already at max_restarts=%d",
 			r.Key, roleKey, role.MaxRestarts)
+	}
+}
+
+// emitReapAccounting brings the reap path to event parity with the health
+// path: after a tick's reap loop has folded a role's lost replicas into one
+// charge, it emits a single accounting event per charged role so the charge,
+// the suppression count, and the resulting backoff are visible on
+// `marvel events` instead of inferable only from the daemon log (and from
+// the absence of any event at all). No new event kind — it reuses the health
+// path's KindCrashLoopBackoff / KindRoleSaturated. See aae-orc-m8n0.
+func (c *Controller) emitReapAccounting(charged map[string]*reapCharge) {
+	for _, acc := range charged {
+		if acc.saturated {
+			events.Emit(c.Events, events.Event{
+				Kind:      events.KindRoleSaturated,
+				Severity:  events.SeverityWarning,
+				Workspace: acc.workspace,
+				Team:      acc.team,
+				Role:      acc.role,
+				Message:   fmt.Sprintf("max_restarts=%d reached (charged 1, suppressed %d)", acc.maxRestarts, acc.suppressed),
+			})
+			continue
+		}
+		events.Emit(c.Events, events.Event{
+			Kind:      events.KindCrashLoopBackoff,
+			Severity:  events.SeverityWarning,
+			Workspace: acc.workspace,
+			Team:      acc.team,
+			Role:      acc.role,
+			Message: fmt.Sprintf("charged 1, suppressed %d; restart #%d, backoff until %s",
+				acc.suppressed, acc.restartCount, acc.backoffUntil.Format(time.RFC3339)),
+		})
 	}
 }
 

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -1070,12 +1070,20 @@ func (c *Controller) abortStuckShift(t *api.Team) {
 }
 
 func (c *Controller) shiftLaunch(t *api.Team, role *api.Role) {
-	newGen := c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role.Name, t.Generation)
+	// Count only LIVE new-gen rows against the replica count, the same
+	// predicate reconcileRoleAt uses. The store query stays all-states
+	// (three of its five callers depend on that; see nextIndex, shiftDrain,
+	// abortStuckShift), so the live filter belongs at this call site: a
+	// Failed or Crashed successor must not satisfy the launch and suppress
+	// the live replacement that should take its place. See aae-orc-6kgq.
+	live := aliveSessions(c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role.Name, t.Generation))
 	desired := role.Replicas
 
-	if len(newGen) < desired {
-		// Create remaining new-gen sessions.
-		for i := len(newGen); i < desired; i++ {
+	if len(live) < desired {
+		// Create remaining new-gen sessions. nextIndex counts all states,
+		// so a dead row keeps its index and the replacement gets a fresh,
+		// non-colliding one.
+		for i := len(live); i < desired; i++ {
 			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, t.Generation, c.nextIndex(t, role, t.Generation))
 			sess := &api.Session{
 				Name:       name,
@@ -1092,8 +1100,12 @@ func (c *Controller) shiftLaunch(t *api.Team, role *api.Role) {
 		}
 	}
 
-	// All new-gen sessions created — check readiness, then transition to draining.
-	newGen = c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role.Name, t.Generation)
+	// All new-gen sessions created — check readiness, then transition to
+	// draining. Filter to live rows again so a leftover dead row neither
+	// counts toward "launched" nor fails allReady and holds the shift in
+	// launching forever.
+	live = aliveSessions(c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role.Name, t.Generation))
+	newGen := live
 	if len(newGen) >= desired {
 		if c.allReady(newGen, role) {
 			log.Printf("shift: %s/%s role %s — %d new sessions ready, draining old gen %d",
@@ -1139,6 +1151,21 @@ func readinessGate(role *api.Role) string {
 		return "running"
 	}
 	return string(role.HealthCheck.Type)
+}
+
+// aliveSessions returns the subset of sessions the reconciler counts as
+// alive (pending, running, crashloop-backoff), preserving order. It is the
+// shift path's slice-shaped companion to api.CountAlive: shiftLaunch needs
+// both the count and the filtered slice (to feed allReady), so it filters
+// once here rather than counting and filtering separately.
+func aliveSessions(sessions []api.Session) []api.Session {
+	out := make([]api.Session, 0, len(sessions))
+	for i := range sessions {
+		if sessions[i].State.CountsAsAlive() {
+			out = append(out, sessions[i])
+		}
+	}
+	return out
 }
 
 // sessionKeys returns the session keys in order, for event messages.

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -251,12 +251,25 @@ func (c *Controller) SnapshotRoleHealth() map[string]RoleHealth {
 // store lock are never held together. See aae-orc-prhx, aae-orc-83m9.
 func (c *Controller) ProjectHeldRoleRows(store *api.Store) []api.Session {
 	health := c.SnapshotRoleHealth()
+	now := c.nowUTC()
 	var out []api.Session
 	for _, t := range store.ListTeams() {
 		for i := range t.Roles {
 			role := &t.Roles[i]
 			rh, ok := health[t.Workspace+"/"+t.Name+"/"+role.Name]
 			if !ok {
+				continue
+			}
+			// Only a role still inside its backoff window is genuinely held
+			// down. RestartCount does not decay until fv3h, so a recovered
+			// role can carry stale RoleHealth with an elapsed backoff; a
+			// benign dip below replicas (mid-spawn, scale-up) must not
+			// synthesize a crashloop-backoff row with a past deadline. The
+			// saturation sentinel is far in the future, so a frozen role that
+			// somehow presented a gap still reads as held. During real
+			// backoff the row is deleted and BackoffUntil is in the future,
+			// so nothing legitimate is hidden.
+			if !rh.BackoffUntil.After(now) {
 				continue
 			}
 			// Row count across any state and any generation: a Failed or
@@ -386,8 +399,9 @@ func (c *Controller) ReconcileOnce() {
 // emitReapAccounting and aae-orc-m8n0.
 type reapCharge struct {
 	workspace, team, role string
-	suppressed            int       // same-role reaps folded into the one charge
-	saturated             bool      // the charge hit max_restarts (noteCrashAndBackoff == false)
+	charges               int       // reaps that actually charged (0 or 1: only the first non-saturated reap charges)
+	suppressed            int       // reaps NOT charged — folded into the one charge, or refused because the role was already saturated
+	saturated             bool      // the charge attempt hit max_restarts (noteCrashAndBackoff == false)
 	restartCount          int       // RestartCount after the charge
 	backoffUntil          time.Time // BackoffUntil after the charge
 	maxRestarts           int
@@ -443,12 +457,17 @@ func (c *Controller) noteReapedCrash(r session.ReapedSession, charged map[string
 	charged[roleKey] = acc
 	if c.noteCrashAndBackoff(r.Workspace, r.Team, r.Role, role.MaxRestarts) {
 		rh := c.roleHealth[roleKey]
+		acc.charges = 1
 		acc.restartCount = rh.RestartCount
 		acc.backoffUntil = rh.BackoffUntil
 		log.Printf("reap: session %s crashed (role %s restart #%d, next backoff=%s)",
 			r.Key, roleKey, rh.RestartCount, time.Until(rh.BackoffUntil))
 	} else {
+		// Saturated: this reap charged nothing (RestartCount unchanged). It
+		// still counts as a non-charged reap so charges+suppressed equals the
+		// tick's total reaps for the role.
 		acc.saturated = true
+		acc.suppressed = 1
 		acc.restartCount = c.roleHealth[roleKey].RestartCount
 		log.Printf("reap: session %s crashed but role %s already at max_restarts=%d",
 			r.Key, roleKey, role.MaxRestarts)
@@ -471,7 +490,7 @@ func (c *Controller) emitReapAccounting(charged map[string]*reapCharge) {
 				Workspace: acc.workspace,
 				Team:      acc.team,
 				Role:      acc.role,
-				Message:   fmt.Sprintf("max_restarts=%d reached (charged 1, suppressed %d)", acc.maxRestarts, acc.suppressed),
+				Message:   fmt.Sprintf("max_restarts=%d reached (charged %d, suppressed %d)", acc.maxRestarts, acc.charges, acc.suppressed),
 			})
 			continue
 		}
@@ -481,8 +500,8 @@ func (c *Controller) emitReapAccounting(charged map[string]*reapCharge) {
 			Workspace: acc.workspace,
 			Team:      acc.team,
 			Role:      acc.role,
-			Message: fmt.Sprintf("charged 1, suppressed %d; restart #%d, backoff until %s",
-				acc.suppressed, acc.restartCount, acc.backoffUntil.Format(time.RFC3339)),
+			Message: fmt.Sprintf("charged %d, suppressed %d; restart #%d, backoff until %s",
+				acc.charges, acc.suppressed, acc.restartCount, acc.backoffUntil.Format(time.RFC3339)),
 		})
 	}
 }
@@ -1380,6 +1399,9 @@ func (c *Controller) shiftDrain(t *api.Team, role *api.Role) {
 		log.Printf("shift: drain session %s: %v", sess.Key(), err)
 		return
 	}
+	// Persist the drain progress through the store — the empty-generation
+	// branch reads it from a fresh snapshot on a later tick, so mutating this
+	// tick's discarded snapshot would be a dead write.
 	_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
 		if live.Shift.Drained == nil {
 			live.Shift.Drained = make(map[string]int)
@@ -1387,10 +1409,6 @@ func (c *Controller) shiftDrain(t *api.Team, role *api.Role) {
 		live.Shift.Drained[role.Name]++
 		return nil
 	})
-	if t.Shift.Drained == nil {
-		t.Shift.Drained = make(map[string]int)
-	}
-	t.Shift.Drained[role.Name]++
 }
 
 // nextIndex finds the next available index for a role's sessions within a generation.

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -213,6 +213,86 @@ func (c *Controller) RoleHealthSnapshot(workspace, team, role string) (*RoleHeal
 	}, true
 }
 
+// SnapshotRoleHealth returns a value copy of every role's crash-loop state,
+// keyed workspace/team/role. RoleHealth is flat (ints and timestamps), so a
+// struct copy is a full deep copy; the result is decoupled from the live map
+// and safe to read without holding c.mu (go.md rule 12).
+func (c *Controller) SnapshotRoleHealth() map[string]RoleHealth {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]RoleHealth, len(c.roleHealth))
+	for k, rh := range c.roleHealth {
+		out[k] = *rh
+	}
+	return out
+}
+
+// ProjectHeldRoleRows joins the two truths marvel keeps about a role — its
+// live session rows (store.sessions) and its crash-loop state (RoleHealth) —
+// into the synthetic rows `get sessions` needs so a held-down role reads as
+// held rather than absent. restartSession deletes a crash-looping session's
+// row before setting the backoff, so a single-replica restart_policy=always
+// role is missing from the session table for the whole (growing) backoff
+// window; the absence is indistinguishable from "never declared" or
+// "deleted".
+//
+// For each declared role whose live row count is below its replica count AND
+// whose gap RoleHealth explains, it returns Replicas-rowCount synthetic rows
+// carrying the derived crash-loop state. Roles at or above their replica
+// count get nothing — a saturated or restart_policy=never role keeps its
+// terminal SessionFailed row, which is why aae-orc-83m9's "saturated role is
+// absent" premise is refuted here: that row never left. A gap with no
+// RoleHealth also gets nothing — that is a mid-flight spawn the reconciler
+// is about to fill, and inventing a row there would be noise.
+//
+// This is read-model composition only: the reconciler, its counting, its
+// tests, and RoleHealth persistence are untouched. SnapshotRoleHealth is
+// taken under c.mu and released before the store reads, so c.mu and the
+// store lock are never held together. See aae-orc-prhx, aae-orc-83m9.
+func (c *Controller) ProjectHeldRoleRows(store *api.Store) []api.Session {
+	health := c.SnapshotRoleHealth()
+	var out []api.Session
+	for _, t := range store.ListTeams() {
+		for i := range t.Roles {
+			role := &t.Roles[i]
+			rh, ok := health[t.Workspace+"/"+t.Name+"/"+role.Name]
+			if !ok {
+				continue
+			}
+			// Row count across any state and any generation: a Failed or
+			// Crashed row IS representation the operator sees, so a role
+			// that kept one is not synthesized.
+			rowCount := len(store.ListSessionsByTeamRole(t.Workspace, t.Name, role.Name))
+			gap := role.Replicas - rowCount
+			if gap <= 0 {
+				continue
+			}
+			reason := fmt.Sprintf("restart #%d, backoff until %s", rh.RestartCount, rh.BackoffUntil.Format(time.RFC3339))
+			for n := 0; n < gap; n++ {
+				out = append(out, api.Session{
+					Name:       fmt.Sprintf("%s-%s-g%d-held-%d", t.Name, role.Name, t.Generation, n),
+					Workspace:  t.Workspace,
+					Team:       t.Name,
+					Role:       role.Name,
+					Generation: t.Generation,
+					// Only case that fires: a role cooling down inside its
+					// backoff window. Saturated / restart_policy=never roles
+					// keep their real SessionFailed row (rowCount==Replicas)
+					// and are never synthesized. Any gap that reaches here is
+					// rendered crashloop-backoff rather than a new
+					// SessionState the reconciler's CountsAsAlive does not
+					// know; frozen/saturated enrichment rides Reason, not the
+					// enum. See §2.2 of the listing-join design.
+					State:        api.SessionCrashLoopBackOff,
+					RestartCount: rh.RestartCount,
+					Reason:       reason,
+				})
+			}
+		}
+	}
+	return out
+}
+
 // ClearRoleHealthForTeam deletes crash-loop state for every role under
 // the given (workspace, team). Called from the cascade delete path in
 // daemon.handleDelete so that a subsequent re-apply of the same manifest

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -1257,8 +1257,27 @@ func (c *Controller) shiftDrain(t *api.Team, role *api.Role) {
 	oldGen := c.store.ListSessionsByTeamRoleGeneration(t.Workspace, t.Name, role.Name, t.Shift.OldGeneration)
 
 	if len(oldGen) == 0 {
-		// All old-gen drained for this role — advance to next role.
-		log.Printf("shift: %s/%s role %s — old gen drained", t.Workspace, t.Name, role.Name)
+		// Old generation empty — advance to the next role. Drained tells a
+		// completed drain from an advance through a role nothing was ever
+		// moved for; both advance, but the empty-and-undrained case earns a
+		// distinct event so it is not silently indistinguishable from a real
+		// drain. See aae-orc-094e.
+		if t.Shift.Drained[role.Name] > 0 {
+			log.Printf("shift: %s/%s role %s — old gen drained (%d session(s))",
+				t.Workspace, t.Name, role.Name, t.Shift.Drained[role.Name])
+		} else {
+			log.Printf("shift: %s/%s role %s — old gen empty, nothing drained; advancing",
+				t.Workspace, t.Name, role.Name)
+			events.Emit(c.Events, events.Event{
+				Kind:       events.KindShiftDrainedEmpty,
+				Severity:   events.SeverityWarning,
+				Workspace:  t.Workspace,
+				Team:       t.Name,
+				Role:       role.Name,
+				Generation: t.Shift.OldGeneration,
+				Message:    fmt.Sprintf("old gen %d for role %s was empty, nothing drained", t.Shift.OldGeneration, role.Name),
+			})
+		}
 		_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
 			live.Shift.RoleIndex++
 			if live.Shift.RoleIndex < len(live.Shift.Roles) {
@@ -1273,11 +1292,25 @@ func (c *Controller) shiftDrain(t *api.Team, role *api.Role) {
 		return
 	}
 
-	// Rolling drain: delete one old-gen session per reconcile tick.
+	// Rolling drain: delete one old-gen session per reconcile tick, and
+	// record the progress so the empty-generation branch above can tell a
+	// finished drain from one that never moved anything.
 	sess := oldGen[0]
 	if err := c.sessMgr.Delete(sess.Key()); err != nil {
 		log.Printf("shift: drain session %s: %v", sess.Key(), err)
+		return
 	}
+	_ = c.store.UpdateTeam(t.Key(), func(live *api.Team) error {
+		if live.Shift.Drained == nil {
+			live.Shift.Drained = make(map[string]int)
+		}
+		live.Shift.Drained[role.Name]++
+		return nil
+	})
+	if t.Shift.Drained == nil {
+		t.Shift.Drained = make(map[string]int)
+	}
+	t.Shift.Drained[role.Name]++
 }
 
 // nextIndex finds the next available index for a role's sessions within a generation.

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -2497,3 +2497,55 @@ func TestReapAccountingEmitsOneEventPerRolePerTick(t *testing.T) {
 		t.Errorf("message %q does not report charged 1 / suppressed 2", ev.Message)
 	}
 }
+
+// TestShiftDrainEmptyOldGenerationEmitsDistinctEvent is aae-orc-094e.
+// shiftDrain read an empty old generation as a successful drain and advanced
+// silently, unable to tell "finished draining N sessions" from "advanced
+// through a role it never moved" (a mis-tag, an early delete, or an
+// intentional scale-up). A per-role drained counter distinguishes the two:
+// when the shift reaches an empty old generation having drained nothing, it
+// emits KindShiftDrainedEmpty and still advances.
+func TestShiftDrainEmptyOldGenerationEmitsDistinctEvent(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+
+	createTeamFixture(t, store, "test-094e", "squad", []api.Role{
+		{Name: "worker", Replicas: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+	teamKey := "test-094e/squad"
+
+	// A shift already draining worker, with zero old-generation rows: the
+	// old generation is empty from the start, so nothing is drained.
+	if err := store.UpdateTeam(teamKey, func(live *api.Team) error {
+		live.Generation = 2
+		live.Shift = api.ShiftState{
+			Phase:         api.ShiftDraining,
+			OldGeneration: 1,
+			Roles:         []string{"worker"},
+			RoleIndex:     0,
+			StartedAt:     time.Now().UTC(),
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed draining shift: %v", err)
+	}
+
+	team, _ := store.GetTeam(teamKey)
+	ctrl.reconcileShift(&team)
+
+	evs := ring.Snapshot(events.Filter{Kind: events.KindShiftDrainedEmpty}, 0)
+	if len(evs) != 1 {
+		t.Fatalf("KindShiftDrainedEmpty events = %d, want 1: the shift advanced through a role it never drained", len(evs))
+	}
+	if evs[0].Role != "worker" || evs[0].Workspace != "test-094e" || evs[0].Team != "squad" {
+		t.Errorf("event scope = %s/%s role %s, want test-094e/squad role worker", evs[0].Workspace, evs[0].Team, evs[0].Role)
+	}
+
+	// Surface, don't judge: the shift still advances past the role.
+	got, _ := store.GetTeam(teamKey)
+	if got.Shift.RoleIndex != 1 {
+		t.Errorf("RoleIndex = %d, want 1 (the shift must still advance)", got.Shift.RoleIndex)
+	}
+}

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -2498,6 +2498,59 @@ func TestReapAccountingEmitsOneEventPerRolePerTick(t *testing.T) {
 	}
 }
 
+// TestReapAccountingSaturatedTickReportsZeroCharge is the accuracy half of
+// aae-orc-m8n0. A tick that reaps an already-saturated role charges NOTHING —
+// noteCrashAndBackoff returns early without incrementing RestartCount — so the
+// KindRoleSaturated accounting event must report charged 0, not a hardcoded 1.
+// A crash-accounting fix whose number is wrong defeats its own purpose.
+func TestReapAccountingSaturatedTickReportsZeroCharge(t *testing.T) {
+	skipIfNoTmux(t)
+	store, sessMgr, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	sessMgr.Events = ring
+
+	clock := newTestClock(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	ws := "test-m8n0-sat"
+	createTeamFixture(t, store, ws, "squad", []api.Role{
+		{Name: "worker", Replicas: 1, RestartPolicy: api.RestartAlways, MaxRestarts: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+
+	// Cycle 1 consumes the single restart (RestartCount 0 → 1 = MaxRestarts).
+	ctrl.ReconcileOnce()
+	got := store.ListSessionsByTeamRole(ws, "squad", "worker")
+	if len(got) == 0 {
+		t.Fatal("expected a running session before cycle 1")
+	}
+	killPaneAndWait(t, got[0].PaneID)
+	ctrl.ReconcileOnce() // reap → charges 1
+	clock.Advance(10 * time.Minute)
+
+	// Cycle 2: respawn, kill, reap → the role is at MaxRestarts, so this tick
+	// saturates and charges nothing.
+	ctrl.ReconcileOnce()
+	got = store.ListSessionsByTeamRole(ws, "squad", "worker")
+	if len(got) == 0 {
+		t.Fatal("expected a respawned session before the saturating cycle")
+	}
+	killPaneAndWait(t, got[0].PaneID)
+	ctrl.ReconcileOnce() // reap → saturates, charges 0
+
+	sat := ring.Snapshot(events.Filter{Kind: events.KindRoleSaturated}, 0)
+	if len(sat) != 1 {
+		t.Fatalf("KindRoleSaturated accounting events = %d, want 1", len(sat))
+	}
+	if !strings.Contains(sat[0].Message, "charged 0") {
+		t.Errorf("saturated accounting message %q must report charged 0 (the tick charged nothing)", sat[0].Message)
+	}
+	if strings.Contains(sat[0].Message, "charged 1") {
+		t.Errorf("saturated accounting message %q reports charged 1, but a saturated tick charges nothing", sat[0].Message)
+	}
+}
+
 // TestShiftDrainEmptyOldGenerationEmitsDistinctEvent is aae-orc-094e.
 // shiftDrain read an empty old generation as a successful drain and advanced
 // silently, unable to tell "finished draining N sessions" from "advanced
@@ -2611,5 +2664,47 @@ func TestProjectHeldRoleRowsSynthesizesCrashloopRow(t *testing.T) {
 	}
 	if !strings.Contains(w[0].Reason, "backoff until") {
 		t.Errorf("worker synthetic Reason = %q, want it to carry the backoff-until deadline", w[0].Reason)
+	}
+}
+
+// TestProjectHeldRoleRowsSkipsRecoveredRoleWithPastBackoff guards the
+// synthesis gate. RestartCount does not decay until fv3h, so a recovered role
+// can carry stale RoleHealth with a backoff window already in the past. If it
+// dips below replicas for a benign reason (mid-spawn, scale-up), synthesizing
+// a crashloop-backoff row with a past "backoff until" would be a lie. Only a
+// role whose backoff is still in the future is genuinely held down.
+func TestProjectHeldRoleRowsSkipsRecoveredRoleWithPastBackoff(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-prhx-past", "squad", []api.Role{
+		{Name: "recovered", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+		{Name: "held", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+
+	// recovered: stale RoleHealth, backoff already elapsed, transiently below
+	// replicas → must NOT be synthesized.
+	rec := ctrl.getRoleHealth("test-prhx-past/squad/recovered")
+	rec.RestartCount = 3
+	rec.BackoffUntil = clock.Now().Add(-30 * time.Second)
+
+	// held: genuinely cooling down, backoff in the future → still synthesized.
+	held := ctrl.getRoleHealth("test-prhx-past/squad/held")
+	held.RestartCount = 2
+	held.BackoffUntil = clock.Now().Add(45 * time.Second)
+
+	rows := ctrl.ProjectHeldRoleRows(store)
+
+	byRole := map[string][]api.Session{}
+	for _, r := range rows {
+		byRole[r.Role] = append(byRole[r.Role], r)
+	}
+	if len(byRole["recovered"]) != 0 {
+		t.Errorf("recovered synthesized %d row(s), want 0 (its backoff is in the past — not held down)", len(byRole["recovered"]))
+	}
+	if len(byRole["held"]) != 1 {
+		t.Errorf("held synthesized %d row(s), want 1 (backoff in the future — genuinely held down)", len(byRole["held"]))
 	}
 }

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -2549,3 +2549,67 @@ func TestShiftDrainEmptyOldGenerationEmitsDistinctEvent(t *testing.T) {
 		t.Errorf("RoleIndex = %d, want 1 (the shift must still advance)", got.Shift.RoleIndex)
 	}
 }
+
+// TestProjectHeldRoleRowsSynthesizesCrashloopRow is aae-orc-prhx (and closes
+// aae-orc-83m9). A single-replica restart_policy=always role crash-looping in
+// its backoff window has no live session row — restartSession deletes it
+// before setting the backoff — so it is absent from get sessions for the
+// whole window and reads as never-declared. The read-path join synthesizes a
+// crashloop-backoff row for such a held-down role, while roles that keep a
+// real row (saturated/frozen) and gaps RoleHealth cannot explain get nothing.
+func TestProjectHeldRoleRowsSynthesizesCrashloopRow(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-prhx", "squad", []api.Role{
+		{Name: "worker", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+		{Name: "boss", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+		{Name: "runner", Replicas: 1, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+
+	// worker: crash-looping, in its backoff window, zero live rows → held.
+	rh := ctrl.getRoleHealth("test-prhx/squad/worker")
+	rh.RestartCount = 2
+	rh.BackoffUntil = clock.Now().Add(90 * time.Second)
+
+	// boss: has RoleHealth but keeps a real (failed) row → representation
+	// already present, must NOT be synthesized (the 83m9 saturated case).
+	bh := ctrl.getRoleHealth("test-prhx/squad/boss")
+	bh.RestartCount = 1
+	bh.BackoffUntil = saturationFreezeUntil
+	seedSession(t, store, api.Session{Name: "squad-boss-g1-0", Workspace: "test-prhx", Team: "squad", Role: "boss", Generation: 1, State: api.SessionFailed})
+
+	// runner: below replicas with NO RoleHealth → a mid-flight spawn gap,
+	// must NOT be synthesized.
+
+	rows := ctrl.ProjectHeldRoleRows(store)
+
+	byRole := map[string][]api.Session{}
+	for _, r := range rows {
+		byRole[r.Role] = append(byRole[r.Role], r)
+	}
+	if len(byRole["boss"]) != 0 {
+		t.Errorf("boss synthesized %d row(s), want 0 (it keeps its real failed row)", len(byRole["boss"]))
+	}
+	if len(byRole["runner"]) != 0 {
+		t.Errorf("runner synthesized %d row(s), want 0 (unexplained gap, reconciler will fill)", len(byRole["runner"]))
+	}
+	w := byRole["worker"]
+	if len(w) != 1 {
+		t.Fatalf("worker synthesized %d row(s), want 1 (held down in backoff, no live row)", len(w))
+	}
+	if w[0].State != api.SessionCrashLoopBackOff {
+		t.Errorf("worker synthetic state = %s, want %s", w[0].State, api.SessionCrashLoopBackOff)
+	}
+	if w[0].Workspace != "test-prhx" || w[0].Team != "squad" {
+		t.Errorf("worker synthetic scope = %s/%s, want test-prhx/squad", w[0].Workspace, w[0].Team)
+	}
+	if w[0].RestartCount != 2 {
+		t.Errorf("worker synthetic RestartCount = %d, want 2", w[0].RestartCount)
+	}
+	if !strings.Contains(w[0].Reason, "backoff until") {
+		t.Errorf("worker synthetic Reason = %q, want it to carry the backoff-until deadline", w[0].Reason)
+	}
+}

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -2341,3 +2341,103 @@ func TestShiftRepairBeforeTurnDoesNotCountAsLaunch(t *testing.T) {
 		}
 	}
 }
+
+// seedSession inserts a session directly into the store without spawning a
+// tmux pane. PaneID stays empty, so ReapDead skips it (it treats an empty
+// pane as "already reaped or never had one") and evaluateHealth skips it
+// unless it is Running. This lets a counting test construct a precise mix of
+// live and terminal new-generation rows without racing the session
+// lifecycle. Runtime and CreatedAt default to a sleeper / now when unset.
+func seedSession(t *testing.T, store *api.Store, s api.Session) {
+	t.Helper()
+	if s.Runtime.Command == "" {
+		s.Runtime = api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}
+	}
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = time.Now().UTC()
+	}
+	if err := store.CreateSession(&s); err != nil {
+		t.Fatalf("seed session %s: %v", s.Key(), err)
+	}
+}
+
+// enterLaunchingShift puts an already-created team into a shift's launching
+// phase over a single role, as InitiateShift would, but without driving the
+// reconciler — the counting tests seed the generation rows themselves.
+func enterLaunchingShift(t *testing.T, store *api.Store, teamKey, role string) {
+	t.Helper()
+	if err := store.UpdateTeam(teamKey, func(live *api.Team) error {
+		live.Generation = 2
+		live.Shift = api.ShiftState{
+			Phase:         api.ShiftLaunching,
+			OldGeneration: 1,
+			Roles:         []string{role},
+			RoleIndex:     0,
+			StartedAt:     time.Now().UTC(),
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("enter launching shift: %v", err)
+	}
+}
+
+// TestShiftLaunchDoesNotCountFailedNewGenTowardLaunch is the create-gate half
+// of aae-orc-6kgq. shiftLaunch counted new-generation rows in any state
+// against the replica count, so a Failed successor satisfied the launch and
+// suppressed the live replacement that should have taken its place. The gate
+// must count only live rows (api.SessionState.CountsAsAlive), exactly as
+// reconcileRoleAt already does on the non-generation query.
+func TestShiftLaunchDoesNotCountFailedNewGenTowardLaunch(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	createTeamFixture(t, store, "test-6kgq-create", "squad", []api.Role{
+		{Name: "worker", Replicas: 1, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+	teamKey := "test-6kgq-create/squad"
+
+	// A single dead new-generation row, no live successor. Before the fix
+	// len(newGen)==1 satisfies replicas=1 and nothing is spawned.
+	enterLaunchingShift(t, store, teamKey, "worker")
+	seedSession(t, store, api.Session{Name: "squad-worker-g2-0", Workspace: "test-6kgq-create", Team: "squad", Role: "worker", Generation: 2, State: api.SessionFailed})
+
+	ctrl.ReconcileOnce()
+
+	gen2 := store.ListSessionsByTeamRoleGeneration("test-6kgq-create", "squad", "worker", 2)
+	if api.CountAlive(gen2) < 1 {
+		t.Fatalf("no live gen-2 successor spawned: the Failed row suppressed the replacement (alive=%d of %d rows)",
+			api.CountAlive(gen2), len(gen2))
+	}
+}
+
+// TestShiftLaunchDeadNewGenRowDoesNotBlockDrainGate is the ready-gate half of
+// aae-orc-6kgq. With the live successors already at replica count, a leftover
+// dead new-generation row must not keep the launch from advancing to drain.
+// Feeding allReady the unfiltered slice let the Failed row fail the readiness
+// check and hold the shift in launching forever.
+func TestShiftLaunchDeadNewGenRowDoesNotBlockDrainGate(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	createTeamFixture(t, store, "test-6kgq-drain", "squad", []api.Role{
+		{Name: "worker", Replicas: 2, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+	teamKey := "test-6kgq-drain/squad"
+
+	enterLaunchingShift(t, store, teamKey, "worker")
+	// Two live successors satisfy replicas=2; one extra dead row must not
+	// block the gate.
+	seedSession(t, store, api.Session{Name: "squad-worker-g2-0", Workspace: "test-6kgq-drain", Team: "squad", Role: "worker", Generation: 2, State: api.SessionRunning})
+	seedSession(t, store, api.Session{Name: "squad-worker-g2-1", Workspace: "test-6kgq-drain", Team: "squad", Role: "worker", Generation: 2, State: api.SessionRunning})
+	seedSession(t, store, api.Session{Name: "squad-worker-g2-2", Workspace: "test-6kgq-drain", Team: "squad", Role: "worker", Generation: 2, State: api.SessionFailed})
+
+	ctrl.ReconcileOnce()
+
+	team, _ := store.GetTeam(teamKey)
+	if team.Shift.Phase != api.ShiftDraining {
+		t.Fatalf("phase = %s, want draining: two live successors are ready, the dead row must not block the gate",
+			team.Shift.Phase)
+	}
+}

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -2441,3 +2441,59 @@ func TestShiftLaunchDeadNewGenRowDoesNotBlockDrainGate(t *testing.T) {
 			team.Shift.Phase)
 	}
 }
+
+// TestReapAccountingEmitsOneEventPerRolePerTick is aae-orc-m8n0. The reap
+// path charges a role once per tick however many replicas it lost, but that
+// accounting was log-only: killing a three-replica role's tmux session put
+// three session.crashed on the ring and nothing explaining that they were
+// charged once, suppressed twice, and cooled into a backoff window. The reap
+// path must reach event parity with the health path — one KindCrashLoopBackoff
+// per charged role per tick, carrying the charge/suppress counts.
+func TestReapAccountingEmitsOneEventPerRolePerTick(t *testing.T) {
+	skipIfNoTmux(t)
+	store, sessMgr, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+	// Both producers share one ring, as the daemon wires them: ReapDead
+	// emits session.crashed through the manager, the accounting through the
+	// controller.
+	ring := events.NewRing(0)
+	ctrl.Events = ring
+	sessMgr.Events = ring
+
+	clock := newTestClock(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	ws := "test-m8n0"
+	createTeamFixture(t, store, ws, "squad", []api.Role{
+		{Name: "worker", Replicas: 3, RestartPolicy: api.RestartAlways, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}},
+	})
+
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRole(ws, "squad", "worker")); got != 3 {
+		t.Fatalf("expected 3 sessions, got %d", got)
+	}
+
+	// Take all three panes down together, then reap them in one tick.
+	killWorkspaceAndWait(t, ws)
+	ctrl.ReconcileOnce()
+
+	crashed := ring.Snapshot(events.Filter{Kind: events.KindSessionCrashed}, 0)
+	if len(crashed) != 3 {
+		t.Fatalf("session.crashed events = %d, want 3 (one per lost replica)", len(crashed))
+	}
+
+	accounting := ring.Snapshot(events.Filter{Kind: events.KindCrashLoopBackoff}, 0)
+	if len(accounting) != 1 {
+		t.Fatalf("crash-accounting events = %d, want exactly 1 for the role (charged once, suppressed twice)", len(accounting))
+	}
+	ev := accounting[0]
+	if ev.Workspace != ws || ev.Team != "squad" || ev.Role != "worker" {
+		t.Errorf("event scope = %s/%s role %s, want %s/squad role worker", ev.Workspace, ev.Team, ev.Role, ws)
+	}
+	if ev.Severity != events.SeverityWarning {
+		t.Errorf("severity = %s, want %s", ev.Severity, events.SeverityWarning)
+	}
+	if !strings.Contains(ev.Message, "charged 1") || !strings.Contains(ev.Message, "suppressed 2") {
+		t.Errorf("message %q does not report charged 1 / suppressed 2", ev.Message)
+	}
+}


### PR DESCRIPTION
## Why

marvel keeps **two** truths about a role — its live session rows (`store.sessions`) and its crash-loop state (`RoleHealth`) — and a cluster of five bugs are each a place where one truth is read as if it were the other, or where the query spanning them is quietly asked to mean two things at once. Failed successors count as launched and flip a role to draining having launched nothing that works; a role crash-looping under `restart_policy=always` vanishes from `get sessions` for the whole (growing) backoff window; a drain reports success over a generation it never moved; and the reap path charges a crash once per tick but says so only in the daemon log, so the event stream shows three crashes and no accounting. This is the architectural spine of that cluster: fixed as **one** coherent change because the load-bearing decision is invisible from inside any single ticket.

That decision: **do not change the meaning of `ListSessionsByTeamRoleGeneration`.** Three of its five callers (`nextIndex` index reservation, `shiftDrain` pane cleanup, `abortStuckShift` rollback) correctly want *all* states; only `shiftLaunch`'s two count sites want *live*. The "obvious" per-ticket fix — add a `State` predicate to the shared store query — would silently break the other three (drain declaring victory over dead panes, abort leaking new-gen panes, `nextIndex` reusing a live index). So counting is fixed at the specific caller, and listing is fixed in the read path, never in the store query. It is a read-model / write-model split: the reconciler stays clean (a deleted session is gone; `RoleHealth` carries the "held" fact) and the operator's `get sessions` becomes a projection over both.

Two composition traps are avoided deliberately, and both are called out here because getting them wrong is how this bug class recurs:
1. **No `State` predicate on the shared store query.** `shiftLaunch` filters at the call site with the existing `api.SessionState.CountsAsAlive()`, mirroring what `reconcileRoleAt` already does on the non-generation query.
2. **6kgq's count and the join's count are not unified.** 6kgq counts *alive* rows to decide whether to *spawn*; the join counts *all* rows to decide whether a role has *representation*. Both call `CountsAsAlive`/`CountAlive` but ask different questions — folding them into one "count of sessions" helper is exactly the conflation that produced the cluster.

## What (four steps, one RED→GREEN commit each)

1. **6kgq** — `fix(team): count only live new-gen sessions at shiftLaunch's gates`. New `aliveSessions` filter at both the create-gate and the ready-gate; store query untouched. RED: a Failed new-gen row suppressed the live replacement, and a dead row blocked an otherwise-ready drain.
2. **m8n0** — `fix(team): emit one crash-accounting event per reaped role per tick`. The reap loop's `charged` map aggregates per-role charge/suppress counts (`reapCharge`); after the loop, one `KindCrashLoopBackoff` (or `KindRoleSaturated`) per charged role — reusing the health path's kinds, no new kind. RED: three same-role reaps in one tick → exactly one accounting event beside the three `session.crashed`.
3. **094e** — `fix(team): distinguish a real drain from advancing through an empty old gen`. New `ShiftState.Drained` per-role counter (deep-cloned, persisted); the empty-old-gen branch emits the new `KindShiftDrainedEmpty` when the shift advanced through a role it never moved, and still advances (surface, don't judge). RED: a `ShiftDraining` seeded with zero old-gen rows emits the event and still advances `RoleIndex`.
4. **prhx** — `fix(daemon): join role health into get sessions so held roles aren't absent`. `Controller.SnapshotRoleHealth` (value-copy, rule 12) + `ProjectHeldRoleRows` synthesize a `crashloop-backoff` row for each declared role whose live row count is below replicas and whose gap `RoleHealth` explains; `handleGet` appends the projection. A projection-only `Session.Reason` (`json:",omitempty"`, so real rows and bolt records are byte-identical) carries `restart #N, backoff until T`. The reconciler, its counting, its tests, and `RoleHealth` persistence are untouched; `c.mu` is released before the store reads, so the two locks are never held together.

**83m9 is refuted and closed by step 4.** Its premise — a MaxRestarts-saturated role is *permanently absent* since `freezeRole` — is wrong: the saturation branch keeps its `SessionFailed` row (measured and code-confirmed), so `rowCount == Replicas` and it is never synthesized. The ~60s absence 83m9 attributed to saturation is the *restart* window, before it. Its real ask — "a held-down role needs a row that says so" — is the general invariant this join establishes.

## Not in scope

**fv3h** (RestartCount decay + a `reset-health` verb) is a deliberate follow-on: it changes `RoleHealth` *lifecycle*, which the join reads but does not depend on, and it is splittable — sequenced after this lands.

## Verification

Every step is red-then-green; `go build ./...`, `go test ./...`, `golangci-lint run ./...`, and `go test -race ./internal/{team,api,daemon}/` all pass. bd ticket closes (6kgq, m8n0, 094e, prhx; 83m9 restated-closed) are pending a kinu session, not done here.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS