### PR TITLE
feat(usage): grade the resolved window by key confidence

### DIFF
--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -96,6 +96,79 @@ func (s LimitSource) Rank() int {
 	return len(limitLadder) + 1
 }
 
+// KeyConfidence grades how well the key that resolved a window determines
+// the window itself. It rides BESIDE LimitSource, not instead of it: the
+// two axes are orthogonal. LimitSource says which rung of the ladder
+// produced the number; KeyConfidence says whether the key that rung used
+// was as wide as the fact it stored.
+//
+// The distinction exists because a miss is loud and a wrong hit is silent
+// (finding-031). A window that misses renders absence and emits
+// context.limit-unresolved; a window resolved on a key too narrow to be
+// right renders a number that reads exactly like a correct one. Grading the
+// key is how a consumer tells the two apart: a renderer marks a soft value
+// low-confidence rather than presenting it as an exact fact (see Soft), and
+// an admission gate can refuse on a narrow key without refusing on a
+// measurement.
+//
+// Two axes make a key narrow, and they resolve at different times:
+//
+//   - ENTITLEMENT (static, graded here today). A bare model id naming the
+//     DEFAULT half of a default/max split does not carry the entitlement
+//     that decides which half a session gets. See the default-versus-maximum
+//     convention on DefaultTable and Table.keyConfidence.
+//   - PROVIDER (dynamic, not graded yet). The same id can name different
+//     windows under different backends (finding-031: the catalog assigns
+//     claude-opus-5 1000000 under anthropic and 264000 under copilot), and
+//     marvel cannot observe which backend served a request. The
+//     discriminator that answers "on the vendor default, or redirected?" is
+//     a spawn-time environment read that does not exist yet (aae-orc-b2d0p);
+//     until it lands, ResolveGraded assumes the default backend and never
+//     emits KeyRedirected. See the seam in ResolveGraded.
+type KeyConfidence string
+
+const (
+	// KeyExact means the key fully determined the window: a value declared
+	// directly (stream, learned, manifest, feed — no keyed lookup), or a
+	// table hit whose id leaves no entitlement ambiguity. The only grade
+	// that is NOT soft.
+	KeyExact KeyConfidence = "exact"
+	// KeyNarrow means the key was narrower than the fact it stored, so the
+	// number may be wrong and must be presented soft. Today it arises two
+	// ways: an entitlement-split table entry resolved on its default-half
+	// key, and any alias hit (an alias names whatever the harness points it
+	// at, so a hit that happens to be right is not a keyed fact).
+	KeyNarrow KeyConfidence = "narrow"
+	// KeyRedirected means the discriminator found the session redirected off
+	// the vendor default, so a table value keyed on the direct-API window
+	// does not apply. RESERVED: produced only once the spawn-time
+	// discriminator lands (aae-orc-b2d0p); ResolveGraded never returns it
+	// today. Declared now because it is the vocabulary the refuse-guard
+	// (aae-orc-bv7m) speaks.
+	KeyRedirected KeyConfidence = "redirected"
+	// KeyUndeterminable means marvel cannot vouch for the window. Today it
+	// marks an unresolved resolution (no rung produced a window). Once the
+	// discriminator lands it will also mark a session whose backend cannot
+	// be determined, which the guard treats as departure from default
+	// (finding-031). Either way: not a number to trust.
+	KeyUndeterminable KeyConfidence = "undeterminable"
+)
+
+// Soft reports whether a resolution should be presented as low-confidence
+// rather than as an exact fact. Everything but KeyExact is soft, so the
+// zero value and any grade a later writer adds default to soft rather than
+// silently reading as exact.
+//
+// Soft is the KEY axis only — whether the key was as wide as the fact. It is
+// not the whole trustworthiness of a number: how far the producing CHANNEL
+// can be trusted is the other axis, carried by LimitSource.Rank (a feed, for
+// instance, is KeyExact here because it declares a number directly, yet ranks
+// low because a side channel can change meaning without a version handle). A
+// consumer that wants full confidence must consult both.
+func (c KeyConfidence) Soft() bool {
+	return c != KeyExact
+}
+
 // Table maps a normalized model id to its context window in tokens.
 type Table map[string]int
 
@@ -110,6 +183,29 @@ type Table map[string]int
 // runtime.context_window without waiting for a marvel release. The
 // learned rung helps only where a harness declares its own window, which
 // today is Claude alone (see Learn).
+//
+// # The default-versus-maximum convention
+//
+// A model with an extended-context beta appears under two keys: the bare id
+// carries the DEFAULT window and the [1m]-suffixed id the MAXIMUM. The
+// vendor's models-overview page lists a single context-window figure (the
+// maximum) for such a model, with no default/max split shown, so the table
+// and the page do not disagree about a number — they disagree about what the
+// number MEANS. That gap has cost a re-verification round before: reading 1M
+// on the page and 200000 in the code looks like staleness (aae-orc-wyza, the
+// gh-144 review, 2026-08-08). Stated so it need not be rediscovered:
+//
+//   - bare = the default window, [1m] = the extended window Claude Code
+//     opted into (NormalizeModel keeps the suffix, so the two never collapse);
+//   - a model whose only window is 1M carries the same number under both
+//     spellings (claude-opus-5) or under [1m] alone (claude-fable-5[1m]),
+//     which is a spelling split, not a default/max split.
+//
+// A bare split key is therefore entitlement-NARROW (see Table.keyConfidence):
+// it names a default whose applicability to a given session the id cannot
+// confirm. Whether a bare-keyed session actually receives the default is
+// empirically open (aae-orc-wyza) and a fixture would settle it, as
+// claude-fable-5[1m] settled the suffix convention.
 func DefaultTable() Table {
 	return Table{
 		// The first two are fixture-verified in this repo (the
@@ -187,6 +283,37 @@ func DefaultTable() Table {
 func (t Table) Lookup(model string) (int, bool) {
 	w, ok := t[model]
 	return w, ok
+}
+
+// keyConfidence grades an EXACT table hit on the ENTITLEMENT axis (see the
+// default-versus-maximum convention on DefaultTable). A bare key whose [1m]
+// sibling carries a DIFFERENT window is the default half of a default/max
+// split, and a bare-keyed session's true window turns on an entitlement the
+// id does not carry, so the hit is KeyNarrow. Every other hit is
+// entitlement-exact: a [1m] key names the extended entitlement outright, and
+// a single-window model (no sibling, or a sibling carrying the same number,
+// as claude-opus-5) has no split to be wrong about.
+//
+// This grades entitlement only. The provider axis (a redirected backend
+// serving a different window under the same id) is not visible here; the
+// discriminator downgrades a redirected hit at Resolve time (aae-orc-b2d0p).
+// See the seam in ResolveGraded.
+//
+// normalizedKey must already be NormalizeModel'd, and window is the hit value
+// Lookup returned for it. The method takes the value rather than re-reading
+// the map so its result depends only on what the caller confirmed. The
+// window > 0 guard makes an off-contract call safe: no entry in this system
+// carries a 0 window (DefaultTable has none and Learn rejects them), so a
+// window of 0 means "not a real hit" and the method reports KeyExact rather
+// than misgrading an absent bare key as narrow against a live [1m] sibling.
+func (t Table) keyConfidence(normalizedKey string, window int) KeyConfidence {
+	if strings.HasSuffix(normalizedKey, "[1m]") {
+		return KeyExact
+	}
+	if sib, ok := t[normalizedKey+"[1m]"]; ok && window > 0 && window != sib {
+		return KeyNarrow
+	}
+	return KeyExact
 }
 
 // aliases map the short forms an operator passes to --model onto table
@@ -315,20 +442,57 @@ func NewResolver(t Table) *Resolver {
 	}
 }
 
-// Resolve walks the ladder and returns the window, the rung that
-// produced it, and the resolved model id ("" when none could be found).
-// A zero window means unresolved; callers must report absence rather than
+// Resolve walks the ladder and returns the window, the rung that produced
+// it, and the resolved model id ("" when none could be found). A zero
+// window means unresolved; callers must report absence rather than
 // substituting a default.
 //
-// The branch order below must match limitLadder, which carries the
-// reasoning and is asserted against this function in
-// TestResolveAgreesWithTheLadder. In short: an in-STREAM declaration
-// outranks the operator override because it is what enforces compaction,
-// while a declaration on the statusline FEED ranks under it because a
-// side channel describes the session rather than governing it. Any rung
-// that contradicts the manifest is logged once, naming both and naming
-// which won.
+// Resolve is ResolveGraded without the key-confidence grade, kept so
+// callers that do not yet plumb the grade are unaffected. A new consumer
+// that renders or gates on confidence should call ResolveGraded.
 func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
+	limit, src, _, model := r.ResolveGraded(req)
+	return limit, src, model
+}
+
+// ResolveGraded is Resolve plus a KeyConfidence grade beside the
+// LimitSource (see KeyConfidence). The branch order must match limitLadder,
+// which carries the reasoning; Resolve delegates here, so the ladder order
+// is covered through Resolve by TestResolveAgreesWithTheLadder, and
+// TestResolveDelegatesToResolveGraded pins that the two agree. In short: an
+// in-STREAM declaration outranks the operator override because it is what
+// enforces compaction, while a declaration on the statusline FEED ranks
+// under it because a side channel describes the session rather than governing
+// it. Any rung that contradicts the manifest is logged once, naming both and
+// naming which won.
+//
+// Grades, today: stream, manifest and feed declare a number directly (no
+// keyed lookup narrowed it) and are KeyExact. Learned is KeyExact too — it
+// is a harness measurement matched on its own [1m]-preserving key — but note
+// its narrowness is real on the PROVIDER axis, not the entitlement one: the
+// cache is one Resolver per daemon, so a value learned under one backend can
+// be served to a session on another. Grading that away is the discriminator's
+// job (aae-orc-b2d0p / aae-orc-bv7m), not A-static's; the learned KEY fix is
+// sequenced there, not here. A table hit inherits the entry's entitlement
+// grade (Table.keyConfidence); an alias hit is always KeyNarrow (an alias
+// names whatever the harness points it at, so a hit is not a keyed fact); an
+// unresolved resolution is KeyUndeterminable — marvel cannot vouch for a
+// window it did not find.
+//
+// THE DISCRIMINATOR SEAM (aae-orc-b2d0p, not built here): a redirected
+// backend can serve a different window under the same id, and marvel cannot
+// see the backend today (finding-031). When the spawn-time environment read
+// lands, its verdict enters here — most naturally a field on Request — and
+// downgrades the table (and learned) branch: a redirected KeyExact hit
+// becomes KeyRedirected, and the refuse-guard (aae-orc-bv7m) resolves
+// LimitUnresolved for KeyNarrow ∧ (redirected ∨ undeterminable). How a hit
+// that is BOTH entitlement-narrow and redirected is represented — a
+// precedence over this single enum, or a second field beside it — is that
+// work's design call, deliberately left open here; A-static only fixes the
+// entitlement axis and reserves the vocabulary. Whatever the shape, the guard
+// must refuse WITHIN a rung, never reorder rungs, so it belongs in the table
+// branch below, not before it. Until then this assumes the vendor default.
+func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, string) {
 	model := req.StreamModel
 	if model == "" {
 		model = ModelFromArgs(req.RuntimeArgs)
@@ -339,7 +503,7 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 			r.warnOnce("override:"+model, "context window: %s declared %d for %q, overriding the manifest's %d",
 				req.Harness, req.SampleLimit, model, req.ManifestLimit)
 		}
-		return req.SampleLimit, LimitFromStream, model
+		return req.SampleLimit, LimitFromStream, KeyExact, model
 	}
 
 	if model != "" {
@@ -351,7 +515,7 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 				r.warnOnce("learned-override:"+model, "context window: %s declared %d for %q in a prior session, overriding the manifest's %d",
 					req.Harness, w, model, req.ManifestLimit)
 			}
-			return w, LimitLearned, model
+			return w, LimitLearned, KeyExact, model
 		}
 	}
 
@@ -360,17 +524,21 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 			r.warnOnce("feed-override:"+model, "context window: %s feed declared %d for %q; the manifest's %d wins, because a side channel does not outrank an operator override",
 				req.Harness, req.FeedLimit, model, req.ManifestLimit)
 		}
-		return req.ManifestLimit, LimitFromManifest, model
+		return req.ManifestLimit, LimitFromManifest, KeyExact, model
 	}
 
 	if req.FeedLimit > 0 {
-		return req.FeedLimit, LimitFromFeed, model
+		return req.FeedLimit, LimitFromFeed, KeyExact, model
 	}
 
 	if model != "" {
 		n := NormalizeModel(model)
 		r.mu.RLock()
 		w, ok := r.table.Lookup(n)
+		var key KeyConfidence
+		if ok {
+			key = r.table.keyConfidence(n, w)
+		}
 		var aw int
 		var aok bool
 		if !ok {
@@ -380,14 +548,14 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 		}
 		r.mu.RUnlock()
 		if ok {
-			return w, LimitFromTable, model
+			return w, LimitFromTable, key, model
 		}
 		if aok {
-			return aw, LimitFromTableAlias, model
+			return aw, LimitFromTableAlias, KeyNarrow, model
 		}
 	}
 
-	return 0, LimitUnresolved, model
+	return 0, LimitUnresolved, KeyUndeterminable, model
 }
 
 // Learn records a window a harness declared, keyed on NormalizeModel so

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -87,9 +87,10 @@ func TestModelFromArgs(t *testing.T) {
 	}
 }
 
-// TestResolveLadderPrecedence walks every rung, asserting both the value
-// and the grade. The grade is load-bearing: a consumer must be able to
-// refuse on low confidence without refusing on measurement.
+// TestResolveLadderPrecedence walks every rung, asserting the value and the
+// LimitSource. The KeyConfidence grade is asserted separately in
+// TestResolveGradedGradesEachRung and TestResolveGradedOverDefaultTable,
+// which call ResolveGraded; this one exercises the legacy Resolve signature.
 func TestResolveLadderPrecedence(t *testing.T) {
 	t.Parallel()
 	table := Table{"claude-haiku-4-5": 200_000, "claude-opus-4-8": 200_000}
@@ -363,6 +364,329 @@ func TestEveryAliasResolvesToARealEntry(t *testing.T) {
 	for alias, canon := range aliases {
 		if _, ok := tbl.Lookup(canon); !ok {
 			t.Errorf("alias %q points at %q, which is not a table key", alias, canon)
+		}
+	}
+}
+
+// Only KeyExact is a hard fact; everything else, including the zero value
+// and any grade a later writer adds, must read as soft. A consumer that
+// forgets to set the grade then defaults to soft rather than silently
+// presenting a narrow value as exact.
+func TestKeyConfidenceSoft(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		c        KeyConfidence
+		wantSoft bool
+	}{
+		{KeyExact, false},
+		{KeyNarrow, true},
+		{KeyRedirected, true},
+		{KeyUndeterminable, true},
+		{KeyConfidence(""), true}, // zero value defaults to soft
+	}
+	for _, c := range cases {
+		if got := c.c.Soft(); got != c.wantSoft {
+			t.Errorf("KeyConfidence(%q).Soft() = %v, want %v", c.c, got, c.wantSoft)
+		}
+	}
+}
+
+// Every DefaultTable entry's entitlement grade, pinned. This documents the
+// default-versus-maximum convention as data (aae-orc-wyza): a bare split key
+// is narrow, a [1m] key and a single-window model are exact. A new table
+// entry must add its expected grade here, so shipping one is a decision
+// about its key confidence, not an accident — the same discipline
+// TestDefaultTableShipsNoGuessedEntries enforces for the values.
+func TestDefaultTableEntryGrades(t *testing.T) {
+	t.Parallel()
+	tbl := DefaultTable()
+	want := map[string]KeyConfidence{
+		"claude-haiku-4-5":      KeyExact,  // no [1m] sibling: single window
+		"claude-fable-5[1m]":    KeyExact,  // [1m] key names the entitlement
+		"claude-sonnet-4-6":     KeyNarrow, // default half of a 200k/1M split
+		"claude-sonnet-4-6[1m]": KeyExact,
+		"claude-sonnet-5":       KeyExact, // no 200k variant
+		"claude-opus-4-7":       KeyNarrow,
+		"claude-opus-4-7[1m]":   KeyExact,
+		"claude-opus-4-8":       KeyNarrow,
+		"claude-opus-4-8[1m]":   KeyExact,
+		"claude-opus-5":         KeyExact, // 1M under both spellings: spelling split, not default/max
+		"claude-opus-5[1m]":     KeyExact,
+	}
+	for key := range tbl {
+		if _, named := want[key]; !named {
+			t.Errorf("table key %q has no pinned key-confidence grade; add it to this test", key)
+		}
+	}
+	for key, wantKey := range want {
+		if _, ok := tbl.Lookup(key); !ok {
+			t.Errorf("pinned grade names %q, which is not a table key", key)
+			continue
+		}
+		if got := tbl.keyConfidence(key, tbl[key]); got != wantKey {
+			t.Errorf("keyConfidence(%q) = %q, want %q", key, got, wantKey)
+		}
+	}
+}
+
+// keyConfidence must react to the STRUCTURE of the table it is called on,
+// not to hard-coded names: a bare key is narrow only when its [1m] sibling
+// carries a DIFFERENT window. This is what keeps opus-5 (1M under both
+// spellings) exact while sonnet-4-6 (200k/1M) is narrow.
+func TestKeyConfidenceReadsTheTableStructure(t *testing.T) {
+	t.Parallel()
+	// A split the caller invented: bare differs from [1m], so bare is narrow.
+	split := Table{"mdl": 200_000, "mdl[1m]": 1_000_000}
+	if got := split.keyConfidence("mdl", split["mdl"]); got != KeyNarrow {
+		t.Errorf("split bare key: keyConfidence = %q, want KeyNarrow", got)
+	}
+	if got := split.keyConfidence("mdl[1m]", split["mdl[1m]"]); got != KeyExact {
+		t.Errorf("split [1m] key: keyConfidence = %q, want KeyExact", got)
+	}
+	// Same number under both spellings: a spelling split, not a default/max
+	// split, so the bare key is exact.
+	same := Table{"mdl": 1_000_000, "mdl[1m]": 1_000_000}
+	if got := same.keyConfidence("mdl", same["mdl"]); got != KeyExact {
+		t.Errorf("same-value bare key: keyConfidence = %q, want KeyExact", got)
+	}
+	// No sibling at all: single window, exact.
+	solo := Table{"mdl": 200_000}
+	if got := solo.keyConfidence("mdl", solo["mdl"]); got != KeyExact {
+		t.Errorf("solo key: keyConfidence = %q, want KeyExact", got)
+	}
+	// Off-contract: a bare key absent from the table, whose [1m] sibling IS
+	// present, must not misgrade as narrow. An absent key carries no window,
+	// so the caller passes 0, and the window > 0 guard reports KeyExact. This
+	// pins the re-read hole closed: without the guard, 0 != sibling would
+	// wrongly report KeyNarrow.
+	orphanSibling := Table{"mdl[1m]": 1_000_000}
+	if got := orphanSibling.keyConfidence("mdl", 0); got != KeyExact {
+		t.Errorf("absent bare key with a live sibling: keyConfidence = %q, want KeyExact", got)
+	}
+}
+
+// TestResolveGradedGradesEachRung walks every rung and asserts the
+// KeyConfidence beside the value and source. The grade is orthogonal to the
+// source: a directly declared value (stream, learned, manifest, feed) is
+// KeyExact whatever its rung, a table hit carries the entry's entitlement
+// grade, an alias hit is always narrow, and a miss is undeterminable.
+func TestResolveGradedGradesEachRung(t *testing.T) {
+	t.Parallel()
+	// opus-4-8 has a differently-valued [1m] sibling → its bare key is narrow.
+	table := Table{
+		"claude-haiku-4-5":    200_000,
+		"claude-opus-4-8":     200_000,
+		"claude-opus-4-8[1m]": 1_000_000,
+	}
+	cases := []struct {
+		name       string
+		req        Request
+		learn      string
+		learnValue int
+		wantLimit  int
+		wantSource LimitSource
+		wantKey    KeyConfidence
+	}{
+		{
+			name:       "stream is exact",
+			req:        Request{StreamModel: "claude-haiku-4-5", SampleLimit: 999_999},
+			wantLimit:  999_999,
+			wantSource: LimitFromStream,
+			wantKey:    KeyExact,
+		},
+		{
+			// No ManifestLimit: a learned hit alone exercises the grade, and
+			// avoids the learned-over-manifest warnOnce writing to the global
+			// logger under t.Parallel().
+			name:       "learned is exact",
+			req:        Request{StreamModel: "claude-haiku-4-5"},
+			learn:      "claude-haiku-4-5",
+			learnValue: 222_222,
+			wantLimit:  222_222,
+			wantSource: LimitLearned,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "manifest is exact",
+			req:        Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
+			wantLimit:  111_111,
+			wantSource: LimitFromManifest,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "feed is exact",
+			req:        Request{StreamModel: "claude-haiku-4-5", FeedLimit: 444_444},
+			wantLimit:  444_444,
+			wantSource: LimitFromFeed,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "table hit on a single-window model is exact",
+			req:        Request{StreamModel: "claude-haiku-4-5"},
+			wantLimit:  200_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "table hit on a split default key is narrow",
+			req:        Request{StreamModel: "claude-opus-4-8"},
+			wantLimit:  200_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyNarrow,
+		},
+		{
+			name:       "table hit on the [1m] key is exact",
+			req:        Request{StreamModel: "claude-opus-4-8[1m]"},
+			wantLimit:  1_000_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "alias hit is narrow even pointing at an exact entry",
+			req:        Request{RuntimeArgs: []string{"--model", "haiku"}},
+			wantLimit:  200_000,
+			wantSource: LimitFromTableAlias,
+			wantKey:    KeyNarrow,
+		},
+		{
+			name:       "unknown model is undeterminable",
+			req:        Request{StreamModel: "some-model-nobody-shipped"},
+			wantLimit:  0,
+			wantSource: LimitUnresolved,
+			wantKey:    KeyUndeterminable,
+		},
+		{
+			name:       "no model at all is undeterminable",
+			req:        Request{Harness: "codex"},
+			wantLimit:  0,
+			wantSource: LimitUnresolved,
+			wantKey:    KeyUndeterminable,
+		},
+	}
+	for _, c := range cases {
+		r := NewResolver(table)
+		if c.learn != "" {
+			r.Learn(c.learn, c.learnValue)
+		}
+		limit, src, key, _ := r.ResolveGraded(c.req)
+		if limit != c.wantLimit {
+			t.Errorf("%s: limit = %d, want %d", c.name, limit, c.wantLimit)
+		}
+		if src != c.wantSource {
+			t.Errorf("%s: source = %q, want %q", c.name, src, c.wantSource)
+		}
+		if key != c.wantKey {
+			t.Errorf("%s: key confidence = %q, want %q", c.name, key, c.wantKey)
+		}
+	}
+}
+
+// An unresolved resolution always carries KeyUndeterminable: marvel cannot
+// vouch for a window it did not find. This is the invariant the refuse-guard
+// (aae-orc-bv7m) will preserve when it resolves LimitUnresolved for a narrow
+// redirected key.
+func TestUnresolvedIsUndeterminable(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{"claude-haiku-4-5": 200_000})
+	for _, req := range []Request{
+		{StreamModel: "some-model-nobody-shipped"},
+		{Harness: "codex"},
+	} {
+		limit, src, key, _ := r.ResolveGraded(req)
+		if limit != 0 || src != LimitUnresolved {
+			t.Fatalf("expected an unresolved resolution, got %d/%q", limit, src)
+		}
+		if key != KeyUndeterminable {
+			t.Errorf("unresolved key confidence = %q, want KeyUndeterminable", key)
+		}
+		if !key.Soft() {
+			t.Error("an unresolved resolution must be soft")
+		}
+	}
+}
+
+// Resolve is ResolveGraded minus the grade. It must agree on the other
+// three returns for every rung, so the legacy signature stays a faithful
+// projection and callers that have not adopted the grade are unaffected.
+func TestResolveDelegatesToResolveGraded(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(DefaultTable())
+	reqs := []Request{
+		{StreamModel: "claude-haiku-4-5", SampleLimit: 999_999},
+		{StreamModel: "claude-opus-4-8"},                // narrow table hit
+		{StreamModel: "claude-opus-4-8[1m]"},            // exact table hit
+		{RuntimeArgs: []string{"--model", "haiku"}},     // alias
+		{StreamModel: "some-model-nobody-shipped"},      // unresolved
+		{StreamModel: "claude-haiku-4-5", FeedLimit: 5}, // feed
+	}
+	for _, req := range reqs {
+		gLimit, gSrc, _, gModel := r.ResolveGraded(req)
+		limit, src, model := r.Resolve(req)
+		if limit != gLimit || src != gSrc || model != gModel {
+			t.Errorf("Resolve(%+v) = (%d,%q,%q); ResolveGraded = (%d,%q,%q)", req, limit, src, model, gLimit, gSrc, gModel)
+		}
+	}
+}
+
+// The unit tests grade keyConfidence and grade ResolveGraded over ad-hoc
+// tables; this one closes the loop by driving ResolveGraded over the SHIPPED
+// DefaultTable, so table structure, aliases, and the ladder are asserted
+// together against the real data — including that an alias floors to
+// KeyNarrow even when it points at an entitlement-exact entry.
+func TestResolveGradedOverDefaultTable(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(DefaultTable())
+	cases := []struct {
+		name       string
+		req        Request
+		wantLimit  int
+		wantSource LimitSource
+		wantKey    KeyConfidence
+	}{
+		{
+			name:       "shipped split default key is narrow",
+			req:        Request{StreamModel: "claude-opus-4-8"},
+			wantLimit:  200_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyNarrow,
+		},
+		{
+			name:       "shipped [1m] key is exact",
+			req:        Request{StreamModel: "claude-opus-4-8[1m]"},
+			wantLimit:  1_000_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyExact,
+		},
+		{
+			name:       "shipped single-window model is exact",
+			req:        Request{StreamModel: "claude-opus-5"},
+			wantLimit:  1_000_000,
+			wantSource: LimitFromTable,
+			wantKey:    KeyExact,
+		},
+		{
+			// opus → claude-opus-4-8, a narrow entry: narrow either way.
+			name:       "alias onto a narrow entry is narrow",
+			req:        Request{RuntimeArgs: []string{"--model", "opus"}},
+			wantLimit:  200_000,
+			wantSource: LimitFromTableAlias,
+			wantKey:    KeyNarrow,
+		},
+		{
+			// haiku → claude-haiku-4-5, an EXACT entry, yet the alias floors
+			// it to narrow: an alias is not a keyed fact.
+			name:       "alias onto an exact entry still floors to narrow",
+			req:        Request{RuntimeArgs: []string{"--model", "haiku"}},
+			wantLimit:  200_000,
+			wantSource: LimitFromTableAlias,
+			wantKey:    KeyNarrow,
+		},
+	}
+	for _, c := range cases {
+		limit, src, key, _ := r.ResolveGraded(c.req)
+		if limit != c.wantLimit || src != c.wantSource || key != c.wantKey {
+			t.Errorf("%s: got (%d, %q, %q), want (%d, %q, %q)",
+				c.name, limit, src, key, c.wantLimit, c.wantSource, c.wantKey)
 		}
 	}
 }


### PR DESCRIPTION
## Why

marvel's CTX% denominator has a silent failure mode (finding-031): the window depends on at least `(model, provider, entitlement)`, but the resolver keys on a model string that reliably carries only the model. A **miss is loud** — it renders absence and emits `context.limit-unresolved`. A **wrong hit is silent** — it renders a number with a perfectly normal `LimitSource`, indistinguishable from a correct one. There is nothing today that lets a renderer or an admission gate tell "this number is a keyed fact" from "this number came from a key too narrow to be sure."

This is the cheapest honest step (Option A-static from finding-031 §5): give the resolved value a key-confidence grade so a consumer *can* mark a soft number soft instead of presenting it as exact, and establish the vocabulary the refuse-guard (`aae-orc-bv7m`) and the spawn-time discriminator (`aae-orc-b2d0p`) will speak. It ships with no new mechanism and no behavior change to existing callers — a small, reviewable, additive win that unblocks the rest of the arc. It also writes down the load-bearing default-versus-maximum table convention that has already cost one re-verification round (`aae-orc-wyza`).

It is deliberately **staged scaffolding**: no production path reads the grade yet (wiring it through the accountant, the API, and the renderer is `bv7m`'s scope and touches files outside this ticket), and the redirection discriminator is **not** built here. So this PR does not itself close finding-031 — it defines the words and leaves a clean seam for the fix.

## What

- **`KeyConfidence`** — a new grade (`KeyExact | KeyNarrow | KeyRedirected | KeyUndeterminable`) declared beside, and orthogonal to, `LimitSource`. `LimitSource` names the ladder rung; `KeyConfidence` says whether that rung's key was as wide as the fact. `Soft()` reports "present as low-confidence" for everything but `KeyExact` (zero value included), and its doc states it is the KEY axis only — channel trust remains `LimitSource.Rank`'s axis.
- **`Table.keyConfidence(key, window)`** grades the ENTITLEMENT axis structurally: a bare key whose `[1m]` sibling carries a *different* window is the default half of a default/max split → `KeyNarrow`; a `[1m]` key or a single-window model (opus-5 is 1M under both spellings → a spelling split, not a default/max split) → `KeyExact`. Takes the confirmed hit value so an off-contract call can't misgrade.
- **`ResolveGraded`** returns `(int, LimitSource, KeyConfidence, string)`. Directly declared values (stream, learned, manifest, feed) grade `KeyExact`; a table hit inherits the entry grade; an alias hit is always `KeyNarrow` (an alias is not a keyed fact); an unresolved resolution is `KeyUndeterminable`. **`Resolve` keeps its three-return signature** by delegating, so no existing caller changes.
- **`KeyRedirected`/`KeyUndeterminable`** are declared as the refuse-guard vocabulary; `KeyRedirected` is reserved and never produced until the discriminator lands. A documented **seam** in `ResolveGraded` marks where the spawn-time redirection verdict (`aae-orc-b2d0p`) will enter and downgrade the table branch, and leaves open — as that work's design call — how a hit that is both entitlement-narrow and redirected is represented.
- **`aae-orc-wyza` doc half**: the default-versus-maximum convention is now stated in the `DefaultTable` comment.

Scope held strictly to `internal/usage/limits.go` and its test. The spawn path, `controller.go`, `session.go`, and the daemon are untouched; no discriminator is built.

Developed red→green (a stubbed grade first, watched fail, then implemented). Self-reviewed with the adversarial code-review layers (Blind Hunter, Edge Case Hunter, Acceptance Auditor): the auditor found all six acceptance criteria met; the substantive hunter findings (learned-rung provider narrowness, narrow+redirected composition) are the deferred discriminator/refuse-guard work and are now documented as such, and the cheap wins (off-contract robustness of `keyConfidence`, an end-to-end grade test over the shipped `DefaultTable`, and doc precision) are folded in.

Quality gates: `go build ./...`, `go test -race ./...`, and `golangci-lint run ./...` all pass.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS