### PR TITLE
feat(heartbeat): carry the numerator and denominator, not a bare percentage

### DIFF
--- a/cmd/marvel/codexctx.go
+++ b/cmd/marvel/codexctx.go
@@ -73,14 +73,19 @@ type codexHookPayload struct {
 // monotone within a compaction generation; reporting zero is not, and
 // zero is what every one of these cases would otherwise produce.
 //
+// tokens is the NUMERATOR (codex's own occupancy, Reading.Level) and
+// window is the DENOMINATOR (Reading.Window); forwarding both lets the
+// daemon derive the percentage against the window it resolves rather than
+// take codex's own. See codexHeartbeatParams and aae-orc-38yr.
+//
 // Pure, so the decision table is testable without a daemon or a hook.
-func codexReading(raw []byte) (pct float64, model string, window int, send bool) {
+func codexReading(raw []byte) (pct float64, model string, tokens int, window int, send bool) {
 	var p codexHookPayload
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return 0, "", 0, false
+		return 0, "", 0, 0, false
 	}
 	if p.TranscriptPath == nil || *p.TranscriptPath == "" {
-		return 0, "", 0, false
+		return 0, "", 0, 0, false
 	}
 	reading, err := codex.ReadOccupancy(*p.TranscriptPath)
 	if err != nil {
@@ -89,11 +94,11 @@ func codexReading(raw []byte) (pct float64, model string, window int, send bool)
 		// a fault (a multi-megabyte tool-output record can sit between
 		// the newest sample and EOF); an unopenable path is a real
 		// fault; neither may become a zero.
-		return 0, "", 0, false
+		return 0, "", 0, 0, false
 	}
 	pct, ok := reading.Percent()
 	if !ok {
-		return 0, "", 0, false
+		return 0, "", 0, 0, false
 	}
 	// The model rides out only with a reading. A hold sends nothing at
 	// all, so returning an identity for a figure that will not be sent
@@ -101,7 +106,7 @@ func codexReading(raw []byte) (pct float64, model string, window int, send bool)
 	if p.Model != nil {
 		model = *p.Model
 	}
-	return pct, model, reading.Window, true
+	return pct, model, reading.Level, reading.Window, true
 }
 
 func newCodexCtxCmd() *cobra.Command {
@@ -114,7 +119,7 @@ func newCodexCtxCmd() *cobra.Command {
 			if err != nil {
 				return nil
 			}
-			pct, model, window, send := codexReading(raw)
+			pct, model, tokens, window, send := codexReading(raw)
 
 			socket := os.Getenv("MARVEL_SOCKET")
 			workspace := os.Getenv("MARVEL_WORKSPACE")
@@ -122,7 +127,7 @@ func newCodexCtxCmd() *cobra.Command {
 			if !send || socket == "" || workspace == "" || session == "" {
 				return nil
 			}
-			p := codexHeartbeatParams(workspace, session, os.Getenv(api.HeartbeatTokenEnv), model, pct, window)
+			p := codexHeartbeatParams(workspace, session, os.Getenv(api.HeartbeatTokenEnv), model, pct, tokens, window)
 			params, _ := json.Marshal(p)
 			// Best-effort by design; see the failure posture above.
 			_, _ = daemon.SendRequest(socket, daemon.Request{
@@ -139,7 +144,7 @@ func newCodexCtxCmd() *cobra.Command {
 // standing up a daemon; the pair of keys below is exactly what the
 // merge of #170 and #168 got wrong, and an inline literal inside a
 // cobra closure is not reachable by any test that would have caught it.
-func codexHeartbeatParams(workspace, session, token, model string, pct float64, window int) api.HeartbeatRequest {
+func codexHeartbeatParams(workspace, session, token, model string, pct float64, tokens, window int) api.HeartbeatRequest {
 	// The token marvel minted for this session at spawn. Without it the
 	// daemon refuses the beat: authenticateHeartbeat fails open only when
 	// the record carries no hash, and Manager.Create now mints one before
@@ -153,28 +158,30 @@ func codexHeartbeatParams(workspace, session, token, model string, pct float64, 
 	// builds, so the next field added to the contract breaks this line at
 	// compile time rather than at runtime. See finding-023.
 	p := api.NewHeartbeatRequestWithToken(workspace+"/"+session, token, pct, model)
-	// context_window is the producer half of a seam whose consumer does
-	// not exist: the daemon parses it and never reads it. See the long
-	// comment in ctxforward.go, which names the edit that would finish it.
+	// The numerator (codex's occupancy) and the denominator (its declared
+	// window). The daemon now consumes both: it routes the window through
+	// usage.Resolve and derives the percentage from occupancy over what it
+	// resolves. See aae-orc-38yr, which built the consumer this seam waited
+	// for.
 	//
-	// Codex sharpens that open decision rather than settling it. This
-	// window is a `stream` declaration (rung 1), and codex is the clean
-	// case: limitLadder's rung-1 sentence has two conjuncts, the harness
-	// enforcing compaction against the window AND stating it "in the same
-	// channel as the token counts it is stating it about", and
-	// model_context_window satisfies both by riding the level's own record.
+	// The rung is the deliberately conservative part. aae-orc-38yr routes
+	// EVERY heartbeat window as usage.LimitFromFeed (rung 4, below an
+	// operator's manifest override). codex arguably deserves rung 1: its
+	// model_context_window rides the level's own record, satisfying
+	// limitLadder's rung-1 conjuncts (the harness enforces compaction
+	// against the window AND states it in the same channel as the counts).
+	// That promotion is NOT taken here. It needs the SampleLimit route
+	// (rung 1, LimitFromStream) and is the open decision reserved to the
+	// operator in marvel PR #172; taking it as a side effect of this wiring
+	// would settle a question this ticket does not own. Until then feed is
+	// the honest floor — below the operator, above the (empty) codex table.
+	// See finding-023 and finding-020.
 	//
-	// Do NOT generalize the rung from this comment. A window the harness
-	// serves over a separate contracted query satisfies the first conjunct
-	// and not the second, and rung 4's text (a human-facing status hook,
-	// no version handle) does not describe it either. That case is open
-	// with the operator, marvel PR #172; see finding-023 and finding-020.
-	// Whatever rung it lands on, it needs a refetch rule codex does not:
-	// fetched under a different model, a window is unresolved rather than
-	// stale.
-	//
-	// Zero means the payload declared no window, and an undeclared window
-	// must not arrive as a declared zero.
+	// Zero means the payload declared none, and an undeclared figure must
+	// not arrive as a declared zero.
+	if tokens > 0 {
+		p.ContextTokens = tokens
+	}
 	if window > 0 {
 		p.ContextWindow = window
 	}

--- a/cmd/marvel/codexctx_test.go
+++ b/cmd/marvel/codexctx_test.go
@@ -55,30 +55,33 @@ func TestCodexReading(t *testing.T) {
 	absent := filepath.Join(t.TempDir(), "never-written.jsonl")
 
 	tests := []struct {
-		name      string
-		payload   string
-		wantSend  bool
-		wantPct   float64
-		wantModel string
-		wantWin   int
+		name       string
+		payload    string
+		wantSend   bool
+		wantPct    float64
+		wantModel  string
+		wantWin    int
+		wantTokens int
 	}{
 		{
-			name:      "a live rollout forwards the level over its own window",
-			payload:   hookPayload(good),
-			wantSend:  true,
-			wantPct:   50,
-			wantModel: "gpt-5.6-sol",
-			wantWin:   258400,
+			name:       "a live rollout forwards the level over its own window",
+			payload:    hookPayload(good),
+			wantSend:   true,
+			wantPct:    50,
+			wantModel:  "gpt-5.6-sol",
+			wantWin:    258400,
+			wantTokens: 129200,
 		},
 		{
 			name: "the compaction sentinel does not become a zero reading",
 			// The sentinel is the newest record; the answer is the
 			// sample before it, at 50% rather than 0%.
-			payload:   hookPayload(afterCompaction),
-			wantSend:  true,
-			wantPct:   50,
-			wantModel: "gpt-5.6-sol",
-			wantWin:   258400,
+			payload:    hookPayload(afterCompaction),
+			wantSend:   true,
+			wantPct:    50,
+			wantModel:  "gpt-5.6-sol",
+			wantWin:    258400,
+			wantTokens: 129200,
 		},
 		{
 			name:     "a rollout carrying only a sentinel holds",
@@ -126,7 +129,7 @@ func TestCodexReading(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			pct, model, window, send := codexReading([]byte(tt.payload))
+			pct, model, tokens, window, send := codexReading([]byte(tt.payload))
 			if send != tt.wantSend {
 				t.Fatalf("send = %v, want %v (pct %v window %d)", send, tt.wantSend, pct, window)
 			}
@@ -134,8 +137,8 @@ func TestCodexReading(t *testing.T) {
 				t.Errorf("model = %q, want %q", model, tt.wantModel)
 			}
 			if !send {
-				if pct != 0 || window != 0 {
-					t.Errorf("held reading carried pct %v window %d, want both zero", pct, window)
+				if pct != 0 || window != 0 || tokens != 0 {
+					t.Errorf("held reading carried pct %v tokens %d window %d, want all zero", pct, tokens, window)
 				}
 				return
 			}
@@ -144,6 +147,9 @@ func TestCodexReading(t *testing.T) {
 			}
 			if window != tt.wantWin {
 				t.Errorf("window = %d, want %d", window, tt.wantWin)
+			}
+			if tokens != tt.wantTokens {
+				t.Errorf("tokens = %d, want %d (the numerator, Reading.Level)", tokens, tt.wantTokens)
 			}
 		})
 	}
@@ -157,7 +163,7 @@ func TestCodexReading(t *testing.T) {
 // most wrong.
 func TestCodexReadingIgnoresTheCumulativeTotal(t *testing.T) {
 	t.Parallel()
-	pct, _, _, send := codexReading([]byte(hookPayload(writeRollout(t, sampleRecord))))
+	pct, _, _, _, send := codexReading([]byte(hookPayload(writeRollout(t, sampleRecord))))
 	if !send {
 		t.Fatal("send = false, want a forwardable reading")
 	}
@@ -198,7 +204,7 @@ func TestCodexHeartbeatParamsCarriesTheSessionToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p := codexHeartbeatParams("ws", "sess", tt.token, "gpt-5.6-sol", 94.0, 258400)
+			p := codexHeartbeatParams("ws", "sess", tt.token, "gpt-5.6-sol", 94.0, 242696, 258400)
 
 			raw, err := json.Marshal(p)
 			if err != nil {

--- a/cmd/marvel/ctxforward.go
+++ b/cmd/marvel/ctxforward.go
@@ -216,21 +216,34 @@ type contextWindow struct {
 // redefinition cannot hide inside it.
 const harnessPercentTolerance = 1.0
 
+// occupancyTokens is the NUMERATOR: input plus cache-creation plus
+// cache-read, with output tokens excluded. Excluding output is not an
+// oversight — it is what the harness does, and it is the same sum
+// recomputeUsedPercent divides, so the token count marvel forwards on the
+// heartbeat is exactly the one it checked the harness's percentage
+// against. ok is false when the payload carries no classes to sum, the
+// normal state of a session that has not called the API yet.
+func occupancyTokens(w *contextWindow) (tokens int, ok bool) {
+	if w == nil || w.CurrentUsage == nil {
+		return 0, false
+	}
+	u := w.CurrentUsage
+	return u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens, true
+}
+
 // recomputeUsedPercent derives occupancy from the classes the payload
 // shipped, mirroring the harness's own arithmetic: input plus
 // cache-creation plus cache-read over the window, rounded then clamped,
-// with output tokens excluded. Excluding output is not an oversight: it
-// is what the harness does, and summing it in would put every reading a
+// with output tokens excluded. Summing output in would put every reading a
 // little over and make the cross-check fire on healthy sessions.
 //
 // ok is false when the payload carries nothing to compute from, which is
 // the normal state of a session that has not called the API yet.
 func recomputeUsedPercent(w *contextWindow) (pct float64, ok bool) {
-	if w == nil || w.CurrentUsage == nil || w.ContextWindowSize <= 0 {
+	occupancy, ok := occupancyTokens(w)
+	if !ok || w.ContextWindowSize <= 0 {
 		return 0, false
 	}
-	u := w.CurrentUsage
-	occupancy := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
 	raw := math.Round(float64(occupancy) / float64(w.ContextWindowSize) * 100)
 	return math.Min(100, math.Max(0, raw)), true
 }
@@ -306,16 +319,18 @@ func untilReset(r resetInstant, now time.Time) string {
 }
 
 // renderForward parses one statusline payload and returns the status text
-// to print, plus the context percentage, model name, and harness-declared
-// window to forward (send=false when the payload carries no forwardable
-// figure). window is 0 when the payload declares none.
+// to print, plus the context percentage, model name, the harness-measured
+// occupancy (the NUMERATOR) and the harness-declared window (the
+// DENOMINATOR) to forward (send=false when the payload carries no
+// forwardable figure). tokens and window are 0 when the payload declares
+// none — the daemon then keeps the percentage-only reading.
 //
 // Pure apart from the clock formatRateLimits needs, so it stays
 // table-testable.
-func renderForward(raw []byte) (line string, pct float64, model string, window int, send bool) {
+func renderForward(raw []byte) (line string, pct float64, model string, tokens int, window int, send bool) {
 	var p statuslinePayload
 	if err := json.Unmarshal(raw, &p); err != nil {
-		return "marvel ctx-forward: unreadable payload", 0, "", 0, false
+		return "marvel ctx-forward: unreadable payload", 0, "", 0, 0, false
 	}
 
 	// Subagent shape: summarize the task rows. No RPC — the daemon has
@@ -343,13 +358,13 @@ func renderForward(raw []byte) (line string, pct float64, model string, window i
 				}
 			}
 		}
-		return fmt.Sprintf("agents %d/%d running · max CTX %.0f%%", running, len(p.Tasks), maxPct), 0, "", 0, false
+		return fmt.Sprintf("agents %d/%d running · max CTX %.0f%%", running, len(p.Tasks), maxPct), 0, "", 0, 0, false
 	}
 
 	if p.ContextWindow == nil || p.ContextWindow.UsedPercentage == nil {
 		// Session too young to have a measurement. Show something
 		// stable rather than flickering an error.
-		return withAcct(fmt.Sprintf("%s · CTX –", orUnknown(p.Model.DisplayName))), 0, "", 0, false
+		return withAcct(fmt.Sprintf("%s · CTX –", orUnknown(p.Model.DisplayName))), 0, "", 0, 0, false
 	}
 	pct = *p.ContextWindow.UsedPercentage
 
@@ -372,7 +387,7 @@ func renderForward(raw []byte) (line string, pct float64, model string, window i
 	// silent blank would look like an ordinary gap in the feed.
 	if mine, ok := recomputeUsedPercent(p.ContextWindow); ok && math.Abs(mine-pct) > harnessPercentTolerance {
 		return withAcct(fmt.Sprintf("%s · CTX ? harness %.0f%% vs recomputed %.0f%% · $%.2f",
-			orUnknown(p.Model.DisplayName), pct, mine, p.Cost.TotalCostUSD)), 0, "", 0, false
+			orUnknown(p.Model.DisplayName), pct, mine, p.Cost.TotalCostUSD)), 0, "", 0, 0, false
 	}
 	// A payload with no classes to check against is unverified, not
 	// suspect. Older harnesses, and any other producer pointed at this
@@ -381,7 +396,13 @@ func renderForward(raw []byte) (line string, pct float64, model string, window i
 	// predates the classes rather than catch anything.
 
 	line = withAcct(fmt.Sprintf("%s · CTX %.0f%% · $%.2f", orUnknown(p.Model.DisplayName), pct, p.Cost.TotalCostUSD))
-	return line, pct, p.Model.DisplayName, p.ContextWindow.ContextWindowSize, true
+	// The numerator rides out only when the payload carried the classes to
+	// sum; a payload with a percentage but no current_usage forwards a bare
+	// percentage still (occupancyTokens ok=false), which the daemon keeps
+	// as a percentage-only reading. tokens is 0 in that case, never a
+	// declared-empty-context zero.
+	tokens, _ = occupancyTokens(p.ContextWindow)
+	return line, pct, p.Model.DisplayName, tokens, p.ContextWindow.ContextWindowSize, true
 }
 
 func orUnknown(s string) string {
@@ -402,7 +423,7 @@ func newCtxForwardCmd() *cobra.Command {
 				fmt.Println("marvel ctx-forward")
 				return nil
 			}
-			line, pct, model, window, send := renderForward(raw)
+			line, pct, model, tokens, window, send := renderForward(raw)
 			fmt.Println(line)
 
 			socket := os.Getenv("MARVEL_SOCKET")
@@ -423,38 +444,24 @@ func newCtxForwardCmd() *cobra.Command {
 			// tokens existed) the daemon admits the beat and says so on
 			// the ring.
 			p := api.NewHeartbeatRequest(workspace+"/"+session, pct, model)
-			// context_window is the harness's own declared window for this
-			// session. It is emitted as the PRODUCER half of a seam whose
-			// consumer does not exist yet: internal/daemon's heartbeatParams
-			// has no field for it, so today the daemon drops it exactly the
-			// way this file used to drop rate_limits. That is deliberate and
-			// documented rather than accidental, but it is not a shipped
-			// feature, and nothing renders differently because of it.
+			// The numerator and the denominator behind the harness's own
+			// percentage. Forwarding both turns this into a GRADED reading:
+			// UpdateSessionHeartbeat routes the window through usage.Resolve
+			// (as a LimitFromFeed rung, below an operator's manifest
+			// override) and derives the percentage from occupancy over the
+			// window it resolves — so an operator's runtime.context_window
+			// wins over the harness's own, and CTX% is against the
+			// denominator marvel trusts. The bare percentage above stands
+			// only as the fallback when there is nothing to derive from.
+			// This was the seam ctxforward opened and aae-orc-38yr closed;
+			// the daemon no longer drops these fields.
 			//
-			// Two edits complete it, both outside cmd/marvel and both
-			// deliberately not made here: a window field on the wire type,
-			// and a window argument on
-			// internal/api.Store.UpdateSessionHeartbeat.
-			//
-			// The first of those is now made and the second is not, which
-			// is why this window still goes nowhere. api.HeartbeatRequest
-			// carries ContextWindow, so the daemon parses it into a field
-			// instead of dropping an untyped map key; it still reads it
-			// nowhere. Typing a value is not consuming it.
-			//
-			// Whoever makes them should read the comment already standing in
-			// UpdateSessionHeartbeat first. It states that a percentage is
-			// ALL this path produces, "no token count, no window, and no
-			// request count", and that this shape is what tells the two
-			// context producers apart downstream. Adding a window narrows
-			// that discriminator, so it is a contract decision rather than
-			// plumbing, and stamping a limit source without routing both
-			// this window and the session's manifest limit through
-			// usage.Resolve would label a rung of the ladder without
-			// climbing it.
-			//
-			// Zero means the payload declared no window, and an undeclared
-			// window must not arrive as a declared zero.
+			// Zero means the payload declared none, and an undeclared figure
+			// must not arrive as a declared zero: tokens omitted keeps the
+			// percentage-only reading, a window of zero resolves to nothing.
+			if tokens > 0 {
+				p.ContextTokens = tokens
+			}
 			if window > 0 {
 				p.ContextWindow = window
 			}

--- a/cmd/marvel/ctxforward_test.go
+++ b/cmd/marvel/ctxforward_test.go
@@ -54,7 +54,7 @@ func TestRateLimitsSurviveParsing(t *testing.T) {
 	if got := formatRateLimits(p.RateLimits, now); got != "acct 5h 41% (3h0m) 7d 63% (4d18h)" {
 		t.Errorf("formatRateLimits = %q", got)
 	}
-	line, _, _, _, send := renderForward(raw)
+	line, _, _, _, _, send := renderForward(raw)
 	if !send {
 		t.Errorf("send = false, want true: the context reading is sound")
 	}
@@ -111,7 +111,7 @@ func TestRateLimitsDoNotBreakTheContextFeed(t *testing.T) {
 		"cost":{"total_cost_usd":0.5},
 		"context_window":{"used_percentage":17},
 		"rate_limits":{"five_hour":{"used_percentage":41,"resets_at":{"epoch":1786000000}}}}`
-	line, pct, model, window, send := renderForward([]byte(payload))
+	line, pct, model, tokens, window, send := renderForward([]byte(payload))
 	if !send {
 		t.Fatalf("send = false, want true; line = %q", line)
 	}
@@ -120,6 +120,9 @@ func TestRateLimitsDoNotBreakTheContextFeed(t *testing.T) {
 	}
 	if window != 0 {
 		t.Errorf("window = %d, want 0: this payload declares none", window)
+	}
+	if tokens != 0 {
+		t.Errorf("tokens = %d, want 0: this payload carries no current_usage", tokens)
 	}
 	if !strings.Contains(line, "acct 5h 41% (resets ?)") {
 		t.Errorf("line = %q, want the level kept and the instant marked absent", line)
@@ -154,7 +157,7 @@ func TestRenderForwardWindow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, _, _, window, send := renderForward([]byte(tt.payload))
+			_, _, _, _, window, send := renderForward([]byte(tt.payload))
 			if !send {
 				t.Fatal("send = false, want true")
 			}
@@ -259,7 +262,7 @@ func TestRenderForwardLiveCapture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	line, _, _, _, send := renderForward(raw)
+	line, _, _, _, _, send := renderForward(raw)
 	if send {
 		t.Errorf("send = true, want false: a null used_percentage is not a reading")
 	}
@@ -419,7 +422,7 @@ func TestRenderForward(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			line, pct, model, _, send := renderForward([]byte(tt.payload))
+			line, pct, model, _, _, send := renderForward([]byte(tt.payload))
 			if send != tt.wantSend {
 				t.Fatalf("send = %v, want %v", send, tt.wantSend)
 			}

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -1941,8 +1941,9 @@ func renderSessionTable(sessions []api.Session) string {
 			llm = "-"
 		}
 		// CTX% has two producers: the cooperative heartbeat RPC (the
-		// simulator) and the usage accountant fed by adapter streams.
-		// Both stamp ContextAt, so that is the single "measured" sentinel.
+		// statusline/codex feeds and the simulator) and the usage
+		// accountant fed by adapter streams. Both stamp ContextAt, so that
+		// is the single "measured" sentinel.
 		//
 		// Three states, not two. "-" means marvel never measured this
 		// session's context: no stream, so an interactive launch, a pane
@@ -1962,10 +1963,13 @@ func renderSessionTable(sessions []api.Session) string {
 		case s.ContextAt.IsZero():
 		case s.ContextLimit == 0 && s.ContextSource != api.ContextSourceHeartbeat:
 			// No window resolved, so a percentage would be a fiction.
-			// The heartbeat is the one legitimate exception: it reports a
-			// percentage the agent computed itself and never needed a
-			// window to do it. Stating the exception explicitly is what
-			// stops a real cooperative reading being rendered absent.
+			// The heartbeat is the one legitimate exception: a feed that
+			// carries a window now resolves one (aae-orc-38yr) and lands in
+			// the default branch like any measured reading, but a
+			// percentage-only heartbeat (the simulator, a feed too young to
+			// have classes) reports a figure the agent computed itself and
+			// never needed a window to do. Stating the exception explicitly
+			// is what stops that reading being rendered absent.
 			ctx = "?"
 		default:
 			ctx = fmt.Sprintf("%.0f%%", s.ContextPercent)

--- a/cmd/marvel/render_test.go
+++ b/cmd/marvel/render_test.go
@@ -144,7 +144,7 @@ func TestRenderSessionTableWithHeartbeat(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if _, err := store.UpdateSessionHeartbeat("ws/agent-0", "", 55.4, ""); err != nil {
+	if _, err := store.UpdateSessionHeartbeat(api.HeartbeatRequest{SessionKey: "ws/agent-0", ContextPercent: 55.4}); err != nil {
 		t.Fatalf("heartbeat: %v", err)
 	}
 

--- a/internal/api/bolt_test.go
+++ b/internal/api/bolt_test.go
@@ -408,7 +408,7 @@ func TestBoltStore_HeartbeatContextReadingSurvivesRehydrate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if _, err := s1.UpdateSessionHeartbeat("ws/agent-0", "", 64.0, ""); err != nil {
+	if _, err := s1.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: "ws/agent-0", ContextPercent: 64.0}); err != nil {
 		t.Fatalf("heartbeat: %v", err)
 	}
 	if err := s1.CloseBolt(); err != nil {

--- a/internal/api/heartbeat.go
+++ b/internal/api/heartbeat.go
@@ -101,13 +101,29 @@ type HeartbeatRequest struct {
 	// does not know (the simulator). The statusline feed sends the
 	// harness's display name.
 	Model string `json:"model,omitempty"`
-	// ContextWindow is carried and NOT consumed. It is the producer half
-	// of a seam whose consumer does not exist: the daemon parses it into
-	// this field and never reads it, exactly as it did when this was a
-	// stray map key. Typing it changes nothing about that contract
-	// decision, which is still the one named in ctxforward.go: whether
-	// UpdateSessionHeartbeat should take a window narrows the
-	// discriminator that tells the two context producers apart.
+	// ContextTokens is the NUMERATOR: the occupancy the harness measured,
+	// in tokens, 0 when the producer ships only a percentage. A producer
+	// that ships it turns this RPC from a bare percentage into a graded
+	// reading — see the pair with ContextWindow below and aae-orc-38yr.
+	//
+	// It is the harness's own occupancy figure (input + cache classes,
+	// output excluded, mirroring the harness's own arithmetic), NOT
+	// re-derived here. Zero is "not reported", never "empty context".
+	ContextTokens int `json:"context_tokens,omitempty"`
+	// ContextWindow is the DENOMINATOR: the window the harness declared on
+	// its cooperative feed, 0 when the payload declared none. When it
+	// arrives WITH a numerator, UpdateSessionHeartbeat routes it and the
+	// session's manifest limit through usage.Resolve as a usage.LimitFromFeed
+	// rung (below an operator's manifest override, above the shipped table),
+	// and derives the percentage against the window that resolves.
+	//
+	// A numerator is required: a window with no ContextTokens is left
+	// unconsumed (the reading stays percentage-only), because there is
+	// nothing to divide by it. Paired with ContextTokens it lets a consumer
+	// DERIVE the percentage against the denominator marvel trusts, rather
+	// than accept a bare figure the harness computed against its own window.
+	// It was the producer half of a seam whose consumer did not exist
+	// (finding-023); aae-orc-38yr built the consumer.
 	ContextWindow int `json:"context_window,omitempty"`
 }
 

--- a/internal/api/heartbeat_graded_test.go
+++ b/internal/api/heartbeat_graded_test.go
@@ -1,0 +1,334 @@
+package api
+
+import "testing"
+
+// gradedSessionKey is the fixed key every store-level heartbeat test in
+// this file registers and beats against.
+const gradedSessionKey = "ws/agent-0"
+
+// gradedSession registers a bound session at gradedSessionKey carrying an
+// optional manifest window, the way the manager does at spawn, and returns
+// the plaintext token the way it reaches the agent's environment.
+func gradedSession(t *testing.T, s *Store, manifestLimit int) (token string) {
+	t.Helper()
+	tok, hash, err := NewHeartbeatToken()
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	sess := &Session{
+		Name:      "agent-0",
+		Workspace: "ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime: Runtime{
+			Name:          "claude",
+			Command:       "claude",
+			ContextWindow: manifestLimit,
+		},
+		State:              SessionRunning,
+		HeartbeatTokenHash: hash,
+	}
+	if err := s.CreateSession(sess); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return tok
+}
+
+// resolverCall records what the store handed the injected resolver, so a
+// test can prove the heartbeat path routes BOTH the feed window and the
+// session's manifest limit through it — the difference between stamping
+// the label "feed" and actually climbing the ladder (aae-orc-38yr, MUST
+// NOT MISS #1).
+type resolverCall struct {
+	harness       string
+	model         string
+	args          []string
+	manifestLimit int
+	feedLimit     int
+}
+
+// ladderResolver is a fake standing in for usage.Resolver's feed/manifest
+// rungs. The store must not embed the ladder itself (internal/api cannot
+// import internal/usage), so the store's whole contribution is to CALL a
+// resolver with the right inputs and stamp what it returns. This fake
+// makes that contribution assertable in isolation; the daemon package
+// tests the real usage.Resolver end to end.
+func ladderResolver(rec *resolverCall) ContextLimitResolveFunc {
+	return func(harness, model string, args []string, manifestLimit, feedLimit int) (int, string) {
+		*rec = resolverCall{harness, model, args, manifestLimit, feedLimit}
+		// The real ladder: an operator's manifest override outranks a
+		// side-channel feed (limitLadder in internal/usage).
+		if manifestLimit > 0 {
+			return manifestLimit, "manifest"
+		}
+		if feedLimit > 0 {
+			return feedLimit, "feed"
+		}
+		return 0, "unresolved"
+	}
+}
+
+// TestHeartbeatCarriesNumeratorAndDenominator is the headline of
+// aae-orc-38yr: a cooperative feed that ships the numerator (occupancy
+// tokens) and the denominator (its declared window) produces a GRADED
+// reading — tokens, a resolved limit, a limit source — and the percentage
+// is DERIVED from the two, not taken from the wire's bare figure.
+func TestHeartbeatCarriesNumeratorAndDenominator(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 0) // no manifest override
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:     gradedSessionKey,
+		SessionToken:   token,
+		ContextTokens:  120_000,
+		ContextWindow:  200_000,
+		Model:          "claude-opus-4-8",
+		ContextPercent: 60, // the harness's own figure, present as a fallback
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextSource != ContextSourceHeartbeat {
+		t.Fatalf("ContextSource = %q, want %q", got.ContextSource, ContextSourceHeartbeat)
+	}
+	if got.ContextTokens != 120_000 {
+		t.Fatalf("ContextTokens = %d, want 120000 (the numerator)", got.ContextTokens)
+	}
+	if got.ContextLimit != 200_000 {
+		t.Fatalf("ContextLimit = %d, want 200000 (the resolved denominator)", got.ContextLimit)
+	}
+	if got.ContextLimitSource != "feed" {
+		t.Fatalf("ContextLimitSource = %q, want \"feed\"", got.ContextLimitSource)
+	}
+	if got.ContextPercent != 60 {
+		t.Fatalf("ContextPercent = %.2f, want 60 (derived 100*120000/200000)", got.ContextPercent)
+	}
+
+	// MUST NOT MISS #1: both the feed window AND the manifest limit are
+	// routed through the resolver, or the operator override never gets its
+	// chance to outrank the feed.
+	if rec.feedLimit != 200_000 {
+		t.Fatalf("resolver feedLimit = %d, want 200000 routed from the wire", rec.feedLimit)
+	}
+	if rec.manifestLimit != 0 {
+		t.Fatalf("resolver manifestLimit = %d, want 0 read from the session record", rec.manifestLimit)
+	}
+	if rec.model != "claude-opus-4-8" {
+		t.Fatalf("resolver model = %q, want the heartbeat's model", rec.model)
+	}
+}
+
+// TestHeartbeatManifestOutranksFeed proves the ruling has EFFECT, not just
+// a label: when an operator has set runtime.context_window, that window
+// wins over the feed's, and the derived percentage is against the
+// operator's denominator.
+func TestHeartbeatManifestOutranksFeed(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 500_000) // operator override
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:    gradedSessionKey,
+		SessionToken:  token,
+		ContextTokens: 120_000,
+		ContextWindow: 200_000, // the feed's window, which the manifest outranks
+		Model:         "claude-opus-4-8",
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextLimit != 500_000 {
+		t.Fatalf("ContextLimit = %d, want 500000 (manifest outranks feed)", got.ContextLimit)
+	}
+	if got.ContextLimitSource != "manifest" {
+		t.Fatalf("ContextLimitSource = %q, want \"manifest\"", got.ContextLimitSource)
+	}
+	if got.ContextPercent != 24 {
+		t.Fatalf("ContextPercent = %.2f, want 24 (100*120000/500000, against the operator's window)", got.ContextPercent)
+	}
+	if rec.manifestLimit != 500_000 || rec.feedLimit != 200_000 {
+		t.Fatalf("resolver got manifest=%d feed=%d, want both routed (500000, 200000)", rec.manifestLimit, rec.feedLimit)
+	}
+}
+
+// TestHeartbeatWithoutNumeratorStaysPercentageOnly is the graceful-
+// degradation half: a producer that ships only a percentage (the
+// simulator, an older harness) keeps the exact behavior it had — a
+// percentage-only reading, no window, no token count — so widening the
+// contract breaks no existing producer.
+func TestHeartbeatWithoutNumeratorStaysPercentageOnly(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 0)
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:     gradedSessionKey,
+		SessionToken:   token,
+		ContextPercent: 40,
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextSource != ContextSourceHeartbeat {
+		t.Fatalf("ContextSource = %q, want %q", got.ContextSource, ContextSourceHeartbeat)
+	}
+	if got.ContextPercent != 40 {
+		t.Fatalf("ContextPercent = %.2f, want 40 (the agent's own figure)", got.ContextPercent)
+	}
+	if got.ContextLimit != 0 || got.ContextTokens != 0 || got.ContextLimitSource != "" {
+		t.Fatalf("percentage-only reading leaked a window: limit=%d tokens=%d src=%q",
+			got.ContextLimit, got.ContextTokens, got.ContextLimitSource)
+	}
+	if rec.harness != "" || rec.model != "" || rec.manifestLimit != 0 || rec.feedLimit != 0 {
+		t.Fatalf("resolver was called for a windowless heartbeat: %+v", rec)
+	}
+}
+
+// TestHeartbeatDerivesPercentFromNumDenomNotWirePercent is the "consumers
+// derive the percentage" guarantee: when the store can compute occupancy
+// against the denominator it trusts, it does — and ignores a bare
+// percentage that disagrees. A harness percentage is against the harness's
+// own window; once marvel resolves its own denominator, its own division
+// is the honest reading.
+func TestHeartbeatDerivesPercentFromNumDenomNotWirePercent(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 0)
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:     gradedSessionKey,
+		SessionToken:   token,
+		ContextTokens:  100_000,
+		ContextWindow:  200_000,
+		ContextPercent: 99, // a bare percentage that contradicts 100000/200000
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextPercent != 50 {
+		t.Fatalf("ContextPercent = %.2f, want 50 (derived), not 99 (the bare wire figure)", got.ContextPercent)
+	}
+}
+
+// TestHeartbeatWithoutResolverStaysPercentageOnly guards the nil-resolver
+// path: a store built without a resolver (every store outside the daemon,
+// including tests) must not panic and must degrade to a percentage-only
+// reading rather than pretending to a window it cannot resolve.
+func TestHeartbeatWithoutResolverStaysPercentageOnly(t *testing.T) {
+	t.Parallel()
+	s := NewStore() // no SetContextLimitResolver
+
+	token := gradedSession(t, s, 0)
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:     gradedSessionKey,
+		SessionToken:   token,
+		ContextTokens:  120_000,
+		ContextWindow:  200_000,
+		ContextPercent: 60,
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextLimit != 0 {
+		t.Fatalf("ContextLimit = %d, want 0 with no resolver wired", got.ContextLimit)
+	}
+	if got.ContextPercent != 60 {
+		t.Fatalf("ContextPercent = %.2f, want 60 (the wire figure stands)", got.ContextPercent)
+	}
+	// The numerator is still recorded even when no window resolves: it is a
+	// real measurement, and ContextLimit==0 beside it is the documented
+	// "tokens measured, window unknown" state.
+	if got.ContextTokens != 120_000 {
+		t.Fatalf("ContextTokens = %d, want 120000 even with no resolver", got.ContextTokens)
+	}
+}
+
+// TestHeartbeatNumeratorWithUnresolvedWindow is the "tokens measured,
+// window unknown" branch: a numerator arrives but no rung resolves a
+// window (no feed window, no manifest, nothing learned). The reading must
+// record the numerator, leave ContextLimit 0 and ContextLimitSource empty,
+// and keep the agent's own percentage — the shape SessionContext documents
+// as the third state.
+func TestHeartbeatNumeratorWithUnresolvedWindow(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 0) // no manifest override
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:     gradedSessionKey,
+		SessionToken:   token,
+		ContextTokens:  90_000,
+		ContextWindow:  0, // the feed declared no window
+		ContextPercent: 45,
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextTokens != 90_000 {
+		t.Fatalf("ContextTokens = %d, want 90000 (measured)", got.ContextTokens)
+	}
+	if got.ContextLimit != 0 || got.ContextLimitSource != "" {
+		t.Fatalf("limit=%d src=%q, want 0 / \"\" (window unknown)", got.ContextLimit, got.ContextLimitSource)
+	}
+	if got.ContextPercent != 45 {
+		t.Fatalf("ContextPercent = %.2f, want 45 (the agent's own figure stands)", got.ContextPercent)
+	}
+}
+
+// TestHeartbeatDerivedPercentIsNotClamped pins the deliberate decision
+// flagged in review: the derived percentage is NOT capped at 100, matching
+// the accountant's own unclamped derive. When occupancy exceeds the
+// resolved window — an operator's manifest override smaller than the window
+// the harness measured against — CTX% must read "over budget", not "at the
+// limit". This is a contract choice, held by a test so it cannot regress
+// into an accidental clamp or an accidental symmetry break with the
+// accountant.
+func TestHeartbeatDerivedPercentIsNotClamped(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 100_000) // operator caps the window below occupancy
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:    gradedSessionKey,
+		SessionToken:  token,
+		ContextTokens: 120_000, // 20% over the operator's declared window
+		ContextWindow: 200_000,
+		Model:         "claude-opus-4-8",
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	got, _ := s.GetSession(gradedSessionKey)
+	if got.ContextLimit != 100_000 || got.ContextLimitSource != "manifest" {
+		t.Fatalf("limit=%d src=%q, want 100000 / manifest", got.ContextLimit, got.ContextLimitSource)
+	}
+	if got.ContextPercent != 120 {
+		t.Fatalf("ContextPercent = %.2f, want 120 (unclamped, over the operator's budget)", got.ContextPercent)
+	}
+}

--- a/internal/api/heartbeat_test.go
+++ b/internal/api/heartbeat_test.go
@@ -103,7 +103,7 @@ func TestUpdateSessionHeartbeatAuthenticates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			before, _ := s.GetSession(tt.key)
-			auth, err := s.UpdateSessionHeartbeat(tt.key, tt.token, 42.5, "")
+			auth, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: tt.key, SessionToken: tt.token, ContextPercent: 42.5})
 
 			if tt.wantErr != nil {
 				if !errors.Is(err, tt.wantErr) {
@@ -148,7 +148,7 @@ func TestUpdateSessionHeartbeatAuthenticates(t *testing.T) {
 
 	// The peer's own beat still works: the refusal above is about binding,
 	// not about a session poisoned by someone else's attempt.
-	if _, err := s.UpdateSessionHeartbeat(peerKey, peerToken, 10, ""); err != nil {
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: peerKey, SessionToken: peerToken, ContextPercent: 10}); err != nil {
 		t.Fatalf("peer heartbeat with its own token: %v", err)
 	}
 }

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -34,6 +34,44 @@ type Store struct {
 	// OpenBolt; cleared by CloseBolt. See bolt.go for the WAL discipline.
 	bolt     *bolt.DB
 	boltPath string
+
+	// contextResolver walks the context-window ladder for the heartbeat
+	// path. Nil means no resolution: a heartbeat carrying a window is
+	// recorded as a percentage-only reading, exactly as before this field
+	// existed. It is injected rather than owned because the ladder lives in
+	// internal/usage, which imports this package; the daemon shares its one
+	// resolver with the accountant so a window learned on either path is
+	// visible to the other. See SetContextLimitResolver and aae-orc-38yr.
+	contextResolver ContextLimitResolveFunc
+}
+
+// ContextLimitResolveFunc resolves a context-window denominator from a
+// feed-declared window and the session's manifest override, returning the
+// window and the ladder rung that produced it (a usage.LimitSource,
+// stringified). A zero window means unresolved; the caller records absence
+// rather than a guess.
+//
+// The signature is deliberately usage-free — harness, model, args, two
+// ints — so internal/api need not import internal/usage (which imports
+// internal/api). The daemon adapts its usage.Resolver to this shape in
+// SetContextLimitResolver's call site.
+type ContextLimitResolveFunc func(harness, model string, args []string, manifestLimit, feedLimit int) (limit int, source string)
+
+// SetContextLimitResolver injects the ladder the heartbeat path consults.
+// Called once at daemon construction with a closure over the same
+// usage.Resolver the accountant holds. A store with none (every store
+// outside the daemon) resolves no windows and keeps the pre-aae-orc-38yr
+// percentage-only behavior.
+//
+// The func is invoked by UpdateSessionHeartbeat while the store's write
+// lock is held, so it MUST NOT call back into the store (GetSession,
+// any Update*): the store mutex is not reentrant and would self-deadlock.
+// The daemon's closure only calls usage.Resolver, which takes its own
+// lock and never reaches back here.
+func (s *Store) SetContextLimitResolver(fn ContextLimitResolveFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.contextResolver = fn
 }
 
 // NewStore creates an empty in-memory store.
@@ -514,16 +552,16 @@ func (s *Store) UpdatePolicy(key string, fn func(*Policy) error) error {
 // dominant write rate for marvel's bbolt usage; if it surfaces as a
 // performance issue, batch by waiting N heartbeats before persisting
 // (or move heartbeat state into a separate in-memory-only path).
-func (s *Store) UpdateSessionHeartbeat(key, token string, contextPercent float64, model string) (HeartbeatAuth, error) {
+func (s *Store) UpdateSessionHeartbeat(r HeartbeatRequest) (HeartbeatAuth, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	sess, ok := s.sessions[key]
+	sess, ok := s.sessions[r.SessionKey]
 	if !ok {
-		return "", fmt.Errorf("session %s: %w", key, ErrNotFound)
+		return "", fmt.Errorf("session %s: %w", r.SessionKey, ErrNotFound)
 	}
-	auth, err := authenticateHeartbeat(sess, token)
+	auth, err := authenticateHeartbeat(sess, r.SessionToken)
 	if err != nil {
-		return "", fmt.Errorf("session %s: %w", key, err)
+		return "", fmt.Errorf("session %s: %w", r.SessionKey, err)
 	}
 	// A heartbeat is a COMPLETE reading of its own shape, not a partial
 	// update layered over whatever the accountant left behind. Writing
@@ -537,27 +575,71 @@ func (s *Store) UpdateSessionHeartbeat(key, token string, contextPercent float64
 	// is a high-water mark against a resolved window, and a heartbeat
 	// percentage is the agent's own figure against its own denominator.
 	// Carrying it would reintroduce the cross-producer mixing this fixes.
-	sess.SessionContext = SessionContext{
+	reading := SessionContext{
 		ContextSource:  ContextSourceHeartbeat,
-		ContextPercent: contextPercent,
+		ContextPercent: r.ContextPercent,
 		ContextModel:   sess.ContextModel,
 	}
+	// The heartbeat used to produce a bare percentage and nothing else,
+	// and that shape WAS the discriminator telling the two CTX% producers
+	// apart. It no longer has to be: marvel#153 made ContextSource a
+	// DECLARED field, so bolt rehydrate and the renderer key on the
+	// producer, not on which fields happen to be populated (see the
+	// comments there). That is what makes it safe for this path to carry a
+	// window for the first time (aae-orc-38yr).
+	//
+	// A cooperative feed that ships the numerator AND a denominator gets a
+	// GRADED reading: the window is resolved through the SAME ladder the
+	// accountant uses, so an operator's runtime.context_window override
+	// outranks the feed's own window (usage.LimitFromManifest above
+	// LimitFromFeed). Routing BOTH the feed window and the manifest limit
+	// through Resolve is the whole point — stamping "feed" without the
+	// manifest in hand would label a rung without climbing the ladder.
+	//
+	// The percentage is then DERIVED from occupancy over the resolved
+	// window, not taken from the wire: a harness percentage is against the
+	// harness's own denominator, and once marvel has resolved its own, its
+	// own division is the reading it can explain. The wire's percentage
+	// stands only as the fallback when there is nothing to derive from (an
+	// unresolved window, or a producer that ships no numerator — the
+	// simulator, an older harness).
+	if r.ContextTokens > 0 {
+		reading.ContextTokens = r.ContextTokens
+		if s.contextResolver != nil {
+			limit, src := s.contextResolver(
+				sess.Runtime.Name, r.Model, sess.Runtime.Args,
+				sess.Runtime.ContextWindow, r.ContextWindow,
+			)
+			if limit > 0 {
+				reading.ContextLimit = limit
+				reading.ContextLimitSource = src
+				// Deliberately NOT clamped to 100, to match the accountant's
+				// own derive (see accountant.go's reading()). ContextPercent
+				// is a >100-capable figure system-wide, and a graded
+				// heartbeat that exceeds it is a real signal, not an error:
+				// an operator whose runtime.context_window is smaller than
+				// the window the harness measured against will see occupancy
+				// run past the budget they set, and "40% over" must not
+				// render as "at the limit". Capping here would also make the
+				// renderer treat a cooperative reading differently from an
+				// accountant one, which is the exact symmetry this ticket
+				// exists to establish (aae-orc-38yr).
+				reading.ContextPercent = 100 * float64(r.ContextTokens) / float64(limit)
+			}
+		}
+	}
+	sess.SessionContext = reading
 	sess.LastHeartbeat = time.Now().UTC()
 	// A cooperative reporter that knows its model names it (the
 	// statusline feed does); one that doesn't sends "" and any
-	// prior reading stands.
-	if model != "" {
-		sess.ContextModel = model
+	// prior reading stands. ContextModel is promoted from the embedded
+	// SessionContext, so this updates the reading just written above.
+	if r.Model != "" {
+		sess.ContextModel = r.Model
 	}
 	// ContextAt is the single "measured" sentinel for the context column,
 	// shared with the usage accountant's path below. A cooperative
 	// heartbeat is a measurement too, so it stamps it.
-	//
-	// A percentage is ALL this path produces: the agent computed it
-	// itself, so there is no token count, no window, and no request count
-	// to record. That shape is what tells the two producers apart
-	// downstream (bolt rehydrate keeps this one, the renderer prints it as
-	// a percentage rather than as an unresolved window).
 	sess.ContextAt = sess.LastHeartbeat
 	if err := s.persistPut(bucketSessions, sess.Key(), sess); err != nil {
 		return "", err

--- a/internal/api/store_test.go
+++ b/internal/api/store_test.go
@@ -167,7 +167,7 @@ func TestUpdateSessionHeartbeat(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 42.5, ""); err != nil {
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: "test-ws/agent-0", ContextPercent: 42.5}); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 
@@ -180,7 +180,7 @@ func TestUpdateSessionHeartbeat(t *testing.T) {
 	}
 
 	// Not found case
-	if _, err := s.UpdateSessionHeartbeat("test-ws/nonexistent", "", 10, ""); !errors.Is(err, ErrNotFound) {
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: "test-ws/nonexistent", ContextPercent: 10}); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -361,7 +361,7 @@ func TestUpdateSessionHeartbeatStampsContextAt(t *testing.T) {
 	if err := s.CreateSession(sess); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
-	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 42.5, ""); err != nil {
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: "test-ws/agent-0", ContextPercent: 42.5}); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 	got, _ := s.GetSession("test-ws/agent-0")
@@ -472,7 +472,7 @@ func TestHeartbeatAfterUnresolvedAccountantReadingIsNotSuppressed(t *testing.T) 
 	})
 
 	// The agent then reports a percentage it computed itself.
-	if _, err := s.UpdateSessionHeartbeat("test-ws/agent-0", "", 61.0, "claude-opus-5"); err != nil {
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{SessionKey: "test-ws/agent-0", ContextPercent: 61.0, Model: "claude-opus-5"}); err != nil {
 		t.Fatalf("update heartbeat: %v", err)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -268,8 +268,24 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	if limits == nil {
 		limits = usage.DefaultTable()
 	}
-	acct := usage.New(store, usage.NewResolver(limits), usage.WithEvents(evRing))
+	// One resolver, shared between the accountant and the heartbeat path,
+	// so a window learned on either (Claude declares its own in-stream) is
+	// visible to the other. The heartbeat path reaches it through the
+	// store's injected ContextLimitResolveFunc, whose usage-free signature
+	// keeps internal/api from importing internal/usage. See aae-orc-38yr.
+	resolver := usage.NewResolver(limits)
+	acct := usage.New(store, resolver, usage.WithEvents(evRing))
 	sessMgr.Usage = acct
+	store.SetContextLimitResolver(func(harness, model string, args []string, manifestLimit, feedLimit int) (int, string) {
+		limit, src, _ := resolver.Resolve(usage.Request{
+			Harness:       harness,
+			StreamModel:   model,
+			RuntimeArgs:   args,
+			ManifestLimit: manifestLimit,
+			FeedLimit:     feedLimit,
+		})
+		return limit, string(src)
+	})
 
 	// Resolved once at construction rather than per response: the home
 	// cannot change under a running daemon, and a failure here is not
@@ -1081,7 +1097,7 @@ func (d *Daemon) handleHeartbeat(params json.RawMessage) Response {
 		return Response{Error: fmt.Sprintf("bad params: %v", err)}
 	}
 
-	auth, err := d.store.UpdateSessionHeartbeat(p.SessionKey, p.SessionToken, p.ContextPercent, p.Model)
+	auth, err := d.store.UpdateSessionHeartbeat(p)
 	if err != nil {
 		if errors.Is(err, api.ErrHeartbeatUnauthorized) {
 			// Two different faults reach this branch and they have

--- a/internal/daemon/heartbeat_graded_test.go
+++ b/internal/daemon/heartbeat_graded_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// registerGradedSession puts a bound session in the store with a chosen
+// harness and manifest window, so a test can exercise the real
+// usage.Resolver the daemon wires into the store at construction. It
+// returns the key and the plaintext token the way the agent's environment
+// receives it.
+func registerGradedSession(t *testing.T, d *Daemon, name, harness string, manifestLimit int) (key, token string) {
+	t.Helper()
+	tok, hash, err := api.NewHeartbeatToken()
+	if err != nil {
+		t.Fatalf("mint token: %v", err)
+	}
+	sess := &api.Session{
+		Name:      name,
+		Workspace: "ws",
+		Team:      "squad",
+		Role:      "worker",
+		Runtime: api.Runtime{
+			Name:          harness,
+			Command:       harness,
+			ContextWindow: manifestLimit,
+		},
+		State:              api.SessionRunning,
+		HeartbeatTokenHash: hash,
+		CreatedAt:          time.Now().UTC(),
+	}
+	if err := d.store.CreateSession(sess); err != nil {
+		t.Fatalf("create session %s: %v", name, err)
+	}
+	return sess.Key(), tok
+}
+
+// TestGradedHeartbeatResolvesThroughTheRealLadder is the composition proof
+// for aae-orc-38yr: a producer's real wire shape, carrying the numerator
+// and the denominator, run through the real handler against the real
+// usage.Resolver the daemon shares with the accountant. It asserts the two
+// halves the store-level fake cannot: that the daemon actually WIRED a
+// resolver into the store, and that the resolver is the genuine ladder
+// (feed below manifest), not a stand-in.
+func TestGradedHeartbeatResolvesThroughTheRealLadder(t *testing.T) {
+	d := newHandlerDaemon(t)
+
+	t.Run("feed window resolves when no operator override is set", func(t *testing.T) {
+		key, token := registerGradedSession(t, d, "agent-feed", "claude", 0)
+		req := api.HeartbeatRequest{
+			SessionKey:     key,
+			SessionToken:   token,
+			ContextTokens:  120_000,
+			ContextWindow:  200_000,
+			Model:          "claude-opus-4-8",
+			ContextPercent: 60,
+		}
+		raw, _ := json.Marshal(req)
+		if resp := d.handleHeartbeat(raw); resp.Error != "" {
+			t.Fatalf("handleHeartbeat: %q", resp.Error)
+		}
+		got, _ := d.store.GetSession(key)
+		if got.ContextSource != api.ContextSourceHeartbeat {
+			t.Fatalf("ContextSource = %q, want heartbeat", got.ContextSource)
+		}
+		if got.ContextLimit != 200_000 || got.ContextLimitSource != "feed" {
+			t.Fatalf("limit=%d source=%q, want 200000 / feed", got.ContextLimit, got.ContextLimitSource)
+		}
+		if got.ContextTokens != 120_000 {
+			t.Fatalf("ContextTokens = %d, want 120000", got.ContextTokens)
+		}
+		if got.ContextPercent != 60 {
+			t.Fatalf("ContextPercent = %.2f, want 60 (derived 120000/200000)", got.ContextPercent)
+		}
+	})
+
+	t.Run("operator manifest override outranks the feed window", func(t *testing.T) {
+		key, token := registerGradedSession(t, d, "agent-manifest", "claude", 500_000)
+		req := api.HeartbeatRequest{
+			SessionKey:    key,
+			SessionToken:  token,
+			ContextTokens: 120_000,
+			ContextWindow: 200_000, // the feed's window, which the manifest outranks
+			Model:         "claude-opus-4-8",
+		}
+		raw, _ := json.Marshal(req)
+		if resp := d.handleHeartbeat(raw); resp.Error != "" {
+			t.Fatalf("handleHeartbeat: %q", resp.Error)
+		}
+		got, _ := d.store.GetSession(key)
+		if got.ContextLimit != 500_000 || got.ContextLimitSource != "manifest" {
+			t.Fatalf("limit=%d source=%q, want 500000 / manifest (the ruling has effect)",
+				got.ContextLimit, got.ContextLimitSource)
+		}
+		if got.ContextPercent != 24 {
+			t.Fatalf("ContextPercent = %.2f, want 24 (120000/500000, the operator's denominator)", got.ContextPercent)
+		}
+	})
+
+	t.Run("a windowless simulator beat stays a percentage-only reading", func(t *testing.T) {
+		key, token := registerGradedSession(t, d, "agent-sim", "simulator", 0)
+		// The simulator's exact shape: percentage, no model, no numerator,
+		// no window. It must keep the pre-38yr behavior.
+		req := api.NewHeartbeatRequestWithToken(key, token, 40, "")
+		raw, _ := json.Marshal(req)
+		if resp := d.handleHeartbeat(raw); resp.Error != "" {
+			t.Fatalf("handleHeartbeat: %q", resp.Error)
+		}
+		got, _ := d.store.GetSession(key)
+		if got.ContextLimit != 0 || got.ContextLimitSource != "" || got.ContextTokens != 0 {
+			t.Fatalf("percentage-only beat leaked a window: limit=%d src=%q tokens=%d",
+				got.ContextLimit, got.ContextLimitSource, got.ContextTokens)
+		}
+		if got.ContextPercent != 40 || got.ContextSource != api.ContextSourceHeartbeat {
+			t.Fatalf("pct=%.2f source=%q, want 40 / heartbeat", got.ContextPercent, got.ContextSource)
+		}
+	})
+}

--- a/internal/daemon/heartbeat_producer_test.go
+++ b/internal/daemon/heartbeat_producer_test.go
@@ -38,18 +38,24 @@ func TestEveryProducerShapeIsAdmitted(t *testing.T) {
 		build func() api.HeartbeatRequest
 	}{
 		{
-			// cmd/marvel/ctxforward.go, the claude statusline feed.
+			// cmd/marvel/ctxforward.go, the claude statusline feed, now
+			// carrying the numerator and denominator (aae-orc-38yr).
 			name: "ctx-forward reads the token from the environment",
 			build: func() api.HeartbeatRequest {
-				return api.NewHeartbeatRequest(boundKey, 61, "claude-opus-5")
+				p := api.NewHeartbeatRequest(boundKey, 61, "claude-opus-5")
+				p.ContextTokens = 122_000
+				p.ContextWindow = 200_000
+				return p
 			},
 		},
 		{
 			// cmd/marvel/codexctx.go, the codex rollout hook. This is the
-			// producer that was refused on the merge commit.
+			// producer that was refused on the merge commit; it now carries
+			// occupancy alongside the window and the token.
 			name: "codex-ctx carries a window alongside the token",
 			build: func() api.HeartbeatRequest {
 				p := api.NewHeartbeatRequest(boundKey, 93.85, "gpt-5.6-sol")
+				p.ContextTokens = 242_696
 				p.ContextWindow = 258400
 				return p
 			},


### PR DESCRIPTION
## Why

The cooperative heartbeat RPC reported context pressure as a pre-computed percentage the agent divided against *its own* window. That threw away the two numbers behind it (occupancy and the window), so marvel could never re-check the figure or apply its own denominator — an operator's `runtime.context_window` override could not affect a cooperative reading, and a heartbeat reading looked nothing like an accountant one to the renderer. This finishes gh-141: the heartbeat now carries the numerator and denominator, the daemon resolves the window through the same ladder the accountant uses, and it derives the percentage itself. A cooperative reading and an accountant reading become the same shape, and the operator override finally has effect on the interactive feed.

The producer half of this seam already existed (ctx-forward emitted `context_window`, parsed-and-dropped by the daemon). The blocking ruling — where a harness-declared window sits on the ladder — was made (`LimitFromFeed`, below the operator's manifest override, in `internal/usage`). This PR builds the missing consumer and wires every producer to it.

## What

- **Wire type** (`internal/api/heartbeat.go`): add `ContextTokens` (the numerator). `ContextWindow` (the denominator) is now consumed, not dropped. `ContextPercent` stays as the graceful-degradation fallback.
- **Store** (`internal/api/store.go`): `UpdateSessionHeartbeat` takes the wire request and, when a numerator arrives, resolves the denominator through an injected `ContextLimitResolveFunc` — routing **both** the feed window and the session's manifest limit through `usage.Resolve`, so the operator override outranks the feed (not just a "feed" label without the ladder). The percentage is then **derived** from occupancy over the resolved window, deliberately **unclamped** to match the accountant (an occupancy over the operator's declared budget reads "over budget", not "at the limit"). A store with no resolver, or a producer with no numerator, keeps the exact pre-existing percentage-only behavior.
- **Import boundary**: `internal/api` cannot import `internal/usage` (which imports `internal/api`). The resolver is injected via a usage-free func signature; the daemon shares **one** `usage.Resolver` between the accountant and the heartbeat path (so a learned window is visible to both) and adapts it in `internal/daemon/daemon.go`.
- **Renderer** (`cmd/marvel/main.go`): comment-only — the heartbeat exception now applies to the percentage-only sub-case; a graded heartbeat lands in the default branch like any measured reading (behavior already correct: it keys on the declared `ContextSource`, not on field shape, per marvel#153).
- **Tests**: red→green throughout. Store-contract tests with an injected fake resolver (graded reading, manifest-outranks-feed, percentage-only degradation, derived-not-wire percent, nil resolver, numerator-with-unresolved-window, deliberate over-100). A composition test in `internal/daemon` runs each producer's real wire shape through the real handler against the **real** `usage.Resolver`.

Safety: this is a `finding-023`-class wire-contract change — every producer is updated in this one PR, the `UpdateSessionHeartbeat` signature change is compile-checked at every caller, and the new JSON fields are additive (`omitempty`), so old and new deserialize both ways. The added fields widen only the CTX% reading; the heartbeat is still authenticated by its minted token before any write (cross-ref aae-orc-mr5c: no new auth surface).

Self-review: ran `bmad-code-review` (Blind Hunter + Edge Case Hunter). No blockers/majors. The one convergent finding — the derived percentage was unclamped — is resolved as a **deliberate, documented, and tested** decision (accountant symmetry), plus the reviewers' minor doc/test-gap items were applied.

Quality gates: `go build ./...`, `go test -race ./...`, `golangci-lint run ./...` — all green.

## Producers updated

The complete set of heartbeat RPC producers (`Method: "heartbeat"` / `api.HeartbeatRequest`), all accounted for in this PR:

- **`cmd/marvel/ctxforward.go`** (Claude Code statusline feed) — now sends the numerator (`ContextTokens`, the occupancy sum: input + cache-creation + cache-read, the same sum the cross-check divides) alongside the existing `ContextWindow`.
- **`cmd/marvel/codexctx.go`** (codex rollout hook) — now sends the numerator (`Reading.Level`) alongside `ContextWindow`. Its window is routed as **feed** (rung 4), not stream (rung 1); the rung-1 promotion is the open decision reserved to the operator in PR #172 and deliberately not taken here.
- **`cmd/simulator/main.go`** (simulator) — unchanged: percentage-only via the shared constructor. Exercised in the composition test to prove the degraded path still works.

Consumer updated: `internal/api.Store.UpdateSessionHeartbeat` (the daemon's `handleHeartbeat`).

Wire type changed: `api.HeartbeatRequest` (added `ContextTokens int` / `context_tokens`; `ContextWindow` now consumed).

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS