### PR TITLE
feat(convergence): hold at the start line, add the converge go-line

### DIFF
--- a/_kos/findings/finding-034-convergence-posture-hold-at-start-line.md
+++ b/_kos/findings/finding-034-convergence-posture-hold-at-start-line.md
@@ -1,0 +1,105 @@
+# finding-034 — convergence posture: hold at the start line, with a control-plane go-line
+
+Work: aae-orc-rwiw (the fix), discharging aae-orc-cxdf (the LIVE P1
+money-spender). Builds on aae-orc-nf0w's plan/apply split (marvel #220).
+
+Related: finding-030 (the empirical grounding — the mechanism confirmed
+"cold convergence from zero" as the exact dangerous case), the frontier node
+`question-convergence-posture`.
+
+**This is a design + implementation finding, not a measurement.** It records
+the load-bearing decision so a future reader (or majordomo author) does not
+re-derive it.
+
+---
+
+## 1. The defect, restated
+
+`marvel daemon` against a populated `~/.marvel` rehydrates durable desired
+state and the reconciler spawns replicas to reach it — spawning real
+claude/codex/opencode processes that spend real tokens — from one unflagged
+command. Reproduced live 2026-08-09: 6 roles, 20 sessions, three vendors, in
+~3s, against a torn-down demo's leftover bolt. A stale bolt is a standing
+instruction to spend money.
+
+## 2. The discriminator (the whole fix in one line)
+
+The dangerous spawn is **cold convergence from zero**: a team with
+`desired > 0` and **no live presence**. Every safe recovery path — detach,
+reexec, SIGTERM — leaves panes alive, so adoption satisfies desired and
+nothing spawns (confirmed in finding-030). So the daemon *can* tell "restarted
+under an operator, wants its fleet back" (panes survived → adopted) from
+"started fresh/stale, wants nothing" (no panes) — by **the panes**, the fact it
+can observe, not a guess.
+
+## 3. What shipped
+
+**Per-team posture** (`api.Team.ConvergencePosture`, persisted; read through
+`Team.Posture()` which normalizes the zero value to `hold`):
+
+- `PostureHold` (default) — a team with no live presence does NOT spawn toward
+  desired.
+- `PostureConverge` — spawns toward desired (the go-line), and the stance a
+  team with surviving panes is given at start so its steady-state maintenance
+  is never suppressed.
+
+**The gate** (`team.Controller.reconcileRole`, steady-state path only, never the
+shift path):
+
+```
+withhold a spawn  ⇔  plan.Action == RoleSpawn
+                     AND team posture == hold
+                     AND the team has zero live sessions
+```
+
+The zero-live clause is the load-bearing exception: a team with even one live
+replica is being *maintained*, not cold-started, so its top-ups and crash-loop
+restarts proceed regardless of posture. A single-replica team that crashes to
+zero still restarts, because posture is a latch set at start (converge for a
+live team) and a crash does not flip it. `planRole` / `PlanConvergence` are left
+RAW (posture-blind) — the dry-run seam (nrk1) is untouched.
+
+**Posture decided at start from ground truth** (`Start` →
+`RefreshLiveness` → `InitConvergencePosture`): after adoption, reap records
+whose panes did not survive (a host reboot leaves stale `Running` rows), then
+set each team's posture from live presence — any live session → converge, none
+→ hold. This **overrides** whatever the bolt rehydrated, so a stale bolt that
+persisted `converge` cannot cold-spawn: only surviving panes yield converge.
+This is the money-safety guarantee, and it is why a persisted posture never has
+to be trusted at start.
+
+**The go-line is a control-plane operation** (`SetConvergencePosture` on the
+controller; `converge` RPC on the daemon; `marvel converge [workspace/team]` as
+one thin client), so a future in-process majordomo pulls the same lever. Empty
+team key = every team. `apply` sets applied teams to `converge` (an explicit
+"make it so"), so apply's spawn-on-apply behavior is unchanged.
+
+## 4. What it does NOT do (deliberate scope)
+
+- No CLI `hold` verb (the RPC supports the hold direction for the majordomo).
+- No `resume-on-power` / start-policy config — that is tu2e, and the start path
+  is written so tu2e can make the hold default conditional per team.
+- No cost dimension. finding-030 showed the cold-convergence *cost* depends on
+  role kind (a headless role with `replicas > 1` re-pays; an interactive role
+  is ~free). The hold gate discharges cxdf for both; pricing the posture is a
+  future refinement, not part of this fix.
+- Scaling a cold held team records the new desired count but spawns nothing
+  until `converge` — consistent, and the operator's spawn intent is the
+  converge verb.
+
+## 5. Non-regression, tested
+
+- **reexec/detach auto-resume**: a fully-adopted team (panes survived) is set to
+  converge at start and reconciles to steady — no spawn (adoption satisfied
+  desired). `TestReexecAutoResumeAdoptedTeamDoesNotSpawn`.
+- **cannot silently re-arm the spender**: a cold held team run through the
+  reconcile boundary spawns nothing, asserted with a nil session manager so any
+  spawn attempt panics. `TestReconcileRoleWithholdsColdHeldTeam`.
+- **maintenance is never suppressed**: a held team with a live replica is topped
+  up to strength. `TestReconcileRoleHoldMaintainsLiveTeam`.
+- **host-reboot money-safety**: a rehydrated `Running` record whose pane is gone
+  is reaped before posture-init, so the team reads cold and holds.
+  `TestRefreshLivenessReapsDeadPaneRecordsBeforePosture`.
+- **the go-line**: cold held team spawns only after converge, end-to-end through
+  the daemon dispatch. `TestConvergeRPCSpawnsHeldTeam`, plus the empty-key
+  all-teams variant and the persisted-converge-override money-safety case.

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -137,6 +137,7 @@ func main() {
 	root.AddCommand(describeCmd())
 	root.AddCommand(deleteCmd())
 	root.AddCommand(scaleCmd())
+	root.AddCommand(convergeCmd())
 	root.AddCommand(runCmd())
 	root.AddCommand(killCmd())
 	root.AddCommand(shiftCmd())
@@ -1005,6 +1006,59 @@ func scaleCmd() *cobra.Command {
 	}
 	cmd.Flags().IntVar(&replicas, "replicas", 1, "desired replica count")
 	cmd.Flags().StringVar(&role, "role", "", "role to scale (required)")
+	return cmd
+}
+
+func convergeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "converge [workspace/team]",
+		Short: "Release a team (or all teams) from the start-line hold and converge to desired",
+		Long: "By default a daemon holds each team at the start line: it adopts surviving\n" +
+			"panes but does not spawn toward a team's desired replica count until told to.\n" +
+			"converge is that go-line. With no argument it converges every team; with a\n" +
+			"workspace/team it converges just that one.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var teamKey string
+			if len(args) == 1 {
+				teamKey = args[0]
+			}
+			params, _ := json.Marshal(map[string]any{"team_key": teamKey})
+			resp, err := send(daemon.Request{Method: "converge", Params: params})
+			if err != nil {
+				return err
+			}
+			if resp.Error != "" {
+				return fmt.Errorf("%s", resp.Error)
+			}
+			var result struct {
+				Posture string `json:"posture"`
+				Teams   []string
+				Roles   []struct {
+					Team    string
+					Role    string
+					Action  string
+					Spawn   int
+					Desired int
+					Actual  int
+				}
+			}
+			_ = json.Unmarshal(resp.Result, &result)
+			if len(result.Teams) == 0 {
+				fmt.Println("no teams to converge")
+				return nil
+			}
+			fmt.Printf("posture set to %q for %d team(s)\n", result.Posture, len(result.Teams))
+			for _, r := range result.Roles {
+				if r.Spawn > 0 {
+					fmt.Printf("  %s role/%s: spawning %d (%d/%d)\n", r.Team, r.Role, r.Spawn, r.Actual, r.Desired)
+				} else {
+					fmt.Printf("  %s role/%s: %s (%d/%d)\n", r.Team, r.Role, r.Action, r.Actual, r.Desired)
+				}
+			}
+			return nil
+		},
+	}
 	return cmd
 }
 

--- a/internal/api/posture_test.go
+++ b/internal/api/posture_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPostureNormalizesZeroValueToHold pins the safety asymmetry: only an
+// explicit PostureConverge reads as converge; the zero value and any other
+// string normalize to PostureHold, so an absent or garbled field can never
+// authorize a cold spawn (aae-orc-cxdf / rwiw).
+func TestPostureNormalizesZeroValueToHold(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		field ConvergencePosture
+		want  ConvergencePosture
+	}{
+		{"zero value (pre-field record)", "", PostureHold},
+		{"explicit hold", PostureHold, PostureHold},
+		{"explicit converge", PostureConverge, PostureConverge},
+		{"garbled value", ConvergencePosture("nonsense"), PostureHold},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tm := Team{ConvergencePosture: tc.field}
+			if got := tm.Posture(); got != tc.want {
+				t.Errorf("Posture() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPostureSurvivesBoltRoundTrip proves the posture is persisted with the
+// team and rehydrates unchanged — the "posture state persists per team"
+// requirement. A team written with PostureConverge reads back PostureConverge
+// from a fresh store over the same bolt file.
+func TestPostureSurvivesBoltRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "marvel.bolt")
+
+	store1 := NewStore()
+	if err := store1.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #1: %v", err)
+	}
+	if err := store1.CreateWorkspace(&Workspace{Name: "ws", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := store1.CreateTeam(&Team{
+		Name:               "crew",
+		Workspace:          "ws",
+		Roles:              []Role{{Name: "crew", Replicas: 3, Runtime: Runtime{Command: "sleep"}}},
+		ConvergencePosture: PostureConverge,
+		CreatedAt:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	if err := store1.CloseBolt(); err != nil {
+		t.Fatalf("CloseBolt: %v", err)
+	}
+
+	store2 := NewStore()
+	if err := store2.OpenBolt(path); err != nil {
+		t.Fatalf("OpenBolt #2: %v", err)
+	}
+	t.Cleanup(func() { _ = store2.CloseBolt() })
+
+	got, err := store2.GetTeam("ws/crew")
+	if err != nil {
+		t.Fatalf("get team after reopen: %v", err)
+	}
+	if got.Posture() != PostureConverge {
+		t.Errorf("posture after reopen = %q, want %q", got.Posture(), PostureConverge)
+	}
+}
+
+// TestCloneTeamCopiesPosture guards that a store snapshot carries the posture
+// and that mutating the snapshot does not reach back into store state.
+func TestCloneTeamCopiesPosture(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	if err := s.CreateWorkspace(&Workspace{Name: "ws", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := s.CreateTeam(&Team{
+		Name:               "crew",
+		Workspace:          "ws",
+		Roles:              []Role{{Name: "crew", Replicas: 1, Runtime: Runtime{Command: "sleep"}}},
+		ConvergencePosture: PostureConverge,
+		CreatedAt:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	snap, err := s.GetTeam("ws/crew")
+	if err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	if snap.Posture() != PostureConverge {
+		t.Fatalf("snapshot posture = %q, want converge", snap.Posture())
+	}
+	snap.ConvergencePosture = PostureHold
+
+	live, err := s.GetTeam("ws/crew")
+	if err != nil {
+		t.Fatalf("get team again: %v", err)
+	}
+	if live.Posture() != PostureConverge {
+		t.Errorf("mutating a snapshot changed store posture: %q", live.Posture())
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -356,7 +356,52 @@ type Team struct {
 	// Admission is the standing admission condition the reconciler
 	// recomputes each tick. Status, not spec — same treatment as Shift.
 	Admission AdmissionState `toml:"-"`
-	CreatedAt time.Time
+	// ConvergencePosture is the team's runtime stance on COLD convergence
+	// toward desired. Status, not spec (toml:"-", same as Shift/Admission):
+	// an operator never declares it in a manifest; the daemon sets it at start
+	// from what adoption found, and `marvel converge` flips it. Read it through
+	// Posture(), which normalizes the zero value to the safe default.
+	// See question-convergence-posture, aae-orc-rwiw / cxdf.
+	ConvergencePosture ConvergencePosture `toml:"-"`
+	CreatedAt          time.Time
+}
+
+// ConvergencePosture is a team's runtime stance on cold convergence toward its
+// desired replica count (question-convergence-posture, aae-orc-rwiw). It is
+// status, not spec: an operator never declares it in a manifest, the daemon
+// sets it at start from what adoption found, and `marvel converge` flips it. It
+// is JSON-persisted with the rest of the Team so `describe` can report it, but
+// the daemon re-derives it from live presence on every start (see
+// team.Controller.InitConvergencePosture), so a persisted value never
+// authorizes a cold spawn on its own — the money-safety guarantee for
+// aae-orc-cxdf, where a daemon start rehydrated stale desired state and spawned
+// a fleet nobody asked for.
+type ConvergencePosture string
+
+const (
+	// PostureHold withholds COLD convergence: a team with no live presence
+	// does not spawn toward desired until an explicit converge. This is the
+	// default — "hold at the start line" — and the zero value ("") normalizes
+	// to it via Team.Posture, so a team record written before this field
+	// existed reads as held.
+	PostureHold ConvergencePosture = "hold"
+	// PostureConverge spawns toward desired: the operator's go-line, and the
+	// stance a team with surviving panes is given at start so its steady-state
+	// maintenance (crash-loop restarts, replica top-ups) is never suppressed.
+	PostureConverge ConvergencePosture = "converge"
+)
+
+// Posture returns the team's convergence posture, normalizing the zero value
+// (an unset field — a team record written before the field existed, or one the
+// daemon has not yet initialized) to the safe default PostureHold. Only an
+// explicit PostureConverge reads as converge; anything else holds. This
+// asymmetry is deliberate: a garbled or absent value must never authorize a
+// cold spawn.
+func (t *Team) Posture() ConvergencePosture {
+	if t.ConvergencePosture == PostureConverge {
+		return PostureConverge
+	}
+	return PostureHold
 }
 
 // Endpoint is a stable name for a session role (service equivalent).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -390,6 +390,19 @@ func (d *Daemon) Start(socketPath string) error {
 		log.Printf("%s on startup: %v", what, err)
 	}
 
+	// Decide the convergence posture from what adoption actually reclaimed,
+	// then hold anything cold at the start line. RefreshLiveness reaps records
+	// whose panes did not survive (a host reboot leaves stale Running rows), so
+	// InitConvergencePosture reads true live presence: a team with surviving
+	// panes converges (its fleet is running — maintain it), a team with none
+	// holds until `marvel converge`. This runs BEFORE the reconcile loop so a
+	// stale bolt can never cold-spawn a fleet on start. See aae-orc-cxdf/rwiw.
+	d.teamCtrl.RefreshLiveness()
+	if perr := d.teamCtrl.InitConvergencePosture(); perr != nil {
+		log.Printf("init convergence posture: %v", perr)
+	}
+	d.logConvergencePosture()
+
 	// Announced from Start, not from the constructor. cmd/marvel installs
 	// log.SetOutput (log ring plus the optional --log-file) only after
 	// NewWithOptions returns, so a line written during construction reaches
@@ -671,6 +684,8 @@ func (d *Daemon) dispatch(req Request) Response {
 		return d.handleDelete(req.Params)
 	case "scale":
 		return d.handleScale(req.Params)
+	case "converge":
+		return d.handleConverge(req.Params)
 	case "reap":
 		return d.handleReap(req.Params)
 	case "heartbeat":
@@ -828,6 +843,21 @@ func (d *Daemon) handleApply(params json.RawMessage) Response {
 
 	if err := m.Apply(d.store); err != nil {
 		return Response{Error: fmt.Sprintf("apply manifest: %v", err)}
+	}
+
+	// Apply is an explicit "make it so": the operator named these teams and
+	// their replica counts, so they converge. This is distinct from a daemon
+	// start rehydrating stale desired state (aae-orc-cxdf), which holds at the
+	// start line. Setting the posture here — not relying on the store default —
+	// keeps apply's spawn-on-apply behavior while the start path stays held.
+	for _, mt := range m.Teams {
+		teamKey := m.Workspace.Name + "/" + mt.Name
+		if err := d.store.UpdateTeam(teamKey, func(live *api.Team) error {
+			live.ConvergencePosture = api.PostureConverge
+			return nil
+		}); err != nil {
+			log.Printf("apply: set convergence posture for %s: %v", teamKey, err)
+		}
 	}
 
 	// Re-project policies for already-running sessions before reconciling.
@@ -1078,6 +1108,106 @@ func (d *Daemon) handleScale(params json.RawMessage) Response {
 		"replicas": p.Replicas,
 	})
 	return Response{Result: result}
+}
+
+// convergeParams selects which team(s) to move and which way. An empty TeamKey
+// targets every team (the daemon-wide go-line). Hold flips the posture the
+// other way — back to the start line — for a future majordomo or an operator
+// re-arming a team; the CLI exposes only the converge direction.
+type convergeParams struct {
+	TeamKey string `json:"team_key,omitempty"`
+	Hold    bool   `json:"hold,omitempty"`
+}
+
+// convergeRoleReport is one role's line in the converge result: what the
+// reconcile the daemon is about to drive will do for it.
+type convergeRoleReport struct {
+	Team    string `json:"team"`
+	Role    string `json:"role"`
+	Action  string `json:"action"`
+	Spawn   int    `json:"spawn,omitempty"`
+	Desired int    `json:"desired"`
+	Actual  int    `json:"actual"`
+}
+
+type convergeResult struct {
+	Posture string               `json:"posture"`
+	Teams   []string             `json:"teams"`
+	Roles   []convergeRoleReport `json:"roles"`
+}
+
+// handleConverge sets the convergence posture (the aae-orc-rwiw go-line) and
+// then reconciles once so the change takes effect immediately. The posture flip
+// lives in the team controller (SetConvergencePosture), not here, so the same
+// control-plane lever is available to a future in-process majordomo; the CLI
+// `marvel converge` is one client of this RPC.
+func (d *Daemon) handleConverge(params json.RawMessage) Response {
+	var p convergeParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return Response{Error: fmt.Sprintf("bad params: %v", err)}
+		}
+	}
+
+	posture := api.PostureConverge
+	if p.Hold {
+		posture = api.PostureHold
+	}
+
+	plans, err := d.teamCtrl.SetConvergencePosture(p.TeamKey, posture)
+	if err != nil {
+		return Response{Error: err.Error()}
+	}
+
+	// Enact the new posture. On a converge this spawns toward desired; on a
+	// hold it changes nothing this tick (the gate withholds cold spawns) but is
+	// recorded for the next reconcile and for `describe`.
+	d.teamCtrl.ReconcileOnce()
+
+	res := convergeResult{Posture: string(posture)}
+	seen := make(map[string]struct{})
+	for _, pl := range plans {
+		key := pl.Workspace + "/" + pl.Team
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			res.Teams = append(res.Teams, key)
+		}
+		res.Roles = append(res.Roles, convergeRoleReport{
+			Team:    key,
+			Role:    pl.Role,
+			Action:  string(pl.Action),
+			Spawn:   pl.Spawn,
+			Desired: pl.Desired,
+			Actual:  pl.Actual,
+		})
+	}
+
+	out, _ := json.Marshal(res)
+	return Response{Result: out}
+}
+
+// logConvergencePosture writes a one-line-per-team start summary of which teams
+// are held at the start line with cold work waiting, so an operator reading the
+// daemon log after start knows a `marvel converge` is available and what it
+// would spawn. Silent when nothing is held. Called once from Start after the
+// posture is initialized.
+func (d *Daemon) logConvergencePosture() {
+	plans := d.teamCtrl.PlanConvergence()
+	held := make(map[string]int) // team key -> sessions a converge would spawn
+	for _, pl := range plans {
+		if pl.Action != team.RoleSpawn {
+			continue
+		}
+		t, err := d.store.GetTeam(pl.Workspace + "/" + pl.Team)
+		if err != nil || t.Posture() != api.PostureHold {
+			continue
+		}
+		held[t.Key()] += pl.Spawn
+	}
+	for key, n := range held {
+		log.Printf("convergence: team %s held at the start line; `marvel converge %s` would spawn %d session(s)",
+			key, key, n)
+	}
 }
 
 // heartbeatParams is an alias, not a copy: producers build the same type

--- a/internal/daemon/posture_test.go
+++ b/internal/daemon/posture_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// createColdHeldTeam seeds a workspace + a cold team holding at the start line
+// (no sessions, posture=hold), the shape a stale bolt rehydrates into.
+func createColdHeldTeam(t *testing.T, d *Daemon, ws, team, role string, replicas int) {
+	t.Helper()
+	if _, err := d.store.GetWorkspace(ws); err != nil {
+		if werr := d.store.CreateWorkspace(&api.Workspace{Name: ws, CreatedAt: time.Now().UTC()}); werr != nil {
+			t.Fatalf("create workspace: %v", werr)
+		}
+	}
+	if err := d.store.CreateTeam(&api.Team{
+		Name:               team,
+		Workspace:          ws,
+		Roles:              []api.Role{{Name: role, Replicas: replicas, Runtime: api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}}}},
+		Generation:         1,
+		ConvergencePosture: api.PostureHold,
+		CreatedAt:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+}
+
+// TestApplyGivesTeamConvergePosture proves apply is an explicit "make it so":
+// the applied team gets the converge posture and spawns, so the aae-orc-cxdf
+// start-hold default never turns apply into a no-op.
+func TestApplyGivesTeamConvergePosture(t *testing.T) {
+	d := newHandlerDaemon(t)
+	if resp := applyManifest(t, d, budgetedManifest); resp.Error != "" {
+		t.Fatalf("apply: %s", resp.Error)
+	}
+	tm, err := d.store.GetTeam("fanout/crew")
+	if err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	if tm.Posture() != api.PostureConverge {
+		t.Errorf("applied team posture = %q, want converge", tm.Posture())
+	}
+	if n := api.CountAlive(d.store.ListSessionsByTeam("fanout", "crew")); n != 3 {
+		t.Errorf("applied team alive sessions = %d, want 3 (apply converges)", n)
+	}
+}
+
+// TestConvergeRPCSpawnsHeldTeam is the go-line end-to-end at the control plane:
+// a cold held team spawns nothing until the converge RPC flips its posture, at
+// which point the reconcile the handler drives brings it to strength. This is
+// the aae-orc-cxdf fix plus its lever, exercised through the daemon dispatch a
+// future majordomo will also use.
+func TestConvergeRPCSpawnsHeldTeam(t *testing.T) {
+	d := newHandlerDaemon(t)
+	createColdHeldTeam(t, d, "ws", "crew", "worker", 3)
+
+	// Held: a reconcile spawns nothing.
+	d.teamCtrl.ReconcileOnce()
+	if n := len(d.store.ListSessionsByTeamRole("ws", "crew", "worker")); n != 0 {
+		t.Fatalf("held team spawned %d session(s) before converge, want 0", n)
+	}
+
+	params, _ := json.Marshal(convergeParams{TeamKey: "ws/crew"})
+	resp := d.dispatch(Request{Method: "converge", Params: params})
+	if resp.Error != "" {
+		t.Fatalf("converge: %s", resp.Error)
+	}
+
+	var res convergeResult
+	if err := json.Unmarshal(resp.Result, &res); err != nil {
+		t.Fatalf("unmarshal converge result: %v", err)
+	}
+	if res.Posture != string(api.PostureConverge) {
+		t.Errorf("result posture = %q, want converge", res.Posture)
+	}
+	if len(res.Teams) != 1 || res.Teams[0] != "ws/crew" {
+		t.Errorf("result teams = %v, want [ws/crew]", res.Teams)
+	}
+	if len(res.Roles) != 1 || res.Roles[0].Spawn != 3 {
+		t.Errorf("result roles = %+v, want one role spawning 3", res.Roles)
+	}
+
+	if tm, _ := d.store.GetTeam("ws/crew"); tm.Posture() != api.PostureConverge {
+		t.Errorf("team posture after converge = %q, want converge", tm.Posture())
+	}
+	if n := api.CountAlive(d.store.ListSessionsByTeamRole("ws", "crew", "worker")); n != 3 {
+		t.Errorf("converged team alive sessions = %d, want 3", n)
+	}
+}
+
+// TestConvergeRPCEmptyKeyTargetsAllTeams proves the daemon-wide go-line: an
+// empty team key converges every held team at once.
+func TestConvergeRPCEmptyKeyTargetsAllTeams(t *testing.T) {
+	d := newHandlerDaemon(t)
+	createColdHeldTeam(t, d, "ws", "a", "worker", 1)
+	createColdHeldTeam(t, d, "ws", "b", "worker", 2)
+
+	resp := d.dispatch(Request{Method: "converge"})
+	if resp.Error != "" {
+		t.Fatalf("converge all: %s", resp.Error)
+	}
+	for _, key := range []string{"ws/a", "ws/b"} {
+		if tm, _ := d.store.GetTeam(key); tm.Posture() != api.PostureConverge {
+			t.Errorf("%s posture = %q, want converge", key, tm.Posture())
+		}
+	}
+	if n := api.CountAlive(d.store.ListSessionsByTeam("ws", "a")); n != 1 {
+		t.Errorf("team a alive = %d, want 1", n)
+	}
+	if n := api.CountAlive(d.store.ListSessionsByTeam("ws", "b")); n != 2 {
+		t.Errorf("team b alive = %d, want 2", n)
+	}
+}

--- a/internal/team/admission_test.go
+++ b/internal/team/admission_test.go
@@ -34,7 +34,10 @@ func createBudgetTeamFixture(t *testing.T, store *api.Store, wsName, teamName st
 		Roles:      roles,
 		Budget:     budget,
 		Generation: 1,
-		CreatedAt:  time.Now().UTC(),
+		// Represents a team meant to run (see createTeamFixture); the hold
+		// posture is set explicitly by the tests that exercise it.
+		ConvergencePosture: api.PostureConverge,
+		CreatedAt:          time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -405,17 +405,132 @@ func (c *Controller) ReconcileOnce() {
 	//
 	// The charge is per role per tick, not per lost replica: see
 	// noteReapedCrash.
-	charged := make(map[string]*reapCharge)
-	for _, r := range c.sessMgr.ReapDead() {
-		c.noteReapedCrash(r, charged)
-	}
-	c.emitReapAccounting(charged)
+	c.reapDeadLocked()
 	c.evaluateHealth()
 
 	teams := c.store.ListTeams()
 	for i := range teams {
 		c.reconcileTeam(&teams[i])
 	}
+}
+
+// reapDeadLocked reaps sessions whose panes have vanished, charging each role's
+// crash accounting once per tick and emitting it. It is the pane-liveness
+// prefix shared by ReconcileOnce and RefreshLiveness — factored out so the
+// daemon can establish a truthful live-session count at start without also
+// running a spawning reconcile. Caller holds c.mu.
+func (c *Controller) reapDeadLocked() {
+	charged := make(map[string]*reapCharge)
+	for _, r := range c.sessMgr.ReapDead() {
+		c.noteReapedCrash(r, charged)
+	}
+	c.emitReapAccounting(charged)
+}
+
+// RefreshLiveness reaps sessions whose panes have vanished so the store's
+// alive-count reflects the panes that actually survived, WITHOUT reconciling
+// desired state (no spawns). The daemon calls it at start after adoption and
+// before InitConvergencePosture: a team whose panes did not survive (a host
+// reboot leaves stale Running records with dead panes) must be counted as the
+// cold team it is, not read as alive and given the converge posture. Takes
+// c.mu; must not be called by a caller already holding it.
+func (c *Controller) RefreshLiveness() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reapDeadLocked()
+}
+
+// InitConvergencePosture sets each team's convergence posture from the ground
+// truth left by adoption (and RefreshLiveness's reap): a team with any live
+// session is PostureConverge — a daemon restarted under an operator, its fleet
+// still running, is maintained, crash-loop restarts and top-ups included; a
+// team with none is PostureHold — a fresh or stale start holds at the start
+// line and waits for `marvel converge`.
+//
+// This is the money-safety guarantee for aae-orc-cxdf. It OVERRIDES whatever
+// posture the store rehydrated, so a stale bolt that persisted PostureConverge
+// cannot cold-spawn a fleet nobody asked for: only surviving panes yield
+// converge. It answers the ticket's central question (a daemon restarted under
+// an operator vs one started fresh) with a fact the daemon can observe — the
+// panes — rather than a guess.
+//
+// Called once from daemon Start after adoption + RefreshLiveness, before the
+// reconcile loop. tu2e (resume-on-power) will let an operator opt a team out of
+// the hold default. Takes c.mu; must not be called by a caller already holding
+// it.
+func (c *Controller) InitConvergencePosture() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, t := range c.store.ListTeams() {
+		want := api.PostureHold
+		if api.CountAlive(c.store.ListSessionsByTeam(t.Workspace, t.Name)) > 0 {
+			want = api.PostureConverge
+		}
+		if t.Posture() == want {
+			continue // already correct (incl. a pre-field "" record that reads hold)
+		}
+		key := t.Key()
+		if err := c.store.UpdateTeam(key, func(live *api.Team) error {
+			live.ConvergencePosture = want
+			return nil
+		}); err != nil {
+			return fmt.Errorf("init convergence posture for %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// SetConvergencePosture sets the convergence posture for one team, or for every
+// team when teamKey is empty, persisting it, and returns the steady-state plans
+// the posture now permits so a caller can report what a converge will do. It
+// does NOT reconcile — the caller drives that (the converge RPC reconciles
+// immediately; a future majordomo may batch). This is the control-plane lever
+// behind `marvel converge`; the CLI is one client of it, so the same lever is
+// available to an in-process assessor. Takes c.mu; must not be called by a
+// caller already holding it.
+func (c *Controller) SetConvergencePosture(teamKey string, posture api.ConvergencePosture) ([]RolePlan, error) {
+	if posture != api.PostureConverge && posture != api.PostureHold {
+		return nil, fmt.Errorf("unknown convergence posture %q", posture)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var targets []api.Team
+	if teamKey == "" {
+		targets = c.store.ListTeams()
+	} else {
+		t, err := c.store.GetTeam(teamKey)
+		if err != nil {
+			return nil, err
+		}
+		targets = []api.Team{t}
+	}
+
+	var plans []RolePlan
+	for i := range targets {
+		key := targets[i].Key()
+		if err := c.store.UpdateTeam(key, func(live *api.Team) error {
+			live.ConvergencePosture = posture
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("set convergence posture for %s: %w", key, err)
+		}
+		// Report the plan against fresh state so the caller can tell the
+		// operator what the reconcile it is about to drive will spawn. A team
+		// mid-shift is deferred to the shift path, so skip it here as
+		// PlanConvergence does.
+		t, err := c.store.GetTeam(key)
+		if err != nil {
+			return nil, err
+		}
+		if t.Shift.Phase != api.ShiftNone {
+			continue
+		}
+		for j := range t.Roles {
+			plans = append(plans, c.planRole(&t, &t.Roles[j], t.Generation))
+		}
+	}
+	return plans, nil
 }
 
 // noteReapedCrash attributes a reaped session to its role and records a
@@ -661,12 +776,40 @@ func (c *Controller) reconcileOrphanedSessions(t *api.Team) {
 	}
 }
 
-// reconcileRole repairs a role at the team's current generation. Outside a
-// shift that is the only generation in play; reconcileShift calls
-// reconcileRoleAt instead, because mid-shift the team generation is
-// aspirational.
+// reconcileRole repairs a role at the team's current generation, subject to the
+// team's convergence posture. Outside a shift this is the only generation in
+// play; reconcileShift calls reconcileRoleAt directly, so the posture gate here
+// governs steady-state convergence only and never interferes with a rotation
+// (a shifting team is alive by definition, so it would not be withheld anyway).
+//
+// The gate is the fix for aae-orc-cxdf: a team that holds at the start line
+// with no live presence does NOT spawn toward desired — the cold, from-nothing
+// convergence that spent real tokens against a stale bolt. Every other outcome
+// proceeds untouched: steady state, scale-down, a crash-loop hold, an admission
+// hold, and — the load-bearing exception (question-convergence-posture) — a
+// spawn for a team that has live replicas, so steady-state maintenance and the
+// crash-loop restart of a still-alive fleet are never suppressed. `marvel
+// converge` flips the posture and lets the cold spawn proceed.
 func (c *Controller) reconcileRole(t *api.Team, role *api.Role) {
-	c.reconcileRoleAt(t, role, t.Generation)
+	plan := c.planRole(t, role, t.Generation)
+	if plan.Action == RoleSpawn && c.postureWithholds(t) {
+		return
+	}
+	c.applyRolePlan(t, role, plan)
+}
+
+// postureWithholds reports whether the team's convergence posture withholds a
+// COLD spawn this tick: the team holds at the start line AND has no live
+// session anywhere in it. The zero-live check is what keeps hold from ever
+// suppressing steady-state maintenance — a team with even one live replica is
+// being maintained, not cold-started, so its top-ups and crash-loop restarts
+// proceed regardless of posture. A team the operator converged is PostureConverge
+// and is never withheld. Caller holds c.mu.
+func (c *Controller) postureWithholds(t *api.Team) bool {
+	if t.Posture() != api.PostureHold {
+		return false
+	}
+	return api.CountAlive(c.store.ListSessionsByTeam(t.Workspace, t.Name)) == 0
 }
 
 // shiftRepairGeneration returns the generation a mid-shift repair of role

--- a/internal/team/controller_test.go
+++ b/internal/team/controller_test.go
@@ -51,7 +51,13 @@ func createTeamFixture(t *testing.T, store *api.Store, wsName, teamName string, 
 		Workspace:  wsName,
 		Roles:      roles,
 		Generation: 1,
-		CreatedAt:  time.Now().UTC(),
+		// A fixture that expects the reconciler to converge represents a team
+		// meant to run — an applied or explicitly-converged team, not one held
+		// at the start line. The daemon's own start path decides posture from
+		// adoption (InitConvergencePosture); tests that exercise the hold
+		// posture set it explicitly. See question-convergence-posture.
+		ConvergencePosture: api.PostureConverge,
+		CreatedAt:          time.Now().UTC(),
 	}
 	if err := store.CreateTeam(team); err != nil {
 		t.Fatal(err)

--- a/internal/team/posture_test.go
+++ b/internal/team/posture_test.go
@@ -1,0 +1,309 @@
+package team
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// createPostureTeam creates a team (in the shared planTestWS workspace) with an
+// explicit convergence posture. The shared createTeamFixture bakes in
+// PostureConverge (it represents a team meant to run); the posture tests need to
+// set hold explicitly. The workspace matches addAliveSessions so the two
+// compose.
+func createPostureTeam(t *testing.T, store *api.Store, team string, posture api.ConvergencePosture, roles []api.Role) {
+	t.Helper()
+	if _, err := store.GetWorkspace(planTestWS); err != nil {
+		if werr := store.CreateWorkspace(&api.Workspace{Name: planTestWS, CreatedAt: time.Now().UTC()}); werr != nil {
+			t.Fatalf("create workspace: %v", werr)
+		}
+	}
+	if err := store.CreateTeam(&api.Team{
+		Name:               team,
+		Workspace:          planTestWS,
+		Roles:              roles,
+		Generation:         1,
+		ConvergencePosture: posture,
+		CreatedAt:          time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+}
+
+// TestPostureWithholds is the gate decision table: posture × live-presence →
+// whether a cold spawn is withheld. This is the load-bearing semantic of
+// question-convergence-posture — hold withholds ONLY a team with no live
+// presence, so a converged team and a held-but-alive team are both maintained.
+func TestPostureWithholds(t *testing.T) {
+	t.Parallel()
+	const ws, team, role = "ws", "crew", "worker"
+	tests := []struct {
+		name    string
+		posture api.ConvergencePosture
+		alive   int
+		want    bool
+	}{
+		{"hold + cold => withheld (the cxdf money-spender)", api.PostureHold, 0, true},
+		{"hold + one live replica => maintained", api.PostureHold, 1, false},
+		{"hold + full strength => maintained", api.PostureHold, 3, false},
+		{"converge + cold => spawns (the go-line)", api.PostureConverge, 0, false},
+		{"converge + live => maintained", api.PostureConverge, 2, false},
+		{"unset posture + cold => withheld (safe default)", "", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := api.NewStore()
+			ctrl := NewController(store, nil)
+			createPostureTeam(t, store, team, tc.posture, []api.Role{sleepRole(role, 3)})
+			addAliveSessions(t, store, team, role, tc.alive)
+			tm, err := store.GetTeam(ws + "/" + team)
+			if err != nil {
+				t.Fatalf("get team: %v", err)
+			}
+			ctrl.mu.Lock()
+			got := ctrl.postureWithholds(&tm)
+			ctrl.mu.Unlock()
+			if got != tc.want {
+				t.Errorf("postureWithholds = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReconcileRoleWithholdsColdHeldTeam is the direct re-arm guard: a cold team
+// holding at the start line must spawn NOTHING. The session manager is nil, so
+// any spawn attempt panics rather than passing silently — if a future change
+// drops the gate, this test fails loudly. This is the aae-orc-cxdf fix asserted
+// at the reconcile boundary.
+func TestReconcileRoleWithholdsColdHeldTeam(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+
+	const ws, team, role = "ws", "crew", "worker"
+	createPostureTeam(t, store, team, api.PostureHold, []api.Role{sleepRole(role, 3)})
+
+	tm, err := store.GetTeam(ws + "/" + team)
+	if err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	ctrl.mu.Lock()
+	ctrl.reconcileRole(&tm, &tm.Roles[0]) // must not reach the nil session manager
+	ctrl.mu.Unlock()
+
+	if n := len(store.ListSessionsByTeamRole(ws, team, role)); n != 0 {
+		t.Fatalf("cold held team spawned %d session(s), want 0", n)
+	}
+}
+
+// TestInitConvergencePostureFromLivePresence proves posture is decided by live
+// presence at start and OVERRIDES whatever the store rehydrated — the
+// money-safety guarantee for aae-orc-cxdf. A team with live sessions converges;
+// a cold team holds; a cold team that PERSISTED converge (a torn-down fleet
+// whose bolt kept the posture) is forced back to hold so it cannot cold-spawn.
+func TestInitConvergencePostureFromLivePresence(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+
+	// alive team: has a running session -> converge
+	createPostureTeam(t, store, "alive", api.PostureHold, []api.Role{sleepRole("w", 2)})
+	addAliveSessions(t, store, "alive", "w", 2)
+
+	// cold team: no sessions -> hold
+	createPostureTeam(t, store, "cold", api.PostureHold, []api.Role{sleepRole("w", 2)})
+
+	// stale team: persisted converge but no live sessions -> forced to hold
+	createPostureTeam(t, store, "stale", api.PostureConverge, []api.Role{sleepRole("w", 2)})
+
+	if err := ctrl.InitConvergencePosture(); err != nil {
+		t.Fatalf("InitConvergencePosture: %v", err)
+	}
+
+	cases := map[string]api.ConvergencePosture{
+		"ws/alive": api.PostureConverge,
+		"ws/cold":  api.PostureHold,
+		"ws/stale": api.PostureHold, // the money-safety override
+	}
+	for key, want := range cases {
+		tm, err := store.GetTeam(key)
+		if err != nil {
+			t.Fatalf("get %s: %v", key, err)
+		}
+		if got := tm.Posture(); got != want {
+			t.Errorf("%s posture = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestSetConvergencePostureFlipsAndReports proves the control-plane lever
+// persists the posture and reports the plan a converge would enact, without
+// spawning (SetConvergencePosture does not reconcile). An empty team key targets
+// every team.
+func TestSetConvergencePostureFlipsAndReports(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil)
+
+	createPostureTeam(t, store, "a", api.PostureHold, []api.Role{sleepRole("w", 3)})
+	createPostureTeam(t, store, "b", api.PostureHold, []api.Role{sleepRole("w", 1)})
+
+	// Converge one team by key.
+	plans, err := ctrl.SetConvergencePosture("ws/a", api.PostureConverge)
+	if err != nil {
+		t.Fatalf("SetConvergencePosture(ws/a): %v", err)
+	}
+	if tm, _ := store.GetTeam("ws/a"); tm.Posture() != api.PostureConverge {
+		t.Errorf("ws/a posture = %q, want converge", tm.Posture())
+	}
+	if len(plans) != 1 || plans[0].Action != RoleSpawn || plans[0].Spawn != 3 {
+		t.Errorf("plans = %+v, want one RoleSpawn of 3", plans)
+	}
+	// It did NOT spawn — SetConvergencePosture only sets the lever.
+	if n := len(store.ListSessionsByTeamRole("ws", "a", "w")); n != 0 {
+		t.Errorf("SetConvergencePosture spawned %d session(s), want 0", n)
+	}
+	// ws/b untouched.
+	if tm, _ := store.GetTeam("ws/b"); tm.Posture() != api.PostureHold {
+		t.Errorf("ws/b posture = %q, want hold (untargeted)", tm.Posture())
+	}
+
+	// Empty key targets all teams.
+	if _, err := ctrl.SetConvergencePosture("", api.PostureConverge); err != nil {
+		t.Fatalf("SetConvergencePosture(all): %v", err)
+	}
+	if tm, _ := store.GetTeam("ws/b"); tm.Posture() != api.PostureConverge {
+		t.Errorf("ws/b posture = %q, want converge after all-teams converge", tm.Posture())
+	}
+
+	// An unknown posture is rejected.
+	if _, err := ctrl.SetConvergencePosture("ws/a", api.ConvergencePosture("bogus")); err == nil {
+		t.Error("SetConvergencePosture accepted a bogus posture, want error")
+	}
+}
+
+// TestReexecAutoResumeAdoptedTeamDoesNotSpawn is the detach+reexec
+// non-regression: a team whose panes survived comes back fully adopted (its
+// desired replicas are all present), the start path sets it to converge, and the
+// reconcile spawns NOTHING because adoption already satisfies desired. This is
+// the property the aae-orc-cxdf fix must never break — reexec still auto-resumes.
+func TestReexecAutoResumeAdoptedTeamDoesNotSpawn(t *testing.T) {
+	t.Parallel()
+	store := api.NewStore()
+	ctrl := NewController(store, nil) // steady state touches no session manager
+
+	const ws, team, role = "ws", "crew", "worker"
+	createPostureTeam(t, store, team, api.PostureHold, []api.Role{sleepRole(role, 3)})
+	addAliveSessions(t, store, team, role, 3) // adoption reclaimed all three panes
+
+	if err := ctrl.InitConvergencePosture(); err != nil {
+		t.Fatalf("InitConvergencePosture: %v", err)
+	}
+	if tm, _ := store.GetTeam(ws + "/" + team); tm.Posture() != api.PostureConverge {
+		t.Fatalf("adopted team posture = %q, want converge", tm.Posture())
+	}
+
+	tm, _ := store.GetTeam(ws + "/" + team)
+	ctrl.mu.Lock()
+	ctrl.reconcileRole(&tm, &tm.Roles[0])
+	ctrl.mu.Unlock()
+
+	if n := len(store.ListSessionsByTeamRole(ws, team, role)); n != 3 {
+		t.Fatalf("adopted team changed session count: got %d, want 3 (steady, no spawn)", n)
+	}
+}
+
+// TestReconcileRoleHoldMaintainsLiveTeam is the load-bearing exception: a team
+// that holds at the start line but still has a live replica is being maintained,
+// not cold-started, so hold must NOT suppress topping it back up to strength. A
+// team that later loses a replica still restarts it (question-convergence-posture).
+func TestReconcileRoleHoldMaintainsLiveTeam(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	const ws, team, role = "ws", "crew", "worker"
+	createPostureTeam(t, store, team, api.PostureHold, []api.Role{sleepRole(role, 2)})
+	addAliveSessions(t, store, team, role, 1) // one replica is alive
+
+	tm, err := store.GetTeam(ws + "/" + team)
+	if err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	ctrl.mu.Lock()
+	ctrl.reconcileRole(&tm, &tm.Roles[0])
+	ctrl.mu.Unlock()
+
+	if n := api.CountAlive(store.ListSessionsByTeamRole(ws, team, role)); n != 2 {
+		t.Fatalf("held team with a live replica was not topped up: alive=%d, want 2", n)
+	}
+}
+
+// TestReconcileConvergeSpawnsColdTeam is the go-line end-to-end: a cold team the
+// operator converges spawns toward desired. Together with
+// TestReconcileRoleWithholdsColdHeldTeam (hold spawns nothing) this pins both
+// sides of the lever.
+func TestReconcileConvergeSpawnsColdTeam(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	const ws, team, role = "ws", "crew", "worker"
+	createPostureTeam(t, store, team, api.PostureHold, []api.Role{sleepRole(role, 3)})
+
+	// Held: nothing spawns.
+	ctrl.ReconcileOnce()
+	if n := len(store.ListSessionsByTeamRole(ws, team, role)); n != 0 {
+		t.Fatalf("held cold team spawned %d session(s), want 0", n)
+	}
+
+	// The go-line.
+	if _, err := ctrl.SetConvergencePosture(ws+"/"+team, api.PostureConverge); err != nil {
+		t.Fatalf("SetConvergencePosture: %v", err)
+	}
+	ctrl.ReconcileOnce()
+	if n := len(store.ListSessionsByTeamRole(ws, team, role)); n != 3 {
+		t.Fatalf("converged team spawned %d session(s), want 3", n)
+	}
+}
+
+// TestRefreshLivenessReapsDeadPaneRecordsBeforePosture is the host-reboot
+// money-safety guard: a rehydrated session whose pane did NOT survive still
+// reads State=Running, so a naive live-count would call the team alive and give
+// it converge. RefreshLiveness reaps it first, so InitConvergencePosture sees
+// the cold team it is and holds. Without this ordering a rebooted host would
+// cold-spawn the fleet (aae-orc-cxdf) on the next start.
+func TestRefreshLivenessReapsDeadPaneRecordsBeforePosture(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	const ws, team, role = "ws", "crew", "worker"
+	createPostureTeam(t, store, team, api.PostureConverge, []api.Role{sleepRole(role, 1)})
+	// A rehydrated Running record whose pane is gone (a host reboot leaves
+	// exactly this): non-empty PaneID that no live tmux pane matches.
+	if err := store.CreateSession(&api.Session{
+		Name:       team + "-" + role + "-g1-0",
+		Workspace:  ws,
+		Team:       team,
+		Role:       role,
+		Generation: 1,
+		State:      api.SessionRunning,
+		PaneID:     "%999999",
+	}); err != nil {
+		t.Fatalf("seed dead-pane session: %v", err)
+	}
+
+	ctrl.RefreshLiveness()
+	if got := api.CountAlive(store.ListSessionsByTeam(ws, team)); got != 0 {
+		t.Fatalf("dead-pane record still counts as alive after reap: %d", got)
+	}
+	if err := ctrl.InitConvergencePosture(); err != nil {
+		t.Fatalf("InitConvergencePosture: %v", err)
+	}
+	if tm, _ := store.GetTeam(ws + "/" + team); tm.Posture() != api.PostureHold {
+		t.Fatalf("rebooted team posture = %q, want hold (its pane did not survive)", tm.Posture())
+	}
+}


### PR DESCRIPTION
## Why

Starting the daemon is not a read-only act today. Against a populated store it
rehydrates stale desired state and the reconciler spawns real agent processes
to reach it — spending model tokens against a live account from one unflagged
command. This was reproduced live (six roles, twenty sessions, three vendors,
in about three seconds) against a torn-down demo's leftover store. A stale
store is a standing instruction to spend money, and this PR removes that
instruction without deleting anyone's intent.

The fix is a configurable convergence posture. By default a daemon **holds at
the start line**: it comes up, adopts the panes that survived, and waits — it
does not spawn a fleet from nothing until an explicit go. The go-line is
`marvel converge`, a control-plane operation so a future supervisor can pull
the same lever the CLI does. A team whose panes are still running is maintained
exactly as before, so the safe recovery paths (detach, reexec, SIGTERM) still
auto-resume with no manual step.

## The discriminator

The only dangerous spawn is **cold convergence from zero**: a team with
`desired > 0` and no live presence. Every safe recovery leaves panes alive, so
adoption satisfies desired and nothing spawns. That lets the daemon tell
"restarted under an operator, wants its fleet back" (panes survived) from
"started fresh or stale, wants nothing" (no panes) — by the panes, a fact it
can observe, not a guess.

## What ships

- **`api.Team.ConvergencePosture`** (persisted). `Team.Posture()` normalizes
  the zero value to `hold`, so a record written before the field existed — and
  any garbled value — reads as held.
- **The gate** in `Controller.reconcileRole` (steady-state path only, never the
  shift path): a spawn is withheld iff posture is `hold` **and** the team has
  zero live sessions. The zero-live clause is load-bearing — a team with a live
  replica is being *maintained*, not cold-started, so top-ups and crash-loop
  restarts proceed regardless of posture, and a single-replica team that
  crashes to zero still restarts. `planRole` / `PlanConvergence` are left raw
  (posture-blind) so the read-only plan/dry-run seam is untouched.
- **Posture decided at start from ground truth**: `Start` now reaps records
  whose panes did not survive (a host reboot leaves stale `Running` rows), then
  sets each team's posture from live presence — any live session → converge,
  none → hold — **overriding** the rehydrated value. This is the money-safety
  guarantee: a persisted `converge` cannot cold-spawn, because only surviving
  panes yield converge.
- **The go-line as a control-plane op**: `SetConvergencePosture` on the
  controller, a `converge` daemon RPC, and a thin `marvel converge
  [workspace/team]` CLI (empty target = all teams). `apply` sets applied teams
  to `converge`, so spawn-on-apply is unchanged.

Builds on the plan/apply split (#220). Bolt is additive — no schema bump.

## Daemon-start behavior change (the composition risk)

`Start`, after adoption, now runs `RefreshLiveness` → `InitConvergencePosture`
→ a one-line-per-held-team log summary, before the reconcile loop. Net: a
fresh or stale start no longer cold-spawns a fleet; a reexec/detach with
surviving panes still auto-resumes via adoption. `dispatch` gains one additive
`converge` case.

## Tests

New, all under `-race`:
- reexec/detach auto-resume: a fully-adopted team reconciles to steady with no
  spawn.
- a nil-session-manager guard that a cold held team cannot silently re-arm the
  spender (any spawn attempt would panic).
- hold never suppresses maintenance of a live team (a held team with a live
  replica is topped up).
- host-reboot money-safety: a dead-pane `Running` record is reaped before
  posture-init, so the team reads cold and holds.
- the go-line end-to-end through the daemon dispatch, plus the all-teams
  variant and the persisted-converge-override case.

Full suite passes with `go test -race ./...`; `golangci-lint run ./...` clean;
`gofumpt` clean.

Design detail:
`_kos/findings/finding-034-convergence-posture-hold-at-start-line.md`.

Refs: aae-orc-rwiw, aae-orc-cxdf

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS