### PR TITLE
fix(team): RestartCount decay + reset-health verb (fv3h)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,15 @@ Recovery behavior, all shipped:
   reclaiming the prefix) is one event, and marvel cannot see which of
   those it was. See finding-019.
 - **`Role.MaxRestarts`** caps restarts per replica slot; on saturation the
-  session is left `failed` rather than respawned. Zero means unlimited.
-  The count never decays, and clearing it means deleting the team.
+  session is left `failed` rather than respawned. Zero means unlimited. The
+  count is a within-window cap, not a lifetime tally: after a role runs
+  continuously healthy for `restartCountDecayWindow` (10m), `RestartCount` and
+  the backoff reset to zero (success-based decay, kubelet's model; fv3h), so
+  `max_restarts` caps crashes *within* that window and a role that crashes less
+  often than the window resets between crashes and never freezes. The one thing
+  decay never auto-thaws is a saturation freeze (or the `restart_policy=never`
+  freeze) — that terminal verdict is cleared only by
+  `marvel reset-health <ws/team> --role <r>` or by deleting the team.
 - **`crashed`** is the transition state `ReapDead` sets when a pane is
   gone, distinguishing a dead process from a drained one. It carries
   `health=unhealthy`: the pane's absence is the process-alive verdict.

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -140,6 +140,7 @@ func main() {
 	root.AddCommand(runCmd())
 	root.AddCommand(killCmd())
 	root.AddCommand(shiftCmd())
+	root.AddCommand(resetHealthCmd())
 	root.AddCommand(injectCmd())
 	root.AddCommand(captureCmd())
 	root.AddCommand(versionCmd())
@@ -1101,6 +1102,54 @@ func shiftCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&role, "role", "", "shift only this role (default: all roles)")
+	return cmd
+}
+
+func resetHealthCmd() *cobra.Command {
+	var role string
+	cmd := &cobra.Command{
+		Use:   "reset-health <workspace/team>",
+		Short: "Clear a role's crash-loop restart count and backoff without deleting the team",
+		Long: `Clear a role's accumulated crash-loop state.
+
+A role's RestartCount only ever climbs and drives the backoff window for its
+next crash, so a long-lived healthy role that crashed a few times long ago
+still gets a lifetime-sized backoff the next time it fails. Success-based decay
+resets the count automatically after a role has run healthy for a while; this
+verb is the operator override for when you know a role is fine now.
+
+It is also the only way to thaw a role frozen by max_restarts saturation or
+restart_policy=never, short of deleting and re-applying the whole team.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, _ := json.Marshal(map[string]any{
+				"team_key": args[0],
+				"role":     role,
+			})
+			resp, err := send(daemon.Request{
+				Method: "reset-health",
+				Params: params,
+			})
+			if err != nil {
+				return err
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+			var res struct {
+				Cleared bool `json:"cleared"`
+			}
+			_ = json.Unmarshal(resp.Result, &res)
+			if res.Cleared {
+				fmt.Printf("reset health for team/%s role/%s\n", args[0], role)
+			} else {
+				fmt.Printf("no crash-loop state for team/%s role/%s (nothing to reset)\n", args[0], role)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&role, "role", "", "role to reset (required)")
+	_ = cmd.MarkFlagRequired("role")
 	return cmd
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -663,6 +663,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleRun(req.Params)
 	case "shift":
 		return d.handleShift(req.Params)
+	case "reset-health":
+		return d.handleResetHealth(req.Params)
 	case "inject":
 		return d.handleInject(req.Params)
 	case "capture":
@@ -1276,6 +1278,57 @@ func (d *Daemon) handleShift(params json.RawMessage) Response {
 	result, _ := json.Marshal(map[string]string{
 		"status": "shift_initiated",
 		"team":   p.TeamKey,
+	})
+	return Response{Result: result}
+}
+
+// Reset-health params — clear one role's crash-loop state (RestartCount +
+// backoff) without deleting the team. See aae-orc-fv3h.
+type resetHealthParams struct {
+	TeamKey string `json:"team_key"` // workspace/team
+	Role    string `json:"role"`
+}
+
+// handleResetHealth clears a single role's accumulated restart count and
+// backoff — the operator override for a role that has recovered, and the only
+// route to thaw a saturated or restart_policy=never freeze short of deleting
+// the team. It resolves the team so it can validate the role and derive the
+// canonical workspace/team, then reconciles so a role no longer held back can
+// spawn its replacement immediately.
+func (d *Daemon) handleResetHealth(params json.RawMessage) Response {
+	var p resetHealthParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return Response{Error: fmt.Sprintf("bad params: %v", err)}
+	}
+	if p.Role == "" {
+		return Response{Error: "reset-health requires --role"}
+	}
+	t, err := d.store.GetTeam(p.TeamKey)
+	if err != nil {
+		return Response{Error: fmt.Sprintf("team %s: %v", p.TeamKey, err)}
+	}
+	found := false
+	for i := range t.Roles {
+		if t.Roles[i].Name == p.Role {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return Response{Error: fmt.Sprintf("role %s not found in team %s", p.Role, p.TeamKey)}
+	}
+
+	cleared := d.teamCtrl.ClearRoleHealthForRole(t.Workspace, t.Name, p.Role)
+	// A cleared freeze or elapsed backoff means the reconciler can now spawn
+	// the role's missing replicas; run one pass so the effect is immediate
+	// rather than waiting for the next tick.
+	d.teamCtrl.ReconcileOnce()
+
+	result, _ := json.Marshal(map[string]any{
+		"status":  "health_reset",
+		"cleared": cleared,
+		"team":    p.TeamKey,
+		"role":    p.Role,
 	})
 	return Response{Result: result}
 }

--- a/internal/daemon/reset_health_test.go
+++ b/internal/daemon/reset_health_test.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// resetHealthManifest is a one-role team with no budget or healthcheck — the
+// reset-health wiring test only needs a team the handler can resolve.
+const resetHealthManifest = `
+workspace:
+  name: recover
+teams:
+  - name: crew
+    roles:
+      - name: worker
+        replicas: 1
+        runtime:
+          command: sleep
+          args: ["300"]
+`
+
+// TestHandleResetHealth exercises the reset-health RPC wiring (aae-orc-fv3h):
+// the handler resolves the team, validates the role, and reports whether a
+// crash-loop record was cleared. The state-level assertion ("RestartCount 0
+// and no backoff") lives on the controller method it calls,
+// TestClearRoleHealthForRole; this test guards the daemon seam around it.
+func TestHandleResetHealth(t *testing.T) {
+	d := newHandlerDaemon(t)
+	if resp := applyManifest(t, d, resetHealthManifest); resp.Error != "" {
+		t.Fatalf("apply: %s", resp.Error)
+	}
+
+	// A valid team/role with no accumulated health: succeeds, reports nothing
+	// to clear (cleared=false), never errors.
+	resp := d.handleResetHealth(mustMarshal(t, resetHealthParams{TeamKey: "recover/crew", Role: "worker"}))
+	if resp.Error != "" {
+		t.Fatalf("reset-health on a valid role errored: %s", resp.Error)
+	}
+	var res struct {
+		Status  string `json:"status"`
+		Cleared bool   `json:"cleared"`
+	}
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res.Status != "health_reset" {
+		t.Errorf("status = %q, want health_reset", res.Status)
+	}
+	if res.Cleared {
+		t.Errorf("cleared = true, want false (no crash-loop state recorded yet)")
+	}
+
+	// Unknown role in a known team is refused with a role-scoped message.
+	resp = d.handleResetHealth(mustMarshal(t, resetHealthParams{TeamKey: "recover/crew", Role: "ghost"}))
+	if resp.Error == "" || !strings.Contains(resp.Error, "role ghost not found") {
+		t.Errorf("unknown-role error = %q, want it to name the missing role", resp.Error)
+	}
+
+	// Unknown team is refused before any role lookup.
+	resp = d.handleResetHealth(mustMarshal(t, resetHealthParams{TeamKey: "recover/absent", Role: "worker"}))
+	if resp.Error == "" || !strings.Contains(resp.Error, "recover/absent") {
+		t.Errorf("unknown-team error = %q, want it to name the missing team", resp.Error)
+	}
+
+	// A missing --role is refused: the verb targets exactly one role.
+	resp = d.handleResetHealth(mustMarshal(t, resetHealthParams{TeamKey: "recover/crew"}))
+	if resp.Error == "" || !strings.Contains(resp.Error, "requires --role") {
+		t.Errorf("missing-role error = %q, want it to require --role", resp.Error)
+	}
+}

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -216,6 +216,11 @@ func (c *Controller) forgetRoleHealth(key string) {
 // RoleHealthSnapshot returns the current restart state for a role,
 // useful for tests and for `marvel describe team` observability.
 // Returns (nil, false) if the role has no recorded crash-loop history.
+// The result is a full value copy of RoleHealth (flat ints and timestamps,
+// so a struct copy is a deep copy — go.md rule 12), including HealthySince:
+// an operator needs it to tell a role about to decay from one that just
+// started its window, and copying the whole struct means a future field
+// cannot be silently dropped here the way HealthySince once was.
 func (c *Controller) RoleHealthSnapshot(workspace, team, role string) (*RoleHealth, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -224,11 +229,8 @@ func (c *Controller) RoleHealthSnapshot(workspace, team, role string) (*RoleHeal
 	if !ok {
 		return nil, false
 	}
-	return &RoleHealth{
-		RestartCount:  rh.RestartCount,
-		LastRestartAt: rh.LastRestartAt,
-		BackoffUntil:  rh.BackoffUntil,
-	}, true
+	rhCopy := *rh
+	return &rhCopy, true
 }
 
 // SnapshotRoleHealth returns a value copy of every role's crash-loop state,
@@ -916,23 +918,43 @@ func (c *Controller) evaluateHealth() {
 }
 
 // roleObs is the health a role showed across one evaluateHealth tick: whether
-// any replica read healthy and whether any read unhealthy. Both can be true
-// for a multi-replica role mid-wobble.
+// any RUNNING replica read healthy and whether any read unhealthy. It is
+// populated only from SessionRunning sessions classified this tick, so a
+// declared replica with no running session (not yet spawned, drained, or gone
+// without a crash) contributes nothing, and a session that read HealthUnknown
+// (no healthcheck, or inside the first-heartbeat grace) contributes nothing
+// either. Both fields can be true for a multi-replica role mid-wobble.
 type roleObs struct {
 	healthy   bool
 	unhealthy bool
 }
 
 // decayHealthyRoles advances success-based RestartCount decay (aae-orc-fv3h).
-// A role that has run continuously healthy — at least one healthy replica and
-// no unhealthy one — for restartCountDecayWindow has its RestartCount reset to
-// zero and its backoff cleared, so a long-lived role that crashed a few times
-// long ago does not carry a lifetime-sized backoff into its next crash. Any
-// unhealthy replica this tick resets the streak instead. A saturation or
-// restart_policy=never freeze is deliberately never auto-thawed: that is a
-// terminal verdict cleared only by the operator (reset-health) or a team
-// delete, and auto-thawing it would re-introduce the uncapped-respawn leak the
-// freeze exists to stop. Caller holds c.mu.
+// A role observed continuously healthy — at least one healthy running replica
+// and no unhealthy one — for restartCountDecayWindow has its RestartCount reset
+// to zero and its backoff cleared, so a long-lived role that crashed a few
+// times long ago does not carry a lifetime-sized backoff into its next crash.
+//
+// It ranges only over roles with an observation this tick (see roleObs), so two
+// boundaries are consciously accepted:
+//
+//   - The streak breaks only on an unhealthy RUNNING replica. A replica that is
+//     down but not crashing (scaled away, pending spawn) leaves no observation
+//     and does not break the streak; a replica that is down BECAUSE it crashed
+//     already reset the streak at charge time (noteCrashAndBackoff), so this is
+//     not a hole through which a crash-looper decays.
+//   - A tick with no classified observation for a role (all its sessions
+//     HealthUnknown, or none running) neither advances nor resets the streak —
+//     the role is simply not visited, and its HealthySince stands. The window
+//     is therefore wall-clock, not consecutive-healthy-ticks; a role cannot ride
+//     an Unknown gap to a full window while actually failing, because a real
+//     crash-looper re-crashes within restartBackoffMax (5m) < the window (10m)
+//     and each crash resets the streak.
+//
+// A saturation or restart_policy=never freeze is deliberately never auto-thawed:
+// that is a terminal verdict cleared only by the operator (reset-health) or a
+// team delete, and auto-thawing it would re-introduce the uncapped-respawn leak
+// the freeze exists to stop. Caller holds c.mu.
 func (c *Controller) decayHealthyRoles(obs map[string]roleObs, now time.Time) {
 	for key, o := range obs {
 		rh, ok := c.roleHealth[key]

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -83,6 +83,15 @@ type RoleHealth struct {
 	// marked SessionCrashLoopBackOff and left alive (not deleted) so
 	// operators see the condition and the reconciler doesn't respawn.
 	BackoffUntil time.Time
+	// HealthySince stamps when the role began an unbroken healthy streak
+	// after its most recent charge; the zero value means no active streak
+	// (never healthy, or a crash/flap cleared it). Once the streak reaches
+	// restartCountDecayWindow, evaluateHealth resets RestartCount so a role
+	// that has run clean for a while does not carry a lifetime-sized backoff
+	// into its next crash. In-memory only (not persisted): a daemon restart
+	// conservatively restarts the streak rather than granting decay early.
+	// See decayHealthyRoles and aae-orc-fv3h.
+	HealthySince time.Time
 }
 
 // Restart backoff configuration. Exponential with a 5-minute cap — the
@@ -90,6 +99,15 @@ type RoleHealth struct {
 const (
 	restartBackoffInitial = 30 * time.Second
 	restartBackoffMax     = 5 * time.Minute
+	// restartCountDecayWindow is how long a role must run continuously
+	// healthy before its accumulated RestartCount decays back to zero
+	// (success-based decay, kubelet's model — a container that has run
+	// successfully for a stability period resets its crash-loop backoff).
+	// Ten minutes is long enough that a genuinely flapping role never
+	// reaches it (its next crash resets the streak) yet short enough that a
+	// role which recovered does not carry old restarts for hours. See
+	// decayHealthyRoles and aae-orc-fv3h.
+	restartCountDecayWindow = 10 * time.Minute
 	// defaultShiftTimeout bounds how long a shift may run before the
 	// reconciler treats it as stuck. A launch whose new generation never
 	// reaches readiness (e.g. a heartbeat-checked role that never beats)
@@ -261,14 +279,16 @@ func (c *Controller) ProjectHeldRoleRows(store *api.Store) []api.Session {
 				continue
 			}
 			// Only a role still inside its backoff window is genuinely held
-			// down. RestartCount does not decay until fv3h, so a recovered
-			// role can carry stale RoleHealth with an elapsed backoff; a
-			// benign dip below replicas (mid-spawn, scale-up) must not
-			// synthesize a crashloop-backoff row with a past deadline. The
-			// saturation sentinel is far in the future, so a frozen role that
-			// somehow presented a gap still reads as held. During real
-			// backoff the row is deleted and BackoffUntil is in the future,
-			// so nothing legitimate is hidden.
+			// down. Success-based decay (fv3h) eventually clears a recovered
+			// role's RoleHealth, but only after restartCountDecayWindow of
+			// health; in the interval between recovery and decay a role can
+			// still carry RoleHealth with an elapsed backoff, so a benign dip
+			// below replicas (mid-spawn, scale-up) must not synthesize a
+			// crashloop-backoff row with a past deadline. The saturation
+			// sentinel is far in the future, so a frozen role that somehow
+			// presented a gap still reads as held. During real backoff the row
+			// is deleted and BackoffUntil is in the future, so nothing
+			// legitimate is hidden.
 			if !rh.BackoffUntil.After(now) {
 				continue
 			}
@@ -343,6 +363,28 @@ func (c *Controller) ClearRoleHealthForWorkspace(workspace string) {
 		}
 	}
 	c.dropAdmissionHolds(prefix)
+}
+
+// ClearRoleHealthForRole deletes crash-loop state for a single role — the
+// operator's "this role is fine now" verb, exposed as `marvel reset-health`.
+// It is the single-role sibling of ClearRoleHealthForTeam: it removes one
+// role's accumulated RestartCount and backoff (including a saturation or
+// restart_policy=never freeze) without deleting the whole team, which was the
+// only prior route to clearing a role's restart history. Returns whether a
+// record existed, so the caller can distinguish a reset from a no-op. Success-
+// based decay (see decayHealthyRoles) is the automatic counterpart; this verb
+// is the manual override, and the only sanctioned way to thaw a frozen role
+// short of a team delete. See aae-orc-fv3h.
+func (c *Controller) ClearRoleHealthForRole(workspace, team, role string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := workspace + "/" + team + "/" + role
+	if _, ok := c.roleHealth[key]; !ok {
+		return false
+	}
+	delete(c.roleHealth, key)
+	c.forgetRoleHealth(key)
+	return true
 }
 
 // ReconcileOnce runs one reconciliation pass for all teams.
@@ -522,6 +564,10 @@ var saturationFreezeUntil = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
 func (c *Controller) noteCrashAndBackoff(workspace, team, role string, maxRestarts int) bool {
 	roleKey := workspace + "/" + team + "/" + role
 	rh := c.getRoleHealth(roleKey)
+	// Any charge — from the health path or the reap path, both of which land
+	// here — ends the role's healthy streak, so success-based decay starts
+	// over the next time it recovers. See decayHealthyRoles (aae-orc-fv3h).
+	rh.HealthySince = time.Time{}
 	if maxRestarts > 0 && rh.RestartCount >= maxRestarts {
 		rh.BackoffUntil = saturationFreezeUntil
 		c.persistRoleHealth(roleKey, rh)
@@ -752,6 +798,12 @@ func (c *Controller) evaluateHealth() {
 		teamCache[t.Key()] = t
 	}
 
+	// Per-role health observed this tick, for success-based RestartCount decay
+	// (aae-orc-fv3h). Collected across the whole session loop and applied once
+	// after it, so a role with any unhealthy replica breaks its streak
+	// regardless of the order its replicas are visited.
+	obs := make(map[string]roleObs)
+
 	for _, sess := range sessions {
 		if sess.State != api.SessionRunning {
 			continue
@@ -829,6 +881,21 @@ func (c *Controller) evaluateHealth() {
 			continue
 		}
 
+		// Record this session's health against its role for decay. Unknown
+		// (no healthcheck, or inside the first-heartbeat grace period) counts
+		// as neither: a role marvel cannot assert is healthy does not decay.
+		key := updated.Workspace + "/" + updated.Team + "/" + updated.Role
+		switch updated.HealthState {
+		case api.HealthHealthy:
+			o := obs[key]
+			o.healthy = true
+			obs[key] = o
+		case api.HealthUnhealthy:
+			o := obs[key]
+			o.unhealthy = true
+			obs[key] = o
+		}
+
 		if transitionedToUnhealthy {
 			events.Emit(c.Events, events.Event{
 				Kind:      events.KindHealthCheckFailed,
@@ -842,6 +909,57 @@ func (c *Controller) evaluateHealth() {
 		}
 		if shouldApplyRestart {
 			c.applyRestartPolicy(&updated, &t, role)
+		}
+	}
+
+	c.decayHealthyRoles(obs, c.nowUTC())
+}
+
+// roleObs is the health a role showed across one evaluateHealth tick: whether
+// any replica read healthy and whether any read unhealthy. Both can be true
+// for a multi-replica role mid-wobble.
+type roleObs struct {
+	healthy   bool
+	unhealthy bool
+}
+
+// decayHealthyRoles advances success-based RestartCount decay (aae-orc-fv3h).
+// A role that has run continuously healthy — at least one healthy replica and
+// no unhealthy one — for restartCountDecayWindow has its RestartCount reset to
+// zero and its backoff cleared, so a long-lived role that crashed a few times
+// long ago does not carry a lifetime-sized backoff into its next crash. Any
+// unhealthy replica this tick resets the streak instead. A saturation or
+// restart_policy=never freeze is deliberately never auto-thawed: that is a
+// terminal verdict cleared only by the operator (reset-health) or a team
+// delete, and auto-thawing it would re-introduce the uncapped-respawn leak the
+// freeze exists to stop. Caller holds c.mu.
+func (c *Controller) decayHealthyRoles(obs map[string]roleObs, now time.Time) {
+	for key, o := range obs {
+		rh, ok := c.roleHealth[key]
+		if !ok || rh.RestartCount == 0 {
+			// Nothing accumulated to decay.
+			continue
+		}
+		if rh.BackoffUntil.Equal(saturationFreezeUntil) {
+			// Frozen: operator-cleared only.
+			continue
+		}
+		if o.unhealthy || !o.healthy {
+			// A flap (or no healthy replica) breaks the streak; start over.
+			rh.HealthySince = time.Time{}
+			continue
+		}
+		if rh.HealthySince.IsZero() {
+			rh.HealthySince = now
+			continue
+		}
+		if now.Sub(rh.HealthySince) >= restartCountDecayWindow {
+			log.Printf("health: role %s ran healthy for %s, decaying restart count %d→0",
+				key, restartCountDecayWindow, rh.RestartCount)
+			rh.RestartCount = 0
+			rh.BackoffUntil = time.Time{}
+			rh.HealthySince = time.Time{}
+			c.persistRoleHealth(key, rh)
 		}
 	}
 }

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1062,6 +1062,42 @@ func TestClearRoleHealthForRole(t *testing.T) {
 	}
 }
 
+// TestRoleHealthSnapshotSurfacesHealthySince guards LOW-4 from the fv3h review:
+// the observability accessor (used by `marvel describe team`) must carry
+// HealthySince, or an operator seeing RestartCount cannot tell a role about to
+// decay from one that just began its window. It also confirms the returned
+// struct is a decoupled copy (go.md rule 12).
+func TestRoleHealthSnapshotSurfacesHealthySince(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	since := clock.Now().Add(-3 * time.Minute)
+	ctrl.roleHealth["ws/t/worker"] = &RoleHealth{
+		RestartCount: 2,
+		BackoffUntil: clock.Now().Add(-time.Second),
+		HealthySince: since,
+	}
+
+	got, ok := ctrl.RoleHealthSnapshot("ws", "t", "worker")
+	if !ok {
+		t.Fatal("RoleHealthSnapshot(worker) = (_, false), want the recorded health")
+	}
+	if !got.HealthySince.Equal(since) {
+		t.Errorf("HealthySince = %v, want %v (the accessor dropped it)", got.HealthySince, since)
+	}
+
+	// A returned copy that leaks into the map would let a reader corrupt the
+	// controller's state; mutating it must not be observable on the next read.
+	got.HealthySince = time.Time{}
+	got.RestartCount = 99
+	if again, _ := ctrl.RoleHealthSnapshot("ws", "t", "worker"); !again.HealthySince.Equal(since) || again.RestartCount != 2 {
+		t.Errorf("mutating the snapshot leaked into the store: got HealthySince=%v RestartCount=%d", again.HealthySince, again.RestartCount)
+	}
+}
+
 func TestComputeBackoff(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -1011,6 +1011,57 @@ func TestClearRoleHealthForTeamEmpty(t *testing.T) {
 	}
 }
 
+// TestClearRoleHealthForRole is the operator reset-health verb at the
+// controller seam (aae-orc-fv3h). A role that crashed and carries a nonzero
+// RestartCount + backoff — or a saturation/never freeze — is cleared to
+// nothing without deleting the team, which was the only prior route. Sibling
+// roles under the same team are untouched, and the method reports whether a
+// record existed so the CLI can say "nothing to reset".
+func TestClearRoleHealthForRole(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	// worker: crashed twice, cooling down in a backoff window.
+	ctrl.roleHealth["ws1/squad/worker"] = &RoleHealth{RestartCount: 2, BackoffUntil: clock.Now().Add(90 * time.Second)}
+	// boss: saturated/frozen far in the future — the case a team delete was
+	// previously the only way to thaw.
+	ctrl.roleHealth["ws1/squad/boss"] = &RoleHealth{RestartCount: 5, BackoffUntil: saturationFreezeUntil}
+	// reviewer: a sibling under the same team that must NOT be touched.
+	ctrl.roleHealth["ws1/squad/reviewer"] = &RoleHealth{RestartCount: 1, BackoffUntil: clock.Now().Add(30 * time.Second)}
+
+	if cleared := ctrl.ClearRoleHealthForRole("ws1", "squad", "worker"); !cleared {
+		t.Fatal("ClearRoleHealthForRole(worker) = false, want true (a record existed)")
+	}
+	// RestartCount 0 and no backoff: the record is gone entirely, so a
+	// subsequent crash starts a fresh count and a 30s window, not a
+	// lifetime-sized one.
+	if rh, ok := ctrl.RoleHealthSnapshot("ws1", "squad", "worker"); ok {
+		t.Fatalf("worker still has health after reset: %+v", rh)
+	}
+
+	// The frozen role thaws through the same verb — no team delete required.
+	if cleared := ctrl.ClearRoleHealthForRole("ws1", "squad", "boss"); !cleared {
+		t.Fatal("ClearRoleHealthForRole(boss) = false, want true (frozen record existed)")
+	}
+	if _, ok := ctrl.RoleHealthSnapshot("ws1", "squad", "boss"); ok {
+		t.Error("frozen boss still has health after reset")
+	}
+
+	// The sibling is untouched.
+	rh, ok := ctrl.RoleHealthSnapshot("ws1", "squad", "reviewer")
+	if !ok || rh.RestartCount != 1 {
+		t.Errorf("reviewer health = (%+v, %v), want RestartCount=1 untouched", rh, ok)
+	}
+
+	// Clearing a role with no record is a no-op that reports false.
+	if cleared := ctrl.ClearRoleHealthForRole("ws1", "squad", "worker"); cleared {
+		t.Error("second ClearRoleHealthForRole(worker) = true, want false (nothing to clear)")
+	}
+}
+
 func TestComputeBackoff(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -2668,11 +2719,13 @@ func TestProjectHeldRoleRowsSynthesizesCrashloopRow(t *testing.T) {
 }
 
 // TestProjectHeldRoleRowsSkipsRecoveredRoleWithPastBackoff guards the
-// synthesis gate. RestartCount does not decay until fv3h, so a recovered role
-// can carry stale RoleHealth with a backoff window already in the past. If it
-// dips below replicas for a benign reason (mid-spawn, scale-up), synthesizing
-// a crashloop-backoff row with a past "backoff until" would be a lie. Only a
-// role whose backoff is still in the future is genuinely held down.
+// synthesis gate. Success-based decay (fv3h) only clears a recovered role's
+// RoleHealth after restartCountDecayWindow of health, so in the interval
+// before decay a recovered role can carry RoleHealth with a backoff window
+// already in the past. If it dips below replicas for a benign reason
+// (mid-spawn, scale-up), synthesizing a crashloop-backoff row with a past
+// "backoff until" would be a lie. Only a role whose backoff is still in the
+// future is genuinely held down.
 func TestProjectHeldRoleRowsSkipsRecoveredRoleWithPastBackoff(t *testing.T) {
 	store := api.NewStore()
 	ctrl := NewController(store, nil)
@@ -2706,5 +2759,189 @@ func TestProjectHeldRoleRowsSkipsRecoveredRoleWithPastBackoff(t *testing.T) {
 	}
 	if len(byRole["held"]) != 1 {
 		t.Errorf("held synthesized %d row(s), want 1 (backoff in the future — genuinely held down)", len(byRole["held"]))
+	}
+}
+
+// TestRestartCountDecaysAfterHealthyWindow is the success-based decay half of
+// aae-orc-fv3h. A role that crashed a few times and has since run healthy
+// should not carry those restarts forever: after it has been continuously
+// healthy for restartCountDecayWindow, its RestartCount resets to 0 and its
+// backoff clears, so its next crash earns a fresh 30s window rather than a
+// lifetime-sized one. Healthy for less than the window changes nothing.
+func TestRestartCountDecaysAfterHealthyWindow(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-decay", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1, RestartPolicy: api.RestartAlways,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 30 * time.Second, FailureThreshold: 3},
+		},
+	})
+
+	// A role that crashed three times, now recovered: RestartCount>0, backoff
+	// already elapsed. Without decay it would carry these restarts forever.
+	rh := ctrl.getRoleHealth("test-decay/squad/worker")
+	rh.RestartCount = 3
+	rh.BackoffUntil = clock.Now().Add(-time.Minute)
+
+	// A running session with a fresh heartbeat reads healthy. The heartbeat
+	// staleness check uses wall-clock time, so one fresh stamp stays healthy
+	// for the whole sub-second test regardless of the injected clock, which
+	// drives only the decay window.
+	seedSession(t, store, api.Session{
+		Name: "squad-worker-g1-0", Workspace: "test-decay", Team: "squad", Role: "worker",
+		Generation: 1, State: api.SessionRunning, LastHeartbeat: time.Now().UTC(),
+	})
+
+	// First eval: healthy → the streak starts (HealthySince at T0), count held.
+	ctrl.evaluateHealth()
+	if got, _ := ctrl.RoleHealthSnapshot("test-decay", "squad", "worker"); got.RestartCount != 3 {
+		t.Fatalf("RestartCount after first healthy eval = %d, want 3 (streak just started)", got.RestartCount)
+	}
+
+	// Still inside the window: no decay.
+	clock.Advance(restartCountDecayWindow - time.Minute)
+	ctrl.evaluateHealth()
+	if got, _ := ctrl.RoleHealthSnapshot("test-decay", "squad", "worker"); got.RestartCount != 3 {
+		t.Fatalf("RestartCount before the window elapses = %d, want 3 (still cooling in)", got.RestartCount)
+	}
+
+	// Past the window: RestartCount decays to 0 and the backoff clears.
+	clock.Advance(2 * time.Minute)
+	ctrl.evaluateHealth()
+	got, ok := ctrl.RoleHealthSnapshot("test-decay", "squad", "worker")
+	if !ok {
+		t.Fatal("role health vanished after decay, want a zeroed record")
+	}
+	if got.RestartCount != 0 {
+		t.Errorf("RestartCount after a full healthy window = %d, want 0 (decayed)", got.RestartCount)
+	}
+	if !got.BackoffUntil.IsZero() {
+		t.Errorf("BackoffUntil after decay = %v, want zero", got.BackoffUntil)
+	}
+}
+
+// TestDecayHealthyRoles pins the decay decision and its guards directly
+// (aae-orc-fv3h): a healthy role past its window decays, a saturation/never
+// freeze is never auto-thawed (that is the operator's reset-health verb), a
+// role that flapped this tick has its streak reset instead of decaying, and a
+// role with nothing to decay is left alone.
+func TestDecayHealthyRoles(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	past := clock.Now().Add(-restartCountDecayWindow - time.Minute)
+	ctrl.roleHealth["ws/t/decays"] = &RoleHealth{RestartCount: 3, BackoffUntil: clock.Now().Add(-time.Second), HealthySince: past}
+	ctrl.roleHealth["ws/t/frozen"] = &RoleHealth{RestartCount: 5, BackoffUntil: saturationFreezeUntil, HealthySince: past}
+	ctrl.roleHealth["ws/t/wobbled"] = &RoleHealth{RestartCount: 2, BackoffUntil: clock.Now().Add(-time.Second), HealthySince: past}
+	ctrl.roleHealth["ws/t/clean"] = &RoleHealth{RestartCount: 0}
+
+	obs := map[string]roleObs{
+		"ws/t/decays":  {healthy: true},                  // healthy past the window → decays
+		"ws/t/frozen":  {healthy: true},                  // healthy but frozen → must NOT decay
+		"ws/t/wobbled": {healthy: true, unhealthy: true}, // a replica flapped → streak resets, no decay
+		"ws/t/clean":   {healthy: true},                  // RestartCount 0 → nothing to do
+	}
+
+	ctrl.decayHealthyRoles(obs, clock.Now())
+
+	if rh := ctrl.roleHealth["ws/t/decays"]; rh.RestartCount != 0 || !rh.BackoffUntil.IsZero() || !rh.HealthySince.IsZero() {
+		t.Errorf("decays: got count=%d backoff=%v since=%v, want all cleared", rh.RestartCount, rh.BackoffUntil, rh.HealthySince)
+	}
+	if rh := ctrl.roleHealth["ws/t/frozen"]; rh.RestartCount != 5 || !rh.BackoffUntil.Equal(saturationFreezeUntil) {
+		t.Errorf("frozen: got count=%d backoff=%v, want untouched (saturation freeze is operator-cleared)", rh.RestartCount, rh.BackoffUntil)
+	}
+	if rh := ctrl.roleHealth["ws/t/wobbled"]; rh.RestartCount != 2 || !rh.HealthySince.IsZero() {
+		t.Errorf("wobbled: got count=%d since=%v, want count untouched and streak reset", rh.RestartCount, rh.HealthySince)
+	}
+	if rh := ctrl.roleHealth["ws/t/clean"]; rh.RestartCount != 0 {
+		t.Errorf("clean: got count=%d, want 0 untouched", rh.RestartCount)
+	}
+}
+
+// TestCrashClearsHealthyStreak guards the single clear point: every charge
+// (health path via restartSession, reap path via noteReapedCrash) runs through
+// noteCrashAndBackoff, which must reset HealthySince so a role that crashes
+// after a partial healthy streak starts its decay window over. See aae-orc-fv3h.
+func TestCrashClearsHealthyStreak(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	rh := ctrl.getRoleHealth("ws/t/worker")
+	rh.RestartCount = 1
+	rh.HealthySince = clock.Now()
+
+	if charged := ctrl.noteCrashAndBackoff("ws", "t", "worker", 0); !charged {
+		t.Fatal("noteCrashAndBackoff returned false, want true (not saturated)")
+	}
+	got := ctrl.roleHealth["ws/t/worker"]
+	if !got.HealthySince.IsZero() {
+		t.Errorf("HealthySince after a charge = %v, want zero (crash breaks the streak)", got.HealthySince)
+	}
+	if got.RestartCount != 2 {
+		t.Errorf("RestartCount after charge = %d, want 2", got.RestartCount)
+	}
+}
+
+// TestDecayStopsJoinSynthesizingRecoveredRole is the join-interaction guard
+// (aae-orc-fv3h × aae-orc-prhx). A crash-looping role in its backoff window is
+// synthesized as a held "crashloop-backoff" row by ProjectHeldRoleRows. Once
+// the role recovers and stays healthy past the decay window, decay clears its
+// RestartCount and backoff — and the join must then STOP representing it as
+// held, even if the role transiently dips below its replica count again.
+func TestDecayStopsJoinSynthesizingRecoveredRole(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+	clock := newTestClock(time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	ctrl.now = clock.Now
+
+	createTeamFixture(t, store, "test-decay-join", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1, RestartPolicy: api.RestartAlways,
+			Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			HealthCheck: &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 30 * time.Second, FailureThreshold: 3},
+		},
+	})
+
+	// Phase 1 — crash-looping in the backoff window, no live row: held.
+	rh := ctrl.getRoleHealth("test-decay-join/squad/worker")
+	rh.RestartCount = 2
+	rh.BackoffUntil = clock.Now().Add(90 * time.Second)
+	if rows := ctrl.ProjectHeldRoleRows(store); len(rows) != 1 {
+		t.Fatalf("phase 1: join synthesized %d rows, want 1 (role held in backoff)", len(rows))
+	}
+
+	// Phase 2 — recovery: the reconciler respawned a session that runs healthy.
+	seedSession(t, store, api.Session{
+		Name: "squad-worker-g1-0", Workspace: "test-decay-join", Team: "squad", Role: "worker",
+		Generation: 1, State: api.SessionRunning, LastHeartbeat: time.Now().UTC(),
+	})
+
+	// Stays healthy across the decay window.
+	ctrl.evaluateHealth() // stamps HealthySince at T0
+	clock.Advance(restartCountDecayWindow + time.Minute)
+	ctrl.evaluateHealth() // past the window → decay fires
+
+	if got, _ := ctrl.RoleHealthSnapshot("test-decay-join", "squad", "worker"); got.RestartCount != 0 {
+		t.Fatalf("RestartCount after the recovery window = %d, want 0 (decayed)", got.RestartCount)
+	}
+
+	// Drop the live row to force the join through its backoff gate rather than
+	// its replica-count gate: decay has cleared BackoffUntil, so a benign dip
+	// below replicas can no longer be read as held. Before decay, the future
+	// backoff (phase 1) synthesized a row here.
+	if err := store.DeleteSession("test-decay-join/squad-worker-g1-0"); err != nil {
+		t.Fatalf("delete session: %v", err)
+	}
+	if rows := ctrl.ProjectHeldRoleRows(store); len(rows) != 0 {
+		t.Fatalf("phase 2: join synthesized %d rows after decay, want 0 (role recovered)", len(rows))
 	}
 }


### PR DESCRIPTION
## Why

A role's `RestartCount` only ever climbed. The single reset was `ClearRoleHealthForTeam`, reached only from the team-delete cascade — so a role that crashed three times last week and has run clean since carried those restarts forever, and `computeBackoff` handed its *next* crash a lifetime-sized backoff it did not earn. A long-lived healthy role was one crash away from a long backoff for reasons that had nothing to do with its recent behavior, and an operator's only lever was deleting the whole team. This is the standard crash-loop-backoff decay question every comparable system answers (kubelet resets after a container runs healthy for a stability period); marvel had no notion of "has been fine for a while," and no per-role "this role is fine now" override.

This closes aae-orc-fv3h — step 5 of the Lane-2 session-listing/generation-counting join (finding-032) — with both halves the design chose: automatic success-based decay, and a manual operator verb.

## What

**Success-based decay** (`fix(team)`). `RoleHealth` gains an in-memory `HealthySince` stamp, set when a role's sessions begin an unbroken healthy streak and cleared on any charge — the single point `noteCrashAndBackoff`, which both the health and reap paths run through — or any unhealthy replica in a tick. Once the streak reaches `restartCountDecayWindow` (10m, kubelet's model, a named const), `evaluateHealth` resets `RestartCount` to 0 and clears the backoff. A saturation / `restart_policy=never` freeze is deliberately **never** auto-thawed: that terminal verdict stays operator-cleared, so the uncapped-respawn leak the freeze prevents cannot return. `HealthySince` is not persisted — a daemon restart conservatively restarts the streak rather than granting decay early.

**`reset-health` operator verb** (`feat(marvel)`). `marvel reset-health <workspace/team> --role <r>` clears one role's `RestartCount` and backoff without a team delete, and is the only route to thaw a frozen role short of re-applying the team. New controller primitive `ClearRoleHealthForRole` (the single-role sibling of `ClearRoleHealthForTeam`); daemon `reset-health` RPC resolves and validates the team/role, clears, then reconciles once so a role no longer held back spawns immediately.

## Interaction with the just-merged join (#215)

`ProjectHeldRoleRows` reads `RoleHealth` to synthesize a held `crashloop-backoff` row for a role gated on RoleHealth existing AND `BackoffUntil.After(now)`. Decay changes that lifecycle, so a regression test (`TestDecayStopsJoinSynthesizingRecoveredRole`) drives a role from backoff (join synthesizes its row) through the decay window and asserts the join then synthesizes **nothing** — even with the live row dropped, forcing the assertion through the backoff gate rather than the replica-count gate. The stale "does not decay until fv3h" comments on the join are updated. `SnapshotRoleHealth`'s value-copy contract (go.md rule 12) is preserved.

## Tests (red→green throughout)

- `TestClearRoleHealthForRole` — RestartCount>0 (and a frozen role) → reset → gone; sibling untouched; no-op reports false.
- `TestHandleResetHealth` — RPC wiring: valid role, unknown role, unknown team, missing `--role`.
- `TestRestartCountDecaysAfterHealthyWindow` — healthy < window → unchanged; healthy past window → decays to 0, backoff cleared.
- `TestDecayHealthyRoles` — decay + guards direct: frozen never thaws, a flapping replica resets the streak, nothing-to-decay is left alone.
- `TestCrashClearsHealthyStreak` — every charge clears `HealthySince`.
- `TestDecayStopsJoinSynthesizingRecoveredRole` — the #215 interaction.

Full suite, `go test -race ./internal/{team,api,daemon}/`, and `golangci-lint run ./...` all green.

Refs: aae-orc-fv3h

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS