### PR TITLE
feat(cli): marvel plan — spawn-free convergence preview

### DIFF
--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/arcavenae/marvel/internal/keys"
 	"github.com/arcavenae/marvel/internal/paths"
 	"github.com/arcavenae/marvel/internal/rlog"
+	"github.com/arcavenae/marvel/internal/team"
 	"github.com/arcavenae/marvel/internal/tmux"
 	"github.com/arcavenae/marvel/internal/upgrade"
 	"github.com/spf13/cobra"
@@ -153,6 +154,7 @@ func main() {
 	root.AddCommand(orphansCmd())
 	root.AddCommand(newCtxForwardCmd())
 	root.AddCommand(newCodexCtxCmd())
+	root.AddCommand(planCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -917,6 +919,127 @@ func getResources(resourceType string) error {
 		fmt.Println(string(resp.Result))
 	}
 	return nil
+}
+
+// planCmd is the read-only preview surface (aae-orc-nrk1): it prints the
+// convergence delta the next reconcile tick would enact without spawning or
+// deleting anything. It is both an operator preview and a spawn-free way to
+// exercise the convergence decision in dev/test.
+func planCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "plan [workspace/team]",
+		Short: "Preview the convergence delta per team without spawning (dry run)",
+		Long: `Print the plan the next reconcile tick would enact — desired vs alive
+replica counts, sessions that would spawn, sessions that would scale down, and
+any hold (crash-loop backoff or admission refusal) — computed without applying
+it. No session is spawned or deleted, so this is a spawn-free way to inspect
+what the daemon is about to do.
+
+With no argument every team is shown. An optional workspace/team narrows the
+preview; a bare name matches that workspace or that team.
+
+Teams mid-shift are omitted: their convergence runs at shift-aware
+generations, which this steady-state preview does not model.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filter := ""
+			if len(args) == 1 {
+				filter = args[0]
+			}
+			return planConvergence(filter)
+		},
+	}
+}
+
+func planConvergence(filter string) error {
+	resp, err := send(daemon.Request{Method: "plan"})
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return fmt.Errorf("%s", resp.Error)
+	}
+	var result struct {
+		Plans []team.RolePlan `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return fmt.Errorf("parse plan: %w", err)
+	}
+	plans := result.Plans
+	if filter != "" {
+		plans = filterPlans(plans, filter)
+	}
+	fmt.Print(renderPlanTable(plans))
+	return nil
+}
+
+// filterPlans narrows a preview to a single workspace/team key. A key with a
+// slash matches workspace and team exactly (the form Team.Key() prints); a
+// bare token matches either the workspace or the team, so `marvel plan api`
+// finds team api in any workspace.
+func filterPlans(plans []team.RolePlan, filter string) []team.RolePlan {
+	ws, tm, hasSlash := strings.Cut(filter, "/")
+	var out []team.RolePlan
+	for _, p := range plans {
+		match := p.Workspace == filter || p.Team == filter
+		if hasSlash {
+			match = p.Workspace == ws && p.Team == tm
+		}
+		if match {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// renderPlanTable is the pure renderer for `marvel plan`, split out for the
+// same reason renderSessionTable and renderBudgetTable are: the table's
+// content and its empty-case wording are worth asserting without a daemon.
+// Rows are sorted workspace, team, role for a deterministic preview, and a
+// summary footer counts the verbs.
+func renderPlanTable(plans []team.RolePlan) string {
+	if len(plans) == 0 {
+		return "no teams to plan (none declared, or all mid-shift)\n"
+	}
+	sorted := make([]team.RolePlan, len(plans))
+	copy(sorted, plans)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Workspace != sorted[j].Workspace {
+			return sorted[i].Workspace < sorted[j].Workspace
+		}
+		if sorted[i].Team != sorted[j].Team {
+			return sorted[i].Team < sorted[j].Team
+		}
+		return sorted[i].Role < sorted[j].Role
+	})
+
+	var spawn, scaleDown, hold, steady int
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "WORKSPACE\tTEAM\tROLE\tGEN\tDESIRED\tACTUAL\tACTION\tSPAWN\tSCALE-DOWN\tHOLD\n")
+	for _, p := range sorted {
+		holdCell := p.HoldDetail
+		if holdCell == "" {
+			holdCell = "-"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%s\n",
+			p.Workspace, p.Team, p.Role, p.Generation, p.Desired, p.Actual,
+			p.Action, p.Spawn, len(p.Delete), holdCell)
+		switch p.Action {
+		case team.RoleSpawn:
+			spawn++
+		case team.RoleScaleDown:
+			scaleDown++
+		case team.RoleHold:
+			hold++
+		default:
+			steady++
+		}
+	}
+	_ = w.Flush()
+	_, _ = fmt.Fprintf(&buf, "\n%d role(s): %d spawn, %d scale-down, %d hold, %d steady\n",
+		len(sorted), spawn, scaleDown, hold, steady)
+	return buf.String()
 }
 
 func describeCmd() *cobra.Command {

--- a/cmd/marvel/plan_test.go
+++ b/cmd/marvel/plan_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/team"
+)
+
+// With no plans — no teams declared, or every team mid-shift — the preview
+// says so in words rather than printing a bare header, so an operator does
+// not read an empty table as "nothing to do here" when it means "nothing
+// to plan against".
+func TestRenderPlanTableEmpty(t *testing.T) {
+	out := renderPlanTable(nil)
+	if !strings.Contains(out, "no teams to plan") {
+		t.Errorf("empty render = %q, want a 'no teams to plan' message", out)
+	}
+}
+
+// A single role with a deficit renders each field of the plan in its own
+// column: desired, the alive count it would adopt toward, the verb, and the
+// spawn count.
+func TestRenderPlanTableSpawn(t *testing.T) {
+	table := renderPlanTable([]team.RolePlan{{
+		Workspace: "ws", Team: "api", Role: "dev",
+		Generation: 0, Desired: 2, Actual: 1,
+		Action: team.RoleSpawn, Spawn: 1,
+	}})
+	if got := column(t, table, "WORKSPACE"); got != "ws" {
+		t.Errorf("WORKSPACE = %q, want ws", got)
+	}
+	if got := column(t, table, "ROLE"); got != "dev" {
+		t.Errorf("ROLE = %q, want dev", got)
+	}
+	if got := column(t, table, "DESIRED"); got != "2" {
+		t.Errorf("DESIRED = %q, want 2", got)
+	}
+	if got := column(t, table, "ACTUAL"); got != "1" {
+		t.Errorf("ACTUAL = %q, want 1", got)
+	}
+	if got := column(t, table, "ACTION"); got != "spawn" {
+		t.Errorf("ACTION = %q, want spawn", got)
+	}
+	if got := column(t, table, "SPAWN"); got != "1" {
+		t.Errorf("SPAWN = %q, want 1", got)
+	}
+	if got := column(t, table, "HOLD"); got != "-" {
+		t.Errorf("HOLD = %q, want - for an unheld spawn", got)
+	}
+}
+
+// A scale-down reports the number of sessions it would delete, and a steady
+// role reports zero of everything.
+func TestRenderPlanTableScaleDownAndSteady(t *testing.T) {
+	scaleDown := renderPlanTable([]team.RolePlan{{
+		Workspace: "ws", Team: "api", Role: "dev",
+		Desired: 1, Actual: 3, Action: team.RoleScaleDown,
+		Delete: []api.Session{{Name: "a"}, {Name: "b"}},
+	}})
+	if got := column(t, scaleDown, "SCALE-DOWN"); got != "2" {
+		t.Errorf("SCALE-DOWN = %q, want 2", got)
+	}
+	if got := column(t, scaleDown, "ACTION"); got != "scale_down" {
+		t.Errorf("ACTION = %q, want scale_down", got)
+	}
+
+	steady := renderPlanTable([]team.RolePlan{{
+		Workspace: "ws", Team: "api", Role: "dev",
+		Desired: 1, Actual: 1, Action: team.RoleSteady,
+	}})
+	if got := column(t, steady, "SPAWN"); got != "0" {
+		t.Errorf("SPAWN = %q, want 0 for steady", got)
+	}
+	if got := column(t, steady, "ACTION"); got != "steady" {
+		t.Errorf("ACTION = %q, want steady", got)
+	}
+}
+
+// A held role carries its human-readable reason in the HOLD column — the
+// backoff window or the admission refusal — so the preview explains why a
+// deficit is not being repaired this tick.
+func TestRenderPlanTableHoldDetail(t *testing.T) {
+	table := renderPlanTable([]team.RolePlan{{
+		Workspace: "ws", Team: "db", Role: "main",
+		Desired: 1, Actual: 0, Action: team.RoleHold,
+		Hold: team.HoldBackoff, HoldDetail: "crash-loop backoff until 2026-01-01T00:00:00Z",
+	}})
+	if !strings.Contains(table, "crash-loop backoff until 2026-01-01T00:00:00Z") {
+		t.Errorf("hold detail missing from render:\n%s", table)
+	}
+	if got := column(t, table, "ACTION"); got != "hold" {
+		t.Errorf("ACTION = %q, want hold", got)
+	}
+}
+
+// The rows are sorted workspace, then team, then role — deterministic
+// regardless of the order the daemon returned them — and a summary footer
+// counts the verbs so the whole preview reads at a glance.
+func TestRenderPlanTableSortedWithSummary(t *testing.T) {
+	table := renderPlanTable([]team.RolePlan{
+		{Workspace: "ws", Team: "b", Role: "z", Desired: 1, Actual: 1, Action: team.RoleSteady},
+		{Workspace: "ws", Team: "a", Role: "x", Desired: 2, Actual: 0, Action: team.RoleSpawn, Spawn: 2},
+		{Workspace: "ws", Team: "a", Role: "y", Desired: 0, Actual: 1, Action: team.RoleScaleDown, Delete: []api.Session{{Name: "s"}}},
+	})
+	lines := strings.Split(strings.TrimRight(table, "\n"), "\n")
+	// lines[0] is the header; rows follow in sorted order.
+	order := [][2]string{{"a", "x"}, {"a", "y"}, {"b", "z"}}
+	for i, want := range order {
+		cells := splitColumns(lines[1+i])
+		// TEAM is column index 1, ROLE index 2.
+		if cells[1] != want[0] || cells[2] != want[1] {
+			t.Errorf("row %d = team %q role %q, want team %q role %q", i, cells[1], cells[2], want[0], want[1])
+		}
+	}
+	if !strings.Contains(table, "1 spawn") || !strings.Contains(table, "1 scale-down") || !strings.Contains(table, "1 steady") {
+		t.Errorf("summary footer missing expected counts:\n%s", table)
+	}
+}
+
+// filterPlans narrows a preview to one workspace/team key, the optional
+// argument to `marvel plan`. A bare token with no slash matches either the
+// workspace or the team, so `marvel plan api` finds team api in any
+// workspace.
+func TestFilterPlans(t *testing.T) {
+	plans := []team.RolePlan{
+		{Workspace: "ws1", Team: "api", Role: "dev"},
+		{Workspace: "ws1", Team: "db", Role: "main"},
+		{Workspace: "ws2", Team: "api", Role: "dev"},
+	}
+
+	byKey := filterPlans(plans, "ws1/api")
+	if len(byKey) != 1 || byKey[0].Workspace != "ws1" || byKey[0].Team != "api" {
+		t.Errorf("filter ws1/api = %+v, want the single ws1/api row", byKey)
+	}
+
+	byTeam := filterPlans(plans, "api")
+	if len(byTeam) != 2 {
+		t.Errorf("filter api = %d rows, want 2 (api in both workspaces)", len(byTeam))
+	}
+
+	none := filterPlans(plans, "ws1/nope")
+	if len(none) != 0 {
+		t.Errorf("filter ws1/nope = %d rows, want 0", len(none))
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -695,6 +695,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleEvents(req.Params)
 	case "orphans":
 		return d.handleOrphans()
+	case "plan":
+		return d.handlePlan()
 	default:
 		return Response{Error: fmt.Sprintf("unknown method: %s", req.Method)}
 	}
@@ -886,6 +888,29 @@ func (d *Daemon) handleGet(params json.RawMessage) Response {
 	data, err := json.Marshal(result)
 	if err != nil {
 		return Response{Error: fmt.Sprintf("marshal result: %v", err)}
+	}
+	return Response{Result: data}
+}
+
+// planResult carries the convergence preview returned by the plan RPC: the
+// RolePlans the next reconcile tick would enact, computed without enacting
+// anything. Named-struct result, like logsResult and eventsResult, so the
+// wire shape is self-describing and can gain aggregate fields later without
+// breaking the CLI decode.
+type planResult struct {
+	Plans []team.RolePlan `json:"plans"`
+}
+
+// handlePlan returns the steady-state convergence plan for every team not
+// mid-shift — the read-only preview surface for `marvel plan` (aae-orc-nrk1).
+// It calls Controller.PlanConvergence, which is pure: no session is spawned
+// or deleted and no store record is written, so this RPC never changes
+// cluster state. Teams mid-shift are omitted by PlanConvergence; see its doc
+// comment for the two fidelity limits a consumer must account for.
+func (d *Daemon) handlePlan() Response {
+	data, err := json.Marshal(planResult{Plans: d.teamCtrl.PlanConvergence()})
+	if err != nil {
+		return Response{Error: fmt.Sprintf("marshal plan: %v", err)}
 	}
 	return Response{Result: data}
 }

--- a/internal/daemon/plan_test.go
+++ b/internal/daemon/plan_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
+	"github.com/arcavenae/marvel/internal/team"
+)
+
+// The plan RPC is the read-only preview surface (aae-orc-nrk1): it must
+// report what the next reconcile tick would spawn WITHOUT spawning it. This
+// test declares a role with a deficit, calls the handler directly (never
+// Start, so the reconcile loop never runs), and asserts both that the plan
+// names the deficit and that not a single session was created.
+func TestHandlePlanReadOnly(t *testing.T) {
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+
+	if err := d.store.CreateTeam(&api.Team{
+		Name:      "squad",
+		Workspace: "test",
+		Roles:     []api.Role{{Name: "worker", Replicas: 2}},
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	resp := d.handlePlan()
+	if resp.Error != "" {
+		t.Fatalf("plan error: %s", resp.Error)
+	}
+
+	var result struct {
+		Plans []team.RolePlan `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("parse plan result: %v", err)
+	}
+
+	if len(result.Plans) != 1 {
+		t.Fatalf("got %d plans, want 1: %+v", len(result.Plans), result.Plans)
+	}
+	p := result.Plans[0]
+	if p.Workspace != "test" || p.Team != "squad" || p.Role != "worker" {
+		t.Errorf("plan identity = %s/%s/%s, want test/squad/worker", p.Workspace, p.Team, p.Role)
+	}
+	if p.Desired != 2 {
+		t.Errorf("Desired = %d, want 2", p.Desired)
+	}
+	if p.Actual != 0 {
+		t.Errorf("Actual = %d, want 0", p.Actual)
+	}
+	if p.Action != team.RoleSpawn {
+		t.Errorf("Action = %q, want %q", p.Action, team.RoleSpawn)
+	}
+	if p.Spawn != 2 {
+		t.Errorf("Spawn = %d, want 2", p.Spawn)
+	}
+
+	// The point of the surface: computing the plan spawns nothing.
+	if got := len(d.store.ListSessions()); got != 0 {
+		t.Errorf("plan created %d sessions; the preview must spawn nothing", got)
+	}
+}
+
+// A team mid-shift is out of scope for the steady-state preview (see the
+// PlanConvergence doc comment). The handler must simply omit it rather than
+// error.
+func TestHandlePlanEmpty(t *testing.T) {
+	skipIfNoTmux(t)
+
+	d, err := New()
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	t.Cleanup(func() { d.Stop() })
+
+	resp := d.handlePlan()
+	if resp.Error != "" {
+		t.Fatalf("plan error: %s", resp.Error)
+	}
+	var result struct {
+		Plans []team.RolePlan `json:"plans"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("parse plan result: %v", err)
+	}
+	if len(result.Plans) != 0 {
+		t.Errorf("got %d plans with no teams, want 0", len(result.Plans))
+	}
+}


### PR DESCRIPTION
## Why

The plan/apply split (nf0w, #220) made the convergence decision an
inspectable value but kept it internal — every path that reaches it still
applies it. This exposes it as a preview: an operator can see what the next
reconcile tick would spawn, scale down, or hold *before* it happens, and a
developer gets a spawn-free way to exercise the convergence decision without
launching real processes. It turns an already-pure function into an
operator-facing and test-facing surface at near-zero risk, because it only
reads.

## What

- New `marvel plan [workspace/team]` command. Prints the convergence delta
  per team — desired vs alive replica counts, would-spawn, would-scale-down,
  and any hold (crash-loop backoff or admission refusal) — sorted
  workspace/team/role, with a one-line verb summary. An optional
  `workspace/team` narrows the view (a bare token matches either).
- New read-only daemon RPC (`Method: "plan"`) that calls the already-exported,
  pure `Controller.PlanConvergence()` and returns the `[]team.RolePlan`.

No reconcile/plan/apply logic was touched — the change consumes
`PlanConvergence()` as-is. The renderer is split out as a pure
`renderPlanTable` (mirroring `renderSessionTable`/`renderBudgetTable`) so the
table and its empty-case wording are asserted without a daemon. The RPC test
asserts the preview creates zero sessions — the load-bearing property of a
dry-run surface.

`marvel daemon --dry-run` (the ticket's alternative form) is deliberately
deferred: it would insert into the daemon-start path, which is being changed
concurrently, and `marvel plan` already delivers both the operator-preview
and spawn-free-inspection value.

## Tests

- `cmd/marvel/plan_test.go` — `renderPlanTable` (empty, spawn, scale-down,
  steady, hold-detail, sorting + summary) and `filterPlans` (key form, bare
  token, no-match).
- `internal/daemon/plan_test.go` — the `plan` RPC returns the expected
  `RolePlan` for a declared deficit and spawns nothing; the empty case.

8 new tests, pass under `-race`. `go build ./...`, `go test -race ./...`,
`golangci-lint run ./...`, and `gofumpt` all clean. Manually smoke-tested
end-to-end against a live daemon (empty case, steady-state table, and the
`workspace/team` + bare-token filters).

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS