### PR TITLE
refactor(team): split reconcile decision from action (planRole/applyRolePlan)

### DIFF
--- a/internal/team/admission.go
+++ b/internal/team/admission.go
@@ -10,9 +10,11 @@ import (
 	"github.com/arcavenae/marvel/internal/events"
 )
 
-// admit evaluates the count clause for one role and returns how many of
-// the requested spawns may proceed. Emitting and latching are side effects,
-// so the caller only has to read the number.
+// admissionVerdict evaluates the count clause for one role and returns the
+// verdict — the pure half of the reconcile admission check. It latches nothing,
+// emits nothing, and writes no store record, so planRole can fold admission
+// into a RolePlan without enacting anything. The effect half is
+// latchAdmissionHold / clearAdmissionHold, run only by applyRolePlan.
 //
 // Never touches RoleHealth in either direction. A refusal is not a crash,
 // and routing one through noteCrashAndBackoff would climb RestartCount
@@ -20,12 +22,12 @@ import (
 // 9999 — durably, in the bolt role_health bucket, surviving restarts. A
 // role held by admission accrues no restart count, so a hold cannot age
 // into a saturation freeze. Caller holds c.mu. See aae-orc-qiay.
-func (c *Controller) admit(t *api.Team, role *api.Role, want int) int {
+func (c *Controller) admissionVerdict(t *api.Team, role *api.Role, want int) admission.Verdict {
 	live := api.CountAlive(c.store.ListSessionsByTeam(t.Workspace, t.Name))
 	// Recomputed per role rather than once per team: spawning for an earlier
 	// role changes the count a later role must be evaluated against, and
 	// computing it once would over-admit within a single tick.
-	v := admission.CheckSessions(t.Budget, live, c.declaredSessions(t), admission.Request{
+	return admission.CheckSessions(t.Budget, live, c.declaredSessions(t), admission.Request{
 		Role: role.Name,
 		Want: want,
 		// The reconciler only ever converges toward an already-declared
@@ -36,36 +38,37 @@ func (c *Controller) admit(t *api.Team, role *api.Role, want int) int {
 		// operator than 0 of 5. The synchronous verbs do the opposite.
 		AllowPartial: true,
 	})
-	if !v.Refused() {
-		c.clearAdmissionHold(t, role.Name)
-		return v.Granted
-	}
+}
 
-	roleKey := t.Workspace + "/" + t.Name + "/" + role.Name
-	key := v.Key()
+// latchAdmissionHold records a standing admission refusal for a role and
+// announces it once. It is the effect half of the reconcile admission check:
+// planRole computes the verdict (admissionVerdict) and stores its Key and
+// Reason on the RolePlan, and applyRolePlan calls this to latch and emit.
+// Emitting only on a change of latched key keeps a standing refusal to one
+// event per transition rather than one per reconcile tick. Caller holds c.mu.
+func (c *Controller) latchAdmissionHold(t *api.Team, role, key, reason string) {
+	roleKey := t.Workspace + "/" + t.Name + "/" + role
 	if c.admissionHolds[roleKey] == key {
-		return v.Granted
+		return
 	}
 	c.admissionHolds[roleKey] = key
-	reason := v.Reason(admission.TriggerReconcile)
 	// Tee to the log ring as well as the event ring: the event ring is
 	// bounded and in-memory, and `marvel daemon logs` works over mrvl://.
-	log.Printf("admission: %s role %s refused: %s", t.Key(), role.Name, reason)
+	log.Printf("admission: %s role %s refused: %s", t.Key(), role, reason)
 	events.Emit(c.Events, events.Event{
 		Kind:      events.KindAdmissionRefused,
 		Severity:  events.SeverityWarning,
 		Workspace: t.Workspace,
 		Team:      t.Name,
-		Role:      role.Name,
+		Role:      role,
 		Message:   reason,
 	})
 	c.setAdmissionState(t, api.AdmissionState{
 		Held:   true,
-		Role:   role.Name,
+		Role:   role,
 		Reason: reason,
 		Since:  c.nowUTC(),
 	})
-	return v.Granted
 }
 
 // clearAdmissionHold drops a role's latch and says so once. A hold

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -690,96 +690,328 @@ func shiftRepairGeneration(t *api.Team, role string) int64 {
 	return t.Shift.OldGeneration
 }
 
+// reconcileRoleAt repairs a role at a given generation by computing its
+// convergence plan and enacting it. The split is the point of this function:
+// planRole decides (pure — no spawns, no store writes, no events) and
+// applyRolePlan acts, so reconcileRoleAt == applyRolePlan(planRole(...)). It is
+// the keystone for the convergence-posture arc — the dry-run surface
+// (aae-orc-nrk1) computes the plan and prints it, the hold posture
+// (aae-orc-rwiw) computes the plan and declines to apply it, and the startup
+// report is the plan at boot. See planRole for the decision, applyRolePlan for
+// the effects, and PlanConvergence for the read-only entry point.
 func (c *Controller) reconcileRoleAt(t *api.Team, role *api.Role, generation int64) {
-	// Counting uses all generations — generation scoping is only
-	// for shift logic (shiftLaunch/shiftDrain). This ensures non-shifting roles
-	// aren't disrupted when only one role shifts and the team generation advances.
+	c.applyRolePlan(t, role, c.planRole(t, role, generation))
+}
+
+// RoleAction is the convergence verb planRole chose for a role this tick. It
+// summarizes the RolePlan for a reader — a dry-run print, a startup report;
+// the payload fields (Spawn, Delete, Hold) carry the detail.
+type RoleAction string
+
+const (
+	// RoleSteady means the alive replica count already matches desired —
+	// nothing to do.
+	RoleSteady RoleAction = "steady"
+	// RoleSpawn means the plan creates Spawn new sessions. On a partial
+	// admission grant, Action is RoleSpawn with Spawn < Desired-Actual and Hold
+	// set to HoldAdmission — so a reader must consult Hold even when the action
+	// is a spawn.
+	RoleSpawn RoleAction = "spawn"
+	// RoleScaleDown means the plan deletes the sessions in Delete.
+	RoleScaleDown RoleAction = "scale_down"
+	// RoleHold means actual is below desired but nothing is spawned this tick —
+	// withheld by crash-loop backoff or a full admission refusal. Hold names
+	// which.
+	RoleHold RoleAction = "hold"
+)
+
+// HoldReason names why a would-be spawn is withheld, in whole or in part. It is
+// set whenever the plan spawns fewer sessions than (Desired-Actual): on a full
+// hold (Action==RoleHold) and on a partial admission grant (Action==RoleSpawn
+// with Spawn < Desired-Actual).
+type HoldReason string
+
+const (
+	// HoldNone means nothing is withheld.
+	HoldNone HoldReason = ""
+	// HoldBackoff means the role is inside its crash-loop backoff window (or
+	// frozen at MaxRestarts / restart_policy=never saturation).
+	HoldBackoff HoldReason = "crash_loop_backoff"
+	// HoldAdmission means a team budget refused some or all of the spawn.
+	HoldAdmission HoldReason = "admission"
+)
+
+// RolePlan is the convergence decision for one role at one generation: what the
+// reconciler would change, computed without changing anything. planRole
+// produces it (pure — it reads state but mutates none), and applyRolePlan
+// enacts exactly it. Exposing the decision as an inspectable value is the
+// keystone for the convergence-posture arc (question-convergence-posture,
+// aae-orc-nf0w): the dry-run surface prints it, the hold posture computes it
+// and declines to apply, and the startup report is the plan at boot.
+type RolePlan struct {
+	Workspace  string
+	Team       string
+	Role       string
+	Generation int64
+	// Desired is the role's declared replica count.
+	Desired int
+	// Actual is the number of the role's sessions that count as alive now.
+	Actual int
+	// Action is the convergence verb — a summary of the fields below.
+	Action RoleAction
+	// Spawn is how many new sessions applyRolePlan would create. Zero unless
+	// Action is RoleSpawn.
+	Spawn int
+	// Delete is the exact set of sessions applyRolePlan would remove, in the
+	// order it removes them (newest first). Non-empty only when Action is
+	// RoleScaleDown.
+	Delete []api.Session
+	// Hold names why the plan spawns fewer than Desired-Actual sessions, when
+	// it does; HoldNone otherwise.
+	Hold HoldReason
+	// HoldDetail is the human-readable reason behind Hold, for a dry-run or
+	// startup report. It is plan metadata only — never emitted as an event, so
+	// it changes no reconcile behavior.
+	HoldDetail string
+
+	// admission is the admission bookkeeping applyRolePlan must perform — clear
+	// a stale hold, or latch and announce a refusal. Computed purely here,
+	// enacted only in apply. Unexported: it is apply plumbing, not part of the
+	// inspectable decision.
+	admission admissionIntent
+}
+
+// admissionOp is the admission bookkeeping applyRolePlan performs for a role.
+type admissionOp int
+
+const (
+	// admissionNoop leaves the role's admission latch untouched — the gate was
+	// not reached this tick, so a role cooling down in backoff keeps whatever
+	// hold it had.
+	admissionNoop admissionOp = iota
+	// admissionClear drops any standing hold: the gate was satisfied or never
+	// applied this tick.
+	admissionClear
+	// admissionLatch records a standing refusal and announces it once.
+	admissionLatch
+)
+
+// admissionIntent carries what applyRolePlan needs to enact the admission
+// bookkeeping planRole decided, without re-running the check.
+type admissionIntent struct {
+	op     admissionOp
+	key    string // verdict key to latch (admissionLatch)
+	reason string // human reason for the event and AdmissionState (admissionLatch)
+}
+
+// planRole computes the convergence decision for a role at a generation without
+// enacting it: no session is spawned or deleted, no store record is written, no
+// event is emitted, and the admission-latch and RoleHealth maps are read but
+// never mutated. Every effect the decision implies is recorded on the returned
+// RolePlan for applyRolePlan to enact.
+//
+// Counting uses all generations — generation scoping is only for shift logic
+// (shiftLaunch/shiftDrain), so non-shifting roles aren't disrupted when one
+// role shifts and the team generation advances. Caller holds c.mu.
+func (c *Controller) planRole(t *api.Team, role *api.Role, generation int64) RolePlan {
 	current := c.store.ListSessionsByTeamRole(t.Workspace, t.Name, role.Name)
 	desired := role.Replicas
-	actual := 0
-	for _, sess := range current {
-		if sess.State.CountsAsAlive() {
-			actual++
-		}
+	actual := api.CountAlive(current)
+
+	plan := RolePlan{
+		Workspace:  t.Workspace,
+		Team:       t.Name,
+		Role:       role.Name,
+		Generation: generation,
+		Desired:    desired,
+		Actual:     actual,
+		Action:     RoleSteady,
 	}
 
-	// An admission hold describes a refusal that is still happening. Drop it
-	// as soon as the gate below is not reached at all — the role is
-	// satisfied, the budget was removed from the manifest, or a shift took
-	// over — so `admission.cleared` fires and Team.Admission stops naming a
-	// condition that has passed.
+	// An admission hold describes a refusal that is still happening. Drop it as
+	// soon as the gate below is not reached at all — the role is satisfied, the
+	// budget was removed from the manifest, or a shift took over — so
+	// applyRolePlan fires admission.cleared and Team.Admission stops naming a
+	// condition that has passed. This is the old top-of-function clear; a role
+	// that instead reaches the admission gate below overrides it there.
 	if actual >= desired || !t.Budget.Declared() || t.Shift.Phase != api.ShiftNone {
-		c.clearAdmissionHold(t, role.Name)
+		plan.admission = admissionIntent{op: admissionClear}
 	}
 
-	if actual < desired {
-		// Respect crash-loop backoff. If the role is cooling down from
-		// a recent restart, hold off on spawning replacements until the
-		// backoff window elapses. Without this the reconciler would
-		// immediately recreate a session we just deleted and defeat
-		// the whole backoff. Reap-path saturation (MaxRestarts) is
-		// also honored here: noteCrashAndBackoff freezes BackoffUntil
-		// to the far future on saturation, so this same gate refuses
-		// respawns once a role has exhausted its budget. See
-		// ArcavenAE/marvel#11.
+	switch {
+	case actual < desired:
+		// Respect crash-loop backoff. If the role is cooling down from a recent
+		// restart, spawn nothing until the backoff window elapses; without this
+		// the reconciler would immediately recreate a session we just deleted
+		// and defeat the whole backoff. Reap-path saturation (MaxRestarts) is
+		// honored here too: noteCrashAndBackoff freezes BackoffUntil to the far
+		// future on saturation, so this same gate withholds respawns once a role
+		// has exhausted its budget. Read-only — the hold is recorded on the
+		// plan, not enacted. See ArcavenAE/marvel#11.
 		roleKey := t.Workspace + "/" + t.Name + "/" + role.Name
 		if rh, ok := c.roleHealth[roleKey]; ok && c.nowUTC().Before(rh.BackoffUntil) {
-			return
+			plan.Action = RoleHold
+			plan.Hold = HoldBackoff
+			// A MaxRestarts / restart_policy=never freeze parks BackoffUntil at
+			// the year-9999 sentinel; render it as a freeze rather than a finite
+			// window so a dry-run reader is not told a permanent hold expires in
+			// 9999. HoldDetail is plan metadata only — never emitted — so this
+			// distinction changes no reconcile behavior.
+			if rh.BackoffUntil.Equal(saturationFreezeUntil) {
+				plan.HoldDetail = fmt.Sprintf("frozen at max_restarts (restart #%d)", rh.RestartCount)
+			} else {
+				plan.HoldDetail = fmt.Sprintf("crash-loop backoff until %s", rh.BackoffUntil.Format(time.RFC3339))
+			}
+			return plan
 		}
+
 		// Admission backstop against a team-declared budget (aae-orc-qiay,
-		// resource-matrix enforcement locus 2). The primary refusal point is
-		// the operator's verb, where nothing has been committed yet; this
-		// catches the state a manifest declaration cannot see, chiefly a
-		// declared count that is itself over the ceiling after an
-		// out-of-band write or two racing scale calls.
+		// resource-matrix enforcement locus 2). The primary refusal point is the
+		// operator's verb, where nothing has been committed yet; this catches
+		// the state a manifest declaration cannot see, chiefly a declared count
+		// that is itself over the ceiling after an out-of-band write or two
+		// racing scale calls.
 		//
 		// Session-count only: the token clause is monotonic within a daemon
 		// lifetime, so gating repair on it would make an over-budget team
-		// permanently unrepairable (R2). Placed AFTER the backoff gate so a
-		// cooling role emits no admission event (backoff is the older,
-		// stronger condition), and BEFORE ClearCrashedForRole because that
-		// call mutates store state: refusing after it would delete this
-		// role's Crashed markers every tick while never spawning.
-		//
-		// Skipped entirely while a shift is in progress, so a launching
-		// generation's transient double count cannot refuse a non-shifting
-		// role's legitimate repair (R5).
+		// permanently unrepairable (R2). Evaluated AFTER the backoff gate so a
+		// cooling role records no admission bookkeeping (backoff is the older,
+		// stronger condition). Skipped entirely while a shift is in progress, so
+		// a launching generation's transient double count cannot refuse a
+		// non-shifting role's legitimate repair (R5).
 		if t.Budget.Declared() && t.Shift.Phase == api.ShiftNone {
-			granted := c.admit(t, role, desired-actual)
-			if granted <= 0 {
-				return
+			v := c.admissionVerdict(t, role, desired-actual)
+			if v.Refused() {
+				reason := v.Reason(admission.TriggerReconcile)
+				plan.admission = admissionIntent{op: admissionLatch, key: v.Key(), reason: reason}
+				plan.Hold = HoldAdmission
+				plan.HoldDetail = reason
+				if v.Granted <= 0 {
+					plan.Action = RoleHold
+					return plan
+				}
+				// Partial grant: spawn what was granted; the hold names the rest.
+				plan.Spawn = v.Granted
+				plan.Action = RoleSpawn
+				return plan
 			}
-			desired = actual + granted
+			// Fully granted — the gate is satisfied, so any standing hold clears.
+			plan.admission = admissionIntent{op: admissionClear}
+			plan.Spawn = v.Granted
+			plan.Action = RoleSpawn
+			return plan
 		}
-		// Crash markers from the reap path have done their observability
-		// job by now (operators saw them during the backoff window). The
-		// fresh session is the new truth — clear stale Crashed markers
-		// for this role so nextIndex computes against live sessions only
-		// and `marvel get sessions` doesn't carry the ghost forward.
-		c.sessMgr.ClearCrashedForRole(t.Workspace, t.Name, role.Name)
-		for i := actual; i < desired; i++ {
-			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, role.Name, generation, c.nextIndex(t, role, generation))
+
+		// No budget (or mid-shift): converge the whole deficit.
+		plan.Spawn = desired - actual
+		plan.Action = RoleSpawn
+		return plan
+
+	case actual > desired:
+		// Shed the excess, newest first — the same sessions and order the old
+		// reconcileRoleAt deleted (current[len-1-i]).
+		excess := actual - desired
+		plan.Delete = make([]api.Session, 0, excess)
+		for i := 0; i < excess; i++ {
+			plan.Delete = append(plan.Delete, current[len(current)-1-i])
+		}
+		plan.Action = RoleScaleDown
+		return plan
+	}
+
+	return plan
+}
+
+// applyRolePlan enacts a RolePlan: the admission bookkeeping planRole decided,
+// then the spawns or the deletes. This is the only side-effecting half of the
+// per-role reconcile decision — the dry-run surface and the hold posture reach
+// the same RolePlan and stop short of calling this.
+//
+// role must be the same role plan.Role names: apply reads role.Runtime for new
+// sessions and role.Name via nextIndex (which must see live store state to pick
+// a non-colliding index, so it is deliberately not precomputed on the plan).
+// reconcileRoleAt builds the plan from this same role, keeping them coupled.
+// Caller holds c.mu.
+func (c *Controller) applyRolePlan(t *api.Team, role *api.Role, plan RolePlan) {
+	switch plan.admission.op {
+	case admissionNoop:
+		// Gate not reached this tick (e.g. a role cooling down in backoff);
+		// leave the role's admission latch as it stands.
+	case admissionClear:
+		c.clearAdmissionHold(t, plan.Role)
+	case admissionLatch:
+		c.latchAdmissionHold(t, plan.Role, plan.admission.key, plan.admission.reason)
+	}
+
+	if plan.Spawn > 0 {
+		// Crash markers from the reap path have done their observability job by
+		// now (operators saw them during the backoff window). The fresh session
+		// is the new truth — clear stale Crashed markers for this role, in the
+		// same order as the old reconcileRoleAt (clear, then create), so
+		// nextIndex computes against live sessions only and `marvel get
+		// sessions` doesn't carry the ghost forward.
+		c.sessMgr.ClearCrashedForRole(t.Workspace, t.Name, plan.Role)
+		for i := 0; i < plan.Spawn; i++ {
+			name := fmt.Sprintf("%s-%s-g%d-%d", t.Name, plan.Role, plan.Generation, c.nextIndex(t, role, plan.Generation))
 			sess := &api.Session{
 				Name:       name,
 				Workspace:  t.Workspace,
 				Team:       t.Name,
-				Role:       role.Name,
-				Generation: generation,
+				Role:       plan.Role,
+				Generation: plan.Generation,
 				Runtime:    role.Runtime,
 			}
 			if err := c.sessMgr.Create(sess); err != nil {
 				log.Printf("reconcile: create session %s: %v", name, err)
 			}
 		}
-	} else if actual > desired {
-		excess := actual - desired
-		for i := 0; i < excess; i++ {
-			sess := current[len(current)-1-i]
-			if err := c.sessMgr.Delete(sess.Key()); err != nil {
-				log.Printf("reconcile: delete session %s: %v", sess.Key(), err)
-			}
+	}
+
+	for _, sess := range plan.Delete {
+		if err := c.sessMgr.Delete(sess.Key()); err != nil {
+			log.Printf("reconcile: delete session %s: %v", sess.Key(), err)
 		}
 	}
+}
+
+// PlanConvergence returns the steady-state convergence plan for every team not
+// mid-shift — the sessions the next reconcile tick would spawn or scale down,
+// computed without enacting anything. It is the read-only companion to
+// ReconcileOnce's role loop and the inspection seam the dry-run surface
+// (aae-orc-nrk1), the hold posture (aae-orc-rwiw), and the startup report build
+// on. It takes c.mu and must NOT be called by a caller already holding it (the
+// mutex is not reentrant).
+//
+// Two fidelity limits a consumer must account for; both are properties of this
+// aggregate view, not of any single RolePlan, and neither affects the live
+// reconciler (which never calls this):
+//
+//   - Budgeted multi-role teams are evaluated per role against CURRENT live
+//     state, because no plan is applied between roles here. A real tick applies
+//     each role before planning the next (that is why admissionVerdict recounts
+//     per role), so when several roles share one MaxSessions the summed Spawn
+//     across the returned plans can exceed the headroom a real sequence of ticks
+//     would grant. A consumer that needs a budget-accurate multi-role preview
+//     must simulate sequential application itself.
+//   - A team mid-shift contributes nothing. reconcileTeam defers such a team to
+//     reconcileShift, which reconciles roles at shift-aware generations; that
+//     path is out of scope for this steady-state view, so a dry-run built on it
+//     under-reports repairs that happen during a rotation.
+func (c *Controller) PlanConvergence() []RolePlan {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	teams := c.store.ListTeams()
+	var plans []RolePlan
+	for i := range teams {
+		t := &teams[i]
+		if t.Shift.Phase != api.ShiftNone {
+			continue
+		}
+		for j := range t.Roles {
+			plans = append(plans, c.planRole(t, &t.Roles[j], t.Generation))
+		}
+	}
+	return plans
 }
 
 // evaluateHealth checks heartbeat staleness for all sessions and applies

--- a/internal/team/plan_test.go
+++ b/internal/team/plan_test.go
@@ -1,0 +1,411 @@
+package team
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/events"
+)
+
+// planTestWS and planTestGen are the workspace and generation every
+// side-effect-free plan test seeds into. These tests never spawn, so both are
+// fixed rather than parameters (their only value would be these constants).
+const (
+	planTestWS  = "ws"
+	planTestGen = int64(1)
+)
+
+// addAliveSessions inserts n running sessions for a role straight into the
+// store, bypassing the session manager (and tmux) entirely. The reconcile
+// decision is store-based, so the plan tests need real rows but not real panes.
+func addAliveSessions(t *testing.T, store *api.Store, team, role string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := store.CreateSession(&api.Session{
+			Name:       fmt.Sprintf("%s-%s-g%d-%d", team, role, planTestGen, i),
+			Workspace:  planTestWS,
+			Team:       team,
+			Role:       role,
+			Generation: planTestGen,
+			State:      api.SessionRunning,
+		}); err != nil {
+			t.Fatalf("seed session: %v", err)
+		}
+	}
+}
+
+// sessionKeySet is a helper for order-independent membership assertions.
+func sessionKeySet(sessions []api.Session) map[string]struct{} {
+	set := make(map[string]struct{}, len(sessions))
+	for i := range sessions {
+		set[sessions[i].Key()] = struct{}{}
+	}
+	return set
+}
+
+// --- Property 1: planRole/PlanConvergence are side-effect-free ---------------
+
+// TestPlanRoleDecision is the pure decision table: every convergence shape,
+// asserted on the RolePlan value. The session manager is nil, so a stray spawn
+// or delete inside planRole would panic rather than pass silently — that is the
+// guard this test adds. Store-write / event / admission-latch purity is proven
+// separately by TestPlanConvergenceIsSideEffectFree; together they cover
+// planRole's side-effect-freedom.
+func TestPlanRoleDecision(t *testing.T) {
+	fixed := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		budget     api.Budget
+		replicas   int
+		alive      int
+		backoff    bool // seed a crash-loop backoff window in the future
+		wantAction RoleAction
+		wantSpawn  int
+		wantDelete int
+		wantHold   HoldReason
+		wantAdmOp  admissionOp
+		admKeySet  bool // admission latch must carry a non-empty key + reason
+	}{
+		{
+			name:       "scale up, no budget",
+			replicas:   3,
+			alive:      0,
+			wantAction: RoleSpawn,
+			wantSpawn:  3,
+			wantHold:   HoldNone,
+			wantAdmOp:  admissionClear, // top clear fires on !Budget.Declared()
+		},
+		{
+			name:       "scale down",
+			replicas:   1,
+			alive:      3,
+			wantAction: RoleScaleDown,
+			wantDelete: 2,
+			wantHold:   HoldNone,
+			wantAdmOp:  admissionClear, // top clear fires on actual>=desired
+		},
+		{
+			name:       "steady",
+			replicas:   2,
+			alive:      2,
+			wantAction: RoleSteady,
+			wantHold:   HoldNone,
+			wantAdmOp:  admissionClear,
+		},
+		{
+			name:       "backoff hold keeps the admission latch untouched",
+			budget:     api.Budget{MaxSessions: 5},
+			replicas:   2,
+			alive:      1,
+			backoff:    true,
+			wantAction: RoleHold,
+			wantHold:   HoldBackoff,
+			wantAdmOp:  admissionNoop, // budget declared + gate not reached => untouched
+		},
+		{
+			name:       "admission full grant",
+			budget:     api.Budget{MaxSessions: 5},
+			replicas:   3,
+			alive:      2,
+			wantAction: RoleSpawn,
+			wantSpawn:  1,
+			wantHold:   HoldNone,
+			wantAdmOp:  admissionClear,
+		},
+		{
+			name:       "admission full refusal",
+			budget:     api.Budget{MaxSessions: 2},
+			replicas:   3,
+			alive:      2,
+			wantAction: RoleHold,
+			wantHold:   HoldAdmission,
+			wantAdmOp:  admissionLatch,
+			admKeySet:  true,
+		},
+		{
+			name:       "admission partial grant spawns and holds",
+			budget:     api.Budget{MaxSessions: 3},
+			replicas:   5,
+			alive:      2,
+			wantAction: RoleSpawn,
+			wantSpawn:  1, // headroom(3,2)=1 of a 3-session deficit
+			wantHold:   HoldAdmission,
+			wantAdmOp:  admissionLatch,
+			admKeySet:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := api.NewStore()
+			ctrl := NewController(store, nil)
+			ctrl.now = func() time.Time { return fixed }
+
+			const ws, team, role = "ws", "team", "worker"
+			team1 := api.Team{
+				Name:       team,
+				Workspace:  ws,
+				Budget:     tc.budget,
+				Roles:      []api.Role{{Name: role, Replicas: tc.replicas, Runtime: api.Runtime{Name: "sleep", Command: "sleep"}}},
+				Generation: 1,
+			}
+			addAliveSessions(t, store, team, role, tc.alive)
+			if tc.backoff {
+				ctrl.roleHealth[ws+"/"+team+"/"+role] = &RoleHealth{
+					RestartCount: 2,
+					BackoffUntil: fixed.Add(time.Minute),
+				}
+			}
+
+			plan := ctrl.planRole(&team1, &team1.Roles[0], team1.Generation)
+
+			if plan.Action != tc.wantAction {
+				t.Errorf("Action = %q, want %q", plan.Action, tc.wantAction)
+			}
+			if plan.Spawn != tc.wantSpawn {
+				t.Errorf("Spawn = %d, want %d", plan.Spawn, tc.wantSpawn)
+			}
+			if len(plan.Delete) != tc.wantDelete {
+				t.Errorf("len(Delete) = %d, want %d", len(plan.Delete), tc.wantDelete)
+			}
+			if plan.Hold != tc.wantHold {
+				t.Errorf("Hold = %q, want %q", plan.Hold, tc.wantHold)
+			}
+			if plan.admission.op != tc.wantAdmOp {
+				t.Errorf("admission.op = %d, want %d", plan.admission.op, tc.wantAdmOp)
+			}
+			if tc.admKeySet && (plan.admission.key == "" || plan.admission.reason == "") {
+				t.Errorf("admission latch missing key/reason: %+v", plan.admission)
+			}
+			if plan.Desired != tc.replicas || plan.Actual != tc.alive {
+				t.Errorf("Desired/Actual = %d/%d, want %d/%d", plan.Desired, plan.Actual, tc.replicas, tc.alive)
+			}
+		})
+	}
+}
+
+// TestPlanScaleDownNamesExactExcess asserts a scale-down plan names exactly the
+// excess (Actual-Desired) sessions to remove, each a distinct, existing session
+// of the role. The old reconciler and planRole both index one store snapshot
+// identically (current[len-1-i]); since ListSessionsByTeamRole returns map
+// order, the SET is the deterministic invariant to pin here, and
+// TestPlanThenApplyScaleDownDeletesExactly proves apply removes exactly that set.
+func TestPlanScaleDownNamesExactExcess(t *testing.T) {
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+
+	const ws, team, role = "ws", "team", "worker"
+	addAliveSessions(t, store, team, role, 3) // indices 0,1,2
+	team1 := api.Team{
+		Name: team, Workspace: ws, Generation: 1,
+		Roles: []api.Role{{Name: role, Replicas: 1}},
+	}
+
+	plan := ctrl.planRole(&team1, &team1.Roles[0], 1)
+	if plan.Action != RoleScaleDown || len(plan.Delete) != 2 {
+		t.Fatalf("plan = %+v, want scale_down deleting 2", plan)
+	}
+
+	existing := sessionKeySet(store.ListSessionsByTeamRole(ws, team, role))
+	seen := make(map[string]struct{})
+	for _, sess := range plan.Delete {
+		if _, ok := existing[sess.Key()]; !ok {
+			t.Errorf("Delete names %s, which is not a current session of the role", sess.Key())
+		}
+		if _, dup := seen[sess.Key()]; dup {
+			t.Errorf("Delete names %s twice", sess.Key())
+		}
+		seen[sess.Key()] = struct{}{}
+	}
+}
+
+// TestPlanConvergenceIsSideEffectFree is the purity guard. It exercises the
+// path most likely to leak — an over-budget team whose apply would latch a
+// hold, emit admission.refused, and write Team.Admission — and asserts that
+// computing the plan does none of it: no sessions created or deleted, no
+// events, no admission latch, no store record touched.
+func TestPlanConvergenceIsSideEffectFree(t *testing.T) {
+	store := api.NewStore()
+	ring := events.NewRing(0)
+	ctrl := NewController(store, nil)
+	ctrl.Events = ring
+
+	const ws, team, role = "ws", "crew", "crew"
+	createBudgetTeamFixture(t, store, ws, team, api.Budget{MaxSessions: 2}, []api.Role{sleepRole(role, 3)})
+	addAliveSessions(t, store, team, role, 2) // over budget: declared 3 > ceiling 2
+
+	before := sessionKeySet(store.ListSessions())
+
+	var plans []RolePlan
+	for i := 0; i < 3; i++ {
+		plans = ctrl.PlanConvergence()
+	}
+
+	// The decision is real: the role wants a third replica but admission holds it.
+	if len(plans) != 1 {
+		t.Fatalf("expected 1 role plan, got %d", len(plans))
+	}
+	if plans[0].Action != RoleHold || plans[0].Hold != HoldAdmission {
+		t.Fatalf("plan = %+v, want hold on admission", plans[0])
+	}
+
+	// ... and it changed nothing.
+	after := sessionKeySet(store.ListSessions())
+	if len(after) != len(before) {
+		t.Errorf("session count changed: before %d, after %d", len(before), len(after))
+	}
+	for k := range before {
+		if _, ok := after[k]; !ok {
+			t.Errorf("session %s disappeared during planning", k)
+		}
+	}
+	if got := len(ctrl.admissionHolds); got != 0 {
+		t.Errorf("planning latched %d admission hold(s), want 0", got)
+	}
+	if evs := ring.Snapshot(events.Filter{}, 0); len(evs) != 0 {
+		t.Errorf("planning emitted %d event(s), want 0: %+v", len(evs), evs)
+	}
+	if tm, _ := store.GetTeam(ws + "/" + team); tm.Admission.Held {
+		t.Errorf("planning wrote Team.Admission = %+v, want zero", tm.Admission)
+	}
+	if got := len(ctrl.SnapshotRoleHealth()); got != 0 {
+		t.Errorf("planning wrote %d role-health record(s), want 0", got)
+	}
+}
+
+// --- Property 2: applyRolePlan enacts exactly the plan -----------------------
+
+// TestApplyRolePlanLatchesAndClearsAdmission proves apply performs precisely the
+// admission bookkeeping the plan carries — latch-and-emit on a hold intent,
+// once per transition — and clears it on a clear intent. No tmux: the hold path
+// touches only the store and the event ring.
+func TestApplyRolePlanLatchesAndClearsAdmission(t *testing.T) {
+	store := api.NewStore()
+	ring := events.NewRing(0)
+	ctrl := NewController(store, nil)
+	ctrl.Events = ring
+
+	const ws, team, role = "ws", "crew", "crew"
+	createBudgetTeamFixture(t, store, ws, team, api.Budget{MaxSessions: 2}, []api.Role{sleepRole(role, 3)})
+	addAliveSessions(t, store, team, role, 2)
+	teamKey := ws + "/" + team
+
+	// Latch.
+	ctrl.mu.Lock()
+	tm, _ := store.GetTeam(teamKey)
+	plan := ctrl.planRole(&tm, &tm.Roles[0], tm.Generation)
+	if plan.admission.op != admissionLatch {
+		ctrl.mu.Unlock()
+		t.Fatalf("plan.admission.op = %d, want latch", plan.admission.op)
+	}
+	ctrl.applyRolePlan(&tm, &tm.Roles[0], plan)
+	// Idempotent within the same standing condition: a second apply of the same
+	// verdict key must not emit a second event.
+	ctrl.applyRolePlan(&tm, &tm.Roles[0], plan)
+	ctrl.mu.Unlock()
+
+	if _, held := ctrl.AdmissionHold(ws, team, role); !held {
+		t.Errorf("apply did not latch the admission hold")
+	}
+	if got := len(admissionEvents(t, ring, events.KindAdmissionRefused)); got != 1 {
+		t.Errorf("admission.refused events = %d, want exactly 1 (once per transition)", got)
+	}
+	if got, _ := store.GetTeam(teamKey); !got.Admission.Held || got.Admission.Role != role {
+		t.Errorf("Team.Admission = %+v, want held on role %s", got.Admission, role)
+	}
+
+	// Clear: raise the ceiling so the gate is satisfied, then apply the fresh plan.
+	setMaxSessions(t, store, teamKey, 5)
+	ctrl.mu.Lock()
+	tm, _ = store.GetTeam(teamKey)
+	clearPlan := ctrl.planRole(&tm, &tm.Roles[0], tm.Generation)
+	if clearPlan.admission.op != admissionClear {
+		ctrl.mu.Unlock()
+		t.Fatalf("clearPlan.admission.op = %d, want clear", clearPlan.admission.op)
+	}
+	// Enact ONLY the admission bookkeeping — drop the spawn so this stays
+	// tmux-free and isolates the clear.
+	clearPlan.Spawn = 0
+	clearPlan.Action = RoleSteady
+	ctrl.applyRolePlan(&tm, &tm.Roles[0], clearPlan)
+	ctrl.mu.Unlock()
+
+	if _, held := ctrl.AdmissionHold(ws, team, role); held {
+		t.Errorf("apply did not clear the admission hold")
+	}
+	if got := len(admissionEvents(t, ring, events.KindAdmissionCleared)); got != 1 {
+		t.Errorf("admission.cleared events = %d, want exactly 1", got)
+	}
+}
+
+// TestApplyRolePlanObeysPlanNotState is the sharpest proof of the seam: apply
+// enacts the plan it is handed, not a fresh reading of the world. A team already
+// at its desired count is handed a plan that spawns one anyway, and apply
+// spawns it — so apply is enacting the decision, never re-deciding.
+func TestApplyRolePlanObeysPlanNotState(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	const ws, team, role = "obey", "agents", "worker"
+	createTeamFixture(t, store, ws, team, []api.Role{sleepRole(role, 1)})
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRole(ws, team, role)); got != 1 {
+		t.Fatalf("expected 1 session after reconcile, got %d", got)
+	}
+
+	tm, _ := store.GetTeam(ws + "/" + team)
+	plan := RolePlan{
+		Workspace: ws, Team: team, Role: role, Generation: 1,
+		Desired: 1, Actual: 1, Action: RoleSpawn, Spawn: 1,
+	}
+	ctrl.mu.Lock()
+	ctrl.applyRolePlan(&tm, &tm.Roles[0], plan)
+	ctrl.mu.Unlock()
+
+	if got := len(store.ListSessionsByTeamRole(ws, team, role)); got != 2 {
+		t.Errorf("apply of Spawn=1 against a satisfied role produced %d sessions, want 2 (apply obeys the plan)", got)
+	}
+}
+
+// TestPlanThenApplyScaleDownDeletesExactly runs the two halves back to back and
+// asserts apply removes exactly the sessions the plan named — no more, no fewer,
+// and the survivor is the one the plan did not name.
+func TestPlanThenApplyScaleDownDeletesExactly(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	const ws, team, role = "exact", "agents", "worker"
+	createTeamFixture(t, store, ws, team, []api.Role{sleepRole(role, 3)})
+	ctrl.ReconcileOnce()
+	if got := len(store.ListSessionsByTeamRole(ws, team, role)); got != 3 {
+		t.Fatalf("expected 3 sessions, got %d", got)
+	}
+
+	setReplicas(t, store, ws+"/"+team, role, 1)
+
+	ctrl.mu.Lock()
+	tm, _ := store.GetTeam(ws + "/" + team)
+	plan := ctrl.planRole(&tm, &tm.Roles[0], tm.Generation)
+	ctrl.mu.Unlock()
+	if plan.Action != RoleScaleDown || len(plan.Delete) != 2 {
+		t.Fatalf("plan = %+v, want scale_down deleting 2", plan)
+	}
+	doomed := sessionKeySet(plan.Delete)
+
+	ctrl.mu.Lock()
+	ctrl.applyRolePlan(&tm, &tm.Roles[0], plan)
+	ctrl.mu.Unlock()
+
+	survivors := store.ListSessionsByTeamRole(ws, team, role)
+	if len(survivors) != 1 {
+		t.Fatalf("expected 1 survivor, got %d", len(survivors))
+	}
+	if _, doomedSurvived := doomed[survivors[0].Key()]; doomedSurvived {
+		t.Errorf("survivor %s was named in the plan's Delete set", survivors[0].Key())
+	}
+}


### PR DESCRIPTION
## Why

The team reconciler decided *what should change* and *made the change* in one
fused pass — desired-vs-actual counted and sessions spawned in the same code.
That fusion is the thing standing between us and three separate features on the
convergence-posture arc: a `--dry-run` preview (aae-orc-nrk1), a hold posture
that computes intent and declines to act (aae-orc-rwiw), and a startup report
that is simply "the plan at boot". All three are the same shape — *compute the
plan, choose whether to apply it* — and none is reachable while the decision has
no separate existence.

This is the keystone (aae-orc-nf0w): it makes the convergence plan a first-class,
inspectable value and leaves every side effect on the far side of a clean seam,
without changing what the reconciler does today. It is worth merging because it
is pure upside — it unblocks two P2 tickets and the boot report at zero behavior
cost — and worth a close read precisely *because* it claims zero behavior cost:
the value of the change is entirely in that claim holding.

## What

- `planRole(t, role, gen) RolePlan` — pure. Computes desired, actual, the spawn
  count, the exact delete set, and any hold reason. Reads state; mutates nothing
  (no spawns, no store writes, no events, no admission latch).
- `applyRolePlan(t, role, plan)` — enacts exactly the plan; owns every side
  effect.
- `reconcileRoleAt` is now `applyRolePlan(planRole(...))`.
- The old effectful `admit()` splits the same way: `admissionVerdict` (pure,
  folded into the plan) + `latchAdmissionHold` (effect, run only by apply). This
  is what lets the plan be computed without emitting `admission.refused` or
  latching a hold.
- `RolePlan` / `RoleAction` / `HoldReason` are exported — the shared seam
  nrk1/rwiw build on. `PlanConvergence()` returns the steady-state plan for all
  non-shifting teams as the read-only inspection entry point (its two
  aggregate-view fidelity limits are documented on the method for those
  consumers).

## Behavior unchanged, and how the tests prove it

Structure-preserving refactor. Spawn count, delete selection/order, admission
event-per-transition timing, hold latch/clear transitions, and
`ClearCrashedForRole` ordering are all carried over unchanged — backstopped by
the pre-existing reconcile/admission suite passing through the new split
(characterization). Three new-seam properties are proven directly in
`plan_test.go`:

1. **plan is side-effect-free** — `TestPlanRoleDecision` runs the full decision
   table with a nil session manager (a stray spawn/delete would panic);
   `TestPlanConvergenceIsSideEffectFree` runs the over-budget path (the one whose
   apply would latch a hold, emit `admission.refused`, and write
   `Team.Admission`) and asserts zero sessions/events/latches/store writes.
2. **apply enacts exactly the plan** — `TestApplyRolePlanObeysPlanNotState`
   hands a `Spawn=1` plan to an already-satisfied role and it spawns anyway
   (apply obeys the plan, never re-decides); `TestPlanThenApplyScaleDownDeletesExactly`
   asserts exactly the named set is deleted and the survivor was unnamed.
3. **admission bookkeeping** — `TestApplyRolePlanLatchesAndClearsAdmission`
   proves once-per-transition latch, idempotency, and clear.

`go build`, `go test -race ./...`, `go vet`, and `golangci-lint run ./...` are
all green. Reviewed with a three-layer adversarial pass (general / edge-case /
acceptance); no correctness or behavior-preservation findings — the actionable
items were doc/metadata and are folded in.

Closes aae-orc-nf0w. Unblocks aae-orc-nrk1, aae-orc-rwiw.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS