### PR TITLE
feat(usage): backend-redirection discriminator for the context-window resolver

### DIFF
--- a/internal/api/backend.go
+++ b/internal/api/backend.go
@@ -42,6 +42,19 @@ const (
 	BackendRedirected BackendRedirection = "redirected"
 )
 
+// String renders the verdict for logs and diagnostics, giving the zero
+// value a name rather than an empty string.
+func (b BackendRedirection) String() string {
+	switch b {
+	case BackendDefault:
+		return "default"
+	case BackendRedirected:
+		return "redirected"
+	default:
+		return "cannot-tell"
+	}
+}
+
 // backendFlagVars are the boolean backend switches Claude Code reads
 // (measured in the 2.1.226 binary, finding-016 axis 4). Any one set to a
 // truthy value redirects the session off the vendor default. This is a

--- a/internal/api/backend.go
+++ b/internal/api/backend.go
@@ -1,0 +1,107 @@
+package api
+
+import "strings"
+
+// BackendRedirection is the spawn-time verdict on whether a session reaches
+// the model vendor's direct API or has been pointed at some other backend.
+// It is the "redirection discriminator" of finding-031: the shipped
+// context-window table holds the vendor's DIRECT-API windows, so a table
+// value applies only to a session on the default backend. The same model id
+// through Bedrock, Vertex, or an arbitrary proxy can carry a different
+// window (finding-016 axis 4), and marvel cannot observe which backend
+// actually served a request — but it CAN observe, at spawn, whether the
+// backend-selecting environment departs from the vendor default.
+//
+// Three states, and only three are answerable: is this session on the
+// vendor default, has something redirected it, or did marvel never observe
+// its spawn environment? The last is not a fourth axis; it is the absence of
+// an observation, and it is the ZERO VALUE on purpose — an adopted pane, an
+// ad-hoc session that never ran the classifier, or a record predating this
+// field all read as "cannot tell", which the window resolver treats as
+// departure from default (finding-031 §4: the guard "may treat cannot tell
+// as departure"). Matching the codebase's pessimistic-provenance default
+// (usage.KeyConfidence.Soft, ContextSourceNone): an unobserved backend is
+// not vouched for.
+type BackendRedirection string
+
+const (
+	// BackendUnknown is the zero value: marvel did not classify this
+	// session's spawn environment. Rendered "cannot tell". The window
+	// resolver treats it as departure from the default backend, because a
+	// table value keyed on the vendor's direct-API window cannot be
+	// vouched for when the backend was never observed.
+	BackendUnknown BackendRedirection = ""
+	// BackendDefault means every backend-selecting variable was absent (or
+	// falsy) at spawn, so the session reaches the vendor's direct API and
+	// the shipped table's direct-API windows apply.
+	BackendDefault BackendRedirection = "default"
+	// BackendRedirected means at least one backend-selecting variable
+	// pointed the session off the vendor default — Bedrock, Vertex, a
+	// proxy base URL, and the rest of finding-016 axis 4. A table value
+	// keyed on the direct-API window does not apply.
+	BackendRedirected BackendRedirection = "redirected"
+)
+
+// backendFlagVars are the boolean backend switches Claude Code reads
+// (measured in the 2.1.226 binary, finding-016 axis 4). Any one set to a
+// truthy value redirects the session off the vendor default. This is a
+// third party's fact that silently breaks a window when wrong, so it lives
+// in Go where it is diff-reviewable and versioned with the binary — the
+// same placement rationale as canonicalPermissionModes (see manifest.go).
+var backendFlagVars = []string{
+	"CLAUDE_CODE_USE_BEDROCK",
+	"CLAUDE_CODE_USE_VERTEX",
+	"CLAUDE_CODE_USE_FOUNDRY",
+	"CLAUDE_CODE_USE_MANTLE",
+	"CLAUDE_CODE_USE_GATEWAY",
+	"CLAUDE_CODE_USE_ANTHROPIC_AWS",
+	"CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD",
+}
+
+// backendValueVars redirect by carrying any value at all: a custom base URL
+// points at a proxy, and a Bedrock service tier presupposes Bedrock. A
+// non-empty value is treated as departure — conservatively, since even the
+// vendor's own canonical URL written here signals non-default intent, and
+// the loud-absence-over-silent-wrong bias (finding-031) prefers a soft
+// verdict to a confident wrong window.
+var backendValueVars = []string{
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_BEDROCK_SERVICE_TIER",
+}
+
+// ClassifyBackendRedirection reads the backend-selecting environment through
+// lookup and returns whether the session is on the vendor default or has
+// been redirected. It NEVER returns BackendUnknown: running the classifier
+// always yields an answer, so "cannot tell" is reserved for the sessions
+// this function was never called on (the zero value).
+//
+// lookup resolves an environment variable name to its value ("" when
+// absent). Taking a lookup rather than calling os.Getenv keeps this pure
+// and lets the caller overlay the process environment with any per-session
+// overrides it constructed for the pane.
+func ClassifyBackendRedirection(lookup func(string) string) BackendRedirection {
+	for _, name := range backendFlagVars {
+		if backendFlagTruthy(lookup(name)) {
+			return BackendRedirected
+		}
+	}
+	for _, name := range backendValueVars {
+		if strings.TrimSpace(lookup(name)) != "" {
+			return BackendRedirected
+		}
+	}
+	return BackendDefault
+}
+
+// backendFlagTruthy reports whether a Claude Code boolean backend switch is
+// enabled. Unset, blank, and the explicit falsy spellings are off;
+// everything else (the usual "1"/"true", but also any other non-empty
+// value an operator might use) is on.
+func backendFlagTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/api/backend_test.go
+++ b/internal/api/backend_test.go
@@ -1,0 +1,115 @@
+package api
+
+import "testing"
+
+// lookupFrom builds a lookup over a fixed map, so a test states exactly the
+// environment it means and nothing leaks in from the process.
+func lookupFrom(env map[string]string) func(string) string {
+	return func(k string) string { return env[k] }
+}
+
+func TestClassifyBackendRedirection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		env  map[string]string
+		want BackendRedirection
+	}{
+		{
+			name: "empty environment is the vendor default",
+			env:  nil,
+			want: BackendDefault,
+		},
+		{
+			name: "a falsy flag is still the default",
+			env:  map[string]string{"CLAUDE_CODE_USE_BEDROCK": "0"},
+			want: BackendDefault,
+		},
+		{
+			name: "the empty string is not a redirect",
+			env:  map[string]string{"ANTHROPIC_BASE_URL": ""},
+			want: BackendDefault,
+		},
+		{
+			name: "whitespace-only value is not a redirect",
+			env:  map[string]string{"ANTHROPIC_BASE_URL": "   "},
+			want: BackendDefault,
+		},
+		{
+			name: "bedrock flag set to 1 redirects",
+			env:  map[string]string{"CLAUDE_CODE_USE_BEDROCK": "1"},
+			want: BackendRedirected,
+		},
+		{
+			name: "vertex flag set to true redirects",
+			env:  map[string]string{"CLAUDE_CODE_USE_VERTEX": "true"},
+			want: BackendRedirected,
+		},
+		{
+			name: "an off-spelled flag is not a redirect",
+			env:  map[string]string{"CLAUDE_CODE_USE_VERTEX": "off"},
+			want: BackendDefault,
+		},
+		{
+			name: "a proxy base URL redirects",
+			env:  map[string]string{"ANTHROPIC_BASE_URL": "https://proxy.internal/v1"},
+			want: BackendRedirected,
+		},
+		{
+			name: "a bedrock service tier redirects",
+			env:  map[string]string{"ANTHROPIC_BEDROCK_SERVICE_TIER": "flex"},
+			want: BackendRedirected,
+		},
+		{
+			name: "the gateway flag redirects",
+			env:  map[string]string{"CLAUDE_CODE_USE_GATEWAY": "yes"},
+			want: BackendRedirected,
+		},
+		{
+			name: "an unrelated variable does not redirect",
+			env:  map[string]string{"ANTHROPIC_MODEL": "claude-opus-4-8"},
+			want: BackendDefault,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyBackendRedirection(lookupFrom(c.env)); got != c.want {
+				t.Errorf("ClassifyBackendRedirection(%v) = %q, want %q", c.env, got, c.want)
+			}
+		})
+	}
+}
+
+// The classifier never invents the "cannot tell" verdict: that state is the
+// zero value, reserved for sessions the classifier was never run on.
+func TestClassifyNeverReturnsUnknown(t *testing.T) {
+	t.Parallel()
+	for _, env := range []map[string]string{
+		nil,
+		{"CLAUDE_CODE_USE_BEDROCK": "1"},
+		{"ANTHROPIC_BASE_URL": "https://x"},
+	} {
+		if got := ClassifyBackendRedirection(lookupFrom(env)); got == BackendUnknown {
+			t.Errorf("ClassifyBackendRedirection(%v) returned the zero value; it must decide default or redirected", env)
+		}
+	}
+}
+
+// Every backend-selecting variable finding-016 axis 4 names must trip the
+// classifier, so adding one to the list is what wires it in. A hand-copied
+// second list here would be the same omission the check is meant to catch,
+// so it drives off the package's own slices.
+func TestEveryBackendVariableRedirects(t *testing.T) {
+	t.Parallel()
+	for _, name := range backendFlagVars {
+		if got := ClassifyBackendRedirection(lookupFrom(map[string]string{name: "1"})); got != BackendRedirected {
+			t.Errorf("flag %q set truthy did not redirect: got %q", name, got)
+		}
+	}
+	for _, name := range backendValueVars {
+		if got := ClassifyBackendRedirection(lookupFrom(map[string]string{name: "set"})); got != BackendRedirected {
+			t.Errorf("value var %q set did not redirect: got %q", name, got)
+		}
+	}
+}

--- a/internal/api/heartbeat_graded_test.go
+++ b/internal/api/heartbeat_graded_test.go
@@ -45,6 +45,7 @@ type resolverCall struct {
 	args          []string
 	manifestLimit int
 	feedLimit     int
+	redirection   BackendRedirection
 }
 
 // ladderResolver is a fake standing in for usage.Resolver's feed/manifest
@@ -54,8 +55,8 @@ type resolverCall struct {
 // makes that contribution assertable in isolation; the daemon package
 // tests the real usage.Resolver end to end.
 func ladderResolver(rec *resolverCall) ContextLimitResolveFunc {
-	return func(harness, model string, args []string, manifestLimit, feedLimit int) (int, string) {
-		*rec = resolverCall{harness, model, args, manifestLimit, feedLimit}
+	return func(harness, model string, args []string, manifestLimit, feedLimit int, redirection BackendRedirection) (int, string) {
+		*rec = resolverCall{harness, model, args, manifestLimit, feedLimit, redirection}
 		// The real ladder: an operator's manifest override outranks a
 		// side-channel feed (limitLadder in internal/usage).
 		if manifestLimit > 0 {
@@ -330,5 +331,38 @@ func TestHeartbeatDerivedPercentIsNotClamped(t *testing.T) {
 	}
 	if got.ContextPercent != 120 {
 		t.Fatalf("ContextPercent = %.2f, want 120 (unclamped, over the operator's budget)", got.ContextPercent)
+	}
+}
+
+// The store must route the session's backend verdict to the injected
+// resolver, or the heartbeat path cannot refuse a redirected table window the
+// way the accountant path does (finding-031 / aae-orc-bv7m). MUST NOT MISS:
+// the verdict is read from the session record, not the wire.
+func TestHeartbeatRoutesBackendVerdictToResolver(t *testing.T) {
+	t.Parallel()
+	s := NewStore()
+	var rec resolverCall
+	s.SetContextLimitResolver(ladderResolver(&rec))
+
+	token := gradedSession(t, s, 0)
+	if err := s.UpdateSession(gradedSessionKey, func(live *Session) error {
+		live.BackendRedirection = BackendRedirected
+		return nil
+	}); err != nil {
+		t.Fatalf("set verdict: %v", err)
+	}
+
+	if _, err := s.UpdateSessionHeartbeat(HeartbeatRequest{
+		SessionKey:    gradedSessionKey,
+		SessionToken:  token,
+		ContextTokens: 120_000,
+		ContextWindow: 200_000,
+		Model:         "claude-opus-4-8",
+	}); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	if rec.redirection != BackendRedirected {
+		t.Errorf("resolver redirection = %q, want %q routed from the session record", rec.redirection, BackendRedirected)
 	}
 }

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -51,11 +51,14 @@ type Store struct {
 // stringified). A zero window means unresolved; the caller records absence
 // rather than a guess.
 //
-// The signature is deliberately usage-free — harness, model, args, two
-// ints — so internal/api need not import internal/usage (which imports
-// internal/api). The daemon adapts its usage.Resolver to this shape in
+// The signature is deliberately usage-free — harness, model, args, two ints,
+// and the session's backend verdict (an api type, not a usage one) — so
+// internal/api need not import internal/usage (which imports internal/api).
+// The verdict lets the heartbeat path refuse a redirected or unobserved table
+// window exactly as the accountant path does (finding-031 / aae-orc-bv7m).
+// The daemon adapts its usage.Resolver to this shape in
 // SetContextLimitResolver's call site.
-type ContextLimitResolveFunc func(harness, model string, args []string, manifestLimit, feedLimit int) (limit int, source string)
+type ContextLimitResolveFunc func(harness, model string, args []string, manifestLimit, feedLimit int, redirection BackendRedirection) (limit int, source string)
 
 // SetContextLimitResolver injects the ladder the heartbeat path consults.
 // Called once at daemon construction with a closure over the same
@@ -609,6 +612,7 @@ func (s *Store) UpdateSessionHeartbeat(r HeartbeatRequest) (HeartbeatAuth, error
 			limit, src := s.contextResolver(
 				sess.Runtime.Name, r.Model, sess.Runtime.Args,
 				sess.Runtime.ContextWindow, r.ContextWindow,
+				sess.BackendRedirection,
 			)
 			if limit > 0 {
 				reading.ContextLimit = limit

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -187,6 +187,21 @@ type Session struct {
 	// Empty means the record predates this field, which is the one case
 	// AuthenticateHeartbeat admits unbound. See its comment.
 	HeartbeatTokenHash string `toml:"-"`
+	// BackendRedirection is the spawn-time verdict on whether this session
+	// reaches the model vendor's direct API or has been redirected off it
+	// (Bedrock, Vertex, a proxy — finding-016 axis 4). The window resolver
+	// consumes it to grade a table hit: the shipped table holds direct-API
+	// windows, so a redirected session's table value does not apply. Set at
+	// Create by classifying the constructed spawn environment; the zero
+	// value (BackendUnknown, "cannot tell") is honest for a session marvel
+	// never spawned or a record predating this field. See finding-031 and
+	// usage.Request.Redirection.
+	//
+	// Status, not spec (toml:"-"), and it persists to bolt via json so an
+	// adopted session keeps the verdict observed at its spawn across a
+	// daemon restart — the pane still runs under the environment it was
+	// launched with.
+	BackendRedirection BackendRedirection `toml:"-"`
 	SessionMetrics     `toml:"-"`
 	SessionContext     `toml:"-"`
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -276,13 +276,14 @@ func NewWithOptions(opts Options) (*Daemon, error) {
 	resolver := usage.NewResolver(limits)
 	acct := usage.New(store, resolver, usage.WithEvents(evRing))
 	sessMgr.Usage = acct
-	store.SetContextLimitResolver(func(harness, model string, args []string, manifestLimit, feedLimit int) (int, string) {
+	store.SetContextLimitResolver(func(harness, model string, args []string, manifestLimit, feedLimit int, redirection api.BackendRedirection) (int, string) {
 		limit, src, _ := resolver.Resolve(usage.Request{
 			Harness:       harness,
 			StreamModel:   model,
 			RuntimeArgs:   args,
 			ManifestLimit: manifestLimit,
 			FeedLimit:     feedLimit,
+			Redirection:   redirection,
 		})
 		return limit, string(src)
 	})

--- a/internal/daemon/heartbeat_graded_test.go
+++ b/internal/daemon/heartbeat_graded_test.go
@@ -101,6 +101,39 @@ func TestGradedHeartbeatResolvesThroughTheRealLadder(t *testing.T) {
 		}
 	})
 
+	t.Run("a redirected session refuses the table window end to end", func(t *testing.T) {
+		// No manifest, no feed window on the wire: the only rung left is the
+		// shipped table, which holds the vendor's DIRECT-API window. The
+		// session's backend is redirected, so the real resolver withholds it
+		// (finding-031 / aae-orc-bv7m) and CTX% renders absent rather than a
+		// confident wrong number.
+		key, token := registerGradedSession(t, d, "agent-redirected", "claude", 0)
+		if err := d.store.UpdateSession(key, func(live *api.Session) error {
+			live.BackendRedirection = api.BackendRedirected
+			return nil
+		}); err != nil {
+			t.Fatalf("set verdict: %v", err)
+		}
+		req := api.HeartbeatRequest{
+			SessionKey:    key,
+			SessionToken:  token,
+			ContextTokens: 120_000,
+			Model:         "claude-opus-4-8", // a real DefaultTable key
+		}
+		raw, _ := json.Marshal(req)
+		if resp := d.handleHeartbeat(raw); resp.Error != "" {
+			t.Fatalf("handleHeartbeat: %q", resp.Error)
+		}
+		got, _ := d.store.GetSession(key)
+		if got.ContextLimit != 0 || got.ContextLimitSource != "" {
+			t.Fatalf("limit=%d source=%q, want the table window withheld under redirection",
+				got.ContextLimit, got.ContextLimitSource)
+		}
+		if got.ContextTokens != 120_000 {
+			t.Errorf("ContextTokens = %d, want 120000 recorded even with no denominator", got.ContextTokens)
+		}
+	})
+
 	t.Run("a windowless simulator beat stays a percentage-only reading", func(t *testing.T) {
 		key, token := registerGradedSession(t, d, "agent-sim", "simulator", 0)
 		// The simulator's exact shape: percentage, no model, no numerator,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -454,6 +454,14 @@ func (m *Manager) Create(sess *api.Session) error {
 
 	plan := m.planLaunch(sess)
 
+	// Classify the backend-selecting environment this session is launched
+	// into (finding-031 / aae-orc-b2d0p). The pane inherits marvel's process
+	// environment and layers the per-pane env map over it, so the effective
+	// value of a backend switch is the constructed override when present and
+	// os.Getenv otherwise. Recorded on the session so the window resolver can
+	// tell a direct-API window from a redirected one.
+	sess.BackendRedirection = api.ClassifyBackendRedirection(backendEnvLookup(plan.env))
+
 	// Log the exact command line we're about to exec so post-hoc
 	// debugging has the argv — operators otherwise had to guess what
 	// tmux new-window was actually running when a pane died quickly.
@@ -492,6 +500,7 @@ func (m *Manager) Create(sess *api.Session) error {
 		live.PaneID = paneID
 		live.PID = pid
 		live.State = api.SessionRunning
+		live.BackendRedirection = sess.BackendRedirection
 		return nil
 	}); err != nil {
 		return fmt.Errorf("update session %s post-create: %w", sess.Key(), err)
@@ -751,9 +760,10 @@ func (m *Manager) attachInstance(sess *api.Session, inst *runtime.TmuxInstance) 
 	// launch args on the first fold, not after a round trip.
 	if m.Usage != nil {
 		m.Usage.Bind(uc, usage.Bind{
-			Harness: sess.Runtime.Name,
-			Args:    sess.Runtime.Args,
-			Window:  sess.Runtime.ContextWindow,
+			Harness:     sess.Runtime.Name,
+			Args:        sess.Runtime.Args,
+			Window:      sess.Runtime.ContextWindow,
+			Redirection: sess.BackendRedirection,
 		})
 	}
 	go func() {
@@ -851,6 +861,21 @@ func (m *Manager) detachInstance(key string) {
 	defer cancel()
 	inst.Detach(ctx)
 	m.forgetUsage(key, drain)
+}
+
+// backendEnvLookup resolves an environment variable name against the
+// constructed spawn environment: a key the adapter placed in the pane's env
+// map wins, and everything else falls back to marvel's own process
+// environment, which the tmux pane inherits. That union is the environment
+// the harness actually launches into, so it is what the backend classifier
+// must read.
+func backendEnvLookup(env map[string]string) func(string) string {
+	return func(k string) string {
+		if v, ok := env[k]; ok {
+			return v
+		}
+		return os.Getenv(k)
+	}
 }
 
 // directPlan builds the command string directly — the pre-adapter path

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -952,3 +952,61 @@ func TestCreateMintsHeartbeatToken(t *testing.T) {
 		t.Errorf("%s = %q in the ad-hoc environment, want the minted token", api.HeartbeatTokenEnv, got)
 	}
 }
+
+// Create classifies the backend-selecting environment at spawn and records
+// the verdict on the session, both on the caller's pointer and in the store
+// (aae-orc-b2d0p). The window resolver reads it to tell a direct-API window
+// from a redirected one.
+func TestCreateRecordsBackendRedirection(t *testing.T) {
+	// No t.Parallel: t.Setenv mutates process-wide state.
+	skipIfNoTmux(t)
+
+	cases := []struct {
+		name   string
+		envKey string
+		envVal string
+		want   api.BackendRedirection
+	}{
+		{"no backend variable set is the vendor default", "", "", api.BackendDefault},
+		{"a bedrock switch is a redirect", "CLAUDE_CODE_USE_BEDROCK", "1", api.BackendRedirected},
+		{"a proxy base URL is a redirect", "ANTHROPIC_BASE_URL", "https://proxy.internal/v1", api.BackendRedirected},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.envKey != "" {
+				t.Setenv(c.envKey, c.envVal)
+			}
+			store := api.NewStore()
+			driver, err := tmux.NewDriver()
+			if err != nil {
+				t.Fatalf("new driver: %v", err)
+			}
+			mgr := NewManager(store, driver)
+			mgr.SocketPath = t.TempDir() + "/marvel.sock"
+
+			ws := "test-sess-backend"
+			t.Cleanup(func() { _ = mgr.CleanupWorkspace(ws) })
+
+			sess := &api.Session{
+				Name:      "agent-0",
+				Workspace: ws,
+				Team:      "agents",
+				Role:      "worker",
+				Runtime:   api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			}
+			if err := mgr.Create(sess); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+			if sess.BackendRedirection != c.want {
+				t.Errorf("caller session verdict = %q, want %q", sess.BackendRedirection, c.want)
+			}
+			stored, err := store.GetSession(sess.Key())
+			if err != nil {
+				t.Fatalf("get from store: %v", err)
+			}
+			if stored.BackendRedirection != c.want {
+				t.Errorf("stored session verdict = %q, want %q", stored.BackendRedirection, c.want)
+			}
+		})
+	}
+}

--- a/internal/usage/accountant.go
+++ b/internal/usage/accountant.go
@@ -53,6 +53,13 @@ type Bind struct {
 	Model string
 	// Window is a manifest override, 0 when unset.
 	Window int
+	// Redirection is the spawn-time backend verdict marvel classified for
+	// this session (api.ClassifyBackendRedirection over the constructed
+	// environment). It rides every denominator resolution for the session
+	// so a redirected or unobserved backend is graded, and eventually
+	// refused, on the keyed rungs. The zero value is BackendUnknown
+	// ("cannot tell").
+	Redirection api.BackendRedirection
 }
 
 // Sink receives computed readings. *api.Store satisfies it.
@@ -154,6 +161,7 @@ type sessionState struct {
 	primaryModel  string
 	args          []string
 	manifestLimit int
+	redirection   api.BackendRedirection
 
 	limit    int
 	limitSrc LimitSource
@@ -207,6 +215,7 @@ func (a *Accountant) Bind(c Coords, b Bind) {
 		StreamModel:   b.Model,
 		RuntimeArgs:   b.Args,
 		ManifestLimit: b.Window,
+		Redirection:   b.Redirection,
 	})
 
 	a.mu.Lock()
@@ -221,6 +230,7 @@ func (a *Accountant) Bind(c Coords, b Bind) {
 		primaryModel:  IdentityKey(model),
 		args:          b.Args,
 		manifestLimit: b.Window,
+		redirection:   b.Redirection,
 		limit:         limit,
 		limitSrc:      src,
 	}
@@ -286,7 +296,7 @@ func (a *Accountant) observeStart(c Coords, ev rtevents.Event, prof profile) {
 
 	a.mu.Lock()
 	st := a.stateLocked(c, ev.Harness, prof)
-	args, manifest := st.args, st.manifestLimit
+	args, manifest, redirection := st.args, st.manifestLimit, st.redirection
 	a.mu.Unlock()
 
 	limit, src, model := a.limits.Resolve(Request{
@@ -294,6 +304,7 @@ func (a *Accountant) observeStart(c Coords, ev rtevents.Event, prof profile) {
 		StreamModel:   d.Model,
 		RuntimeArgs:   args,
 		ManifestLimit: manifest,
+		Redirection:   redirection,
 	})
 
 	a.mu.Lock()

--- a/internal/usage/accountant.go
+++ b/internal/usage/accountant.go
@@ -200,7 +200,10 @@ type foldResult struct {
 	unresolved  bool
 	learnModel  string
 	learnWindow int
-	warnings    []string
+	// learnVerdict is the session's backend verdict, so a learned window is
+	// cached under the backend it was measured on (D-key, aae-orc-bv7m).
+	learnVerdict api.BackendRedirection
+	warnings     []string
 }
 
 // Bind records launch-time knowledge for a session and resolves its
@@ -266,7 +269,7 @@ func (a *Accountant) Observe(c Coords, ev rtevents.Event) {
 		log.Print(w)
 	}
 	if res.learnWindow > 0 {
-		a.limits.Learn(res.learnModel, res.learnWindow)
+		a.limits.Learn(res.learnModel, res.learnWindow, res.learnVerdict)
 	}
 	if res.unresolved {
 		events.Emit(a.ev, events.Event{
@@ -447,7 +450,7 @@ func (a *Accountant) fold(c Coords, ev rtevents.Event, prof profile) foldResult 
 	if s.DeclaredLimit > 0 && st.limit != s.DeclaredLimit {
 		st.limit = s.DeclaredLimit
 		st.limitSrc = LimitFromStream
-		res.learnModel, res.learnWindow = st.rawModel, s.DeclaredLimit
+		res.learnModel, res.learnWindow, res.learnVerdict = st.rawModel, s.DeclaredLimit, st.redirection
 	}
 
 	if st.limit > 0 {
@@ -472,7 +475,7 @@ func (a *Accountant) foldTerminalLocked(st *sessionState, s Sample, res *foldRes
 	if s.DeclaredLimit > 0 {
 		st.limit = s.DeclaredLimit
 		st.limitSrc = LimitFromStream
-		res.learnModel, res.learnWindow = st.rawModel, s.DeclaredLimit
+		res.learnModel, res.learnWindow, res.learnVerdict = st.rawModel, s.DeclaredLimit, st.redirection
 		if st.tokens > 0 {
 			if pct := 100 * float64(st.tokens) / float64(st.limit); pct > st.peak {
 				st.peak = pct

--- a/internal/usage/accountant_test.go
+++ b/internal/usage/accountant_test.go
@@ -156,6 +156,7 @@ func TestSpendAccumulatesWhileOccupancyDoesNot(t *testing.T) {
 func TestTerminalSampleNeverEntersOccupancy(t *testing.T) {
 	t.Parallel()
 	a, _, _ := newTestAccountant(t, Table{"claude-fable-5[1m]": 1_000_000})
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Redirection: api.BackendDefault})
 	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
 
 	for _, r := range []rtevents.RequestUsage{
@@ -300,6 +301,7 @@ func TestCompactionNotDetectedWithinHysteresis(t *testing.T) {
 func TestNonPrimaryModelRoutedToSpendOnly(t *testing.T) {
 	t.Parallel()
 	a, _, _ := newTestAccountant(t, Table{"claude-fable-5[1m]": 1_000_000})
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Redirection: api.BackendDefault})
 	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
 
 	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
@@ -664,7 +666,7 @@ func TestSessionStartUpgradesDenominator(t *testing.T) {
 		"claude-fable-5[1m]": 1_000_000,
 	})
 
-	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Args: []string{"--model", "haiku"}})
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Args: []string{"--model", "haiku"}, Redirection: api.BackendDefault})
 	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
 	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
 		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 100_000,
@@ -695,6 +697,7 @@ func TestSiblingWindowsDoNotCollideAtSessionStart(t *testing.T) {
 		{"claude-sonnet-4-6[1m]", 1_000_000},
 	} {
 		a, sink, _ := newTestAccountant(t, table)
+		a.Bind(testCoords, Bind{Harness: claudecode.Harness, Redirection: api.BackendDefault})
 		a.Observe(testCoords, startedEvent(c.start))
 		a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
 			Layout: rtevents.LayoutAdditive, Model: "claude-sonnet-4-6", In: 100_000,
@@ -723,6 +726,7 @@ func TestTerminalDeclarationLearnsWindow(t *testing.T) {
 	res := NewResolver(Table{})
 	a := New(sink, res, WithClock(fixedClock()))
 
+	a.Bind(testCoords, Bind{Harness: claudecode.Harness, Redirection: api.BackendDefault})
 	a.Observe(testCoords, startedEvent("claude-fable-5[1m]"))
 	a.Observe(testCoords, turnEvent(claudecode.Harness, rtevents.RequestUsage{
 		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 34_136,
@@ -739,17 +743,19 @@ func TestTerminalDeclarationLearnsWindow(t *testing.T) {
 		}},
 	))
 
-	if w, ok := res.Learned("claude-fable-5[1m]"); !ok || w != 1_000_000 {
+	// Learned under the session's backend verdict (default here).
+	if w, ok := res.Learned("claude-fable-5[1m]", api.BackendDefault); !ok || w != 1_000_000 {
 		t.Errorf("learned window = %d (%v), want 1000000", w, ok)
 	}
 	// The [1m] suffix must survive into the cache key: it changes the
 	// window 5x, so a key that strips it collapses two models into one.
-	if _, ok := res.Learned("claude-fable-5"); ok {
+	if _, ok := res.Learned("claude-fable-5", api.BackendDefault); ok {
 		t.Error("the learned key dropped the [1m] suffix, which changes the window 5x")
 	}
 
 	// A second session on the same daemon resolves live.
 	next := Coords{AgentID: "ws/agent-1", Workspace: "ws", Team: "squad", Role: "worker"}
+	a.Bind(next, Bind{Harness: claudecode.Harness, Redirection: api.BackendDefault})
 	a.Observe(next, startedEvent("claude-fable-5[1m]"))
 	a.Observe(next, turnEvent(claudecode.Harness, rtevents.RequestUsage{
 		Layout: rtevents.LayoutAdditive, Model: "claude-fable-5", In: 50_000,

--- a/internal/usage/ladder_test.go
+++ b/internal/usage/ladder_test.go
@@ -5,6 +5,8 @@ import (
 	"go/parser"
 	"go/token"
 	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
 )
 
 // The resolution ladder is a ruled ordering, not an implementation
@@ -159,7 +161,9 @@ func TestResolveAgreesWithTheLadder(t *testing.T) {
 				model = aliasModel
 			}
 
-			req := Request{StreamModel: model}
+			// The ladder is exercised on the vendor default, so the keyed
+			// rungs resolve rather than being refused by the backend guard.
+			req := Request{StreamModel: model, Redirection: api.BackendDefault}
 			for _, r := range []rung{hi, lo} {
 				if r.apply != nil {
 					r.apply(&req)
@@ -172,7 +176,7 @@ func TestResolveAgreesWithTheLadder(t *testing.T) {
 				if lo.learn {
 					w = lo.limit
 				}
-				res.Learn(model, w)
+				res.Learn(model, w, api.BackendDefault)
 			}
 
 			limit, src, _ := res.Resolve(req)

--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -431,12 +431,30 @@ type Request struct {
 	Redirection api.BackendRedirection
 }
 
+// learnedKey identifies a learned window by model AND the backend verdict
+// the learning session ran under (the D-key of finding-031 §5). One Resolver
+// is shared across a daemon's sessions, so keying on the model alone lets a
+// window measured under one backend be served to a session on another. The
+// verdict segregates the cache: a hit is backend-matched by construction, so
+// it is a measurement that applies to this session, not a cross-backend
+// guess — which is why the learned rung is trusted (KeyExact) rather than
+// downgraded the way the model-only table rung must be.
+//
+// The segregation is coarse: BackendRedirected does not name WHICH backend,
+// so two different redirected backends share a bucket. That residue is
+// accepted (finding-031 §5, "smaller than today's, not zero"); putting the
+// provider in the key is option B, deferred behind the eooi standing trigger.
+type learnedKey struct {
+	model   string
+	backend api.BackendRedirection
+}
+
 // Resolver walks the denominator ladder and caches windows a harness has
 // declared. Safe for concurrent use.
 type Resolver struct {
 	mu      sync.RWMutex
 	table   Table
-	learned map[string]int
+	learned map[learnedKey]int
 	warned  map[string]struct{}
 }
 
@@ -448,7 +466,7 @@ func NewResolver(t Table) *Resolver {
 	}
 	return &Resolver{
 		table:   t,
-		learned: make(map[string]int),
+		learned: make(map[learnedKey]int),
 		warned:  make(map[string]struct{}),
 	}
 }
@@ -478,17 +496,16 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 // naming which won.
 //
 // Grades, today: stream, manifest and feed declare a number directly (no
-// keyed lookup narrowed it) and are KeyExact. Learned is KeyExact too — it
-// is a harness measurement matched on its own [1m]-preserving key — but note
-// its narrowness is real on the PROVIDER axis, not the entitlement one: the
-// cache is one Resolver per daemon, so a value learned under one backend can
-// be served to a session on another. Grading that away is the discriminator's
-// job (aae-orc-b2d0p / aae-orc-bv7m), not A-static's; the learned KEY fix is
-// sequenced there, not here. A table hit inherits the entry's entitlement
-// grade (Table.keyConfidence); an alias hit is always KeyNarrow (an alias
-// names whatever the harness points it at, so a hit is not a keyed fact); an
-// unresolved resolution is KeyUndeterminable — marvel cannot vouch for a
-// window it did not find.
+// keyed lookup narrowed it) and are KeyExact. Learned is KeyExact too — it is
+// a harness measurement matched on its own [1m]-preserving key AND on the
+// backend verdict (learnedKey), so its old provider narrowness — a value
+// learned under one backend served to a session on another — is now closed by
+// the key rather than the grade (aae-orc-bv7m D-key). A table hit inherits the
+// entry's entitlement grade (Table.keyConfidence) on the vendor default and is
+// graded/refused by the backend verdict otherwise (see below); an alias hit is
+// always KeyNarrow on the default (an alias names whatever the harness points
+// it at, so a hit is not a keyed fact); an unresolved resolution is
+// KeyUndeterminable — marvel cannot vouch for a window it did not find.
 //
 // THE DISCRIMINATOR (aae-orc-b2d0p, landed here): a redirected backend can
 // serve a different window under the same id, and marvel cannot see WHICH
@@ -506,11 +523,14 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 // KEY problem, not a grade one, and is fixed by keying it on the same
 // verdict (aae-orc-bv7m / finding-031 §5 D-key), sequenced there.
 //
-// The refuse-guard (aae-orc-bv7m) turns KeyRedirected/KeyUndeterminable on
-// the table and alias rungs into LimitUnresolved, WITHIN the rung and never
-// reordering the ladder (TestResolveAgreesWithTheLadder constrains this).
-// b2d0p stops at the grade; it changes no resolved window, so Resolve (which
-// drops the grade) is unaffected.
+// The refuse-guard (aae-orc-bv7m, landed) then turns
+// KeyRedirected/KeyUndeterminable on the table and alias rungs into
+// LimitUnresolved via refuseKeyed — WITHIN the rung and never reordering the
+// ladder (TestResolveAgreesWithTheLadder constrains this) — so a redirected or
+// unobserved table window renders absent rather than a confident wrong number.
+// The refuse flows through Resolve too, so the heartbeat path that calls the
+// ungraded signature refuses identically. On the vendor default nothing is
+// refused, which is the common case and unchanged.
 func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, string) {
 	model := req.StreamModel
 	if model == "" {
@@ -527,13 +547,19 @@ func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, 
 
 	if model != "" {
 		r.mu.RLock()
-		w, ok := r.learned[NormalizeModel(model)]
+		w, ok := r.learned[learnedKey{NormalizeModel(model), req.Redirection}]
 		r.mu.RUnlock()
 		if ok {
 			if req.ManifestLimit > 0 && req.ManifestLimit != w {
 				r.warnOnce("learned-override:"+model, "context window: %s declared %d for %q in a prior session, overriding the manifest's %d",
 					req.Harness, w, model, req.ManifestLimit)
 			}
+			// KeyExact, not graded by the verdict: the learnedKey already
+			// carries it, so a hit was measured under this session's backend
+			// (aae-orc-bv7m / finding-031 §5 D-key). A cold-start redirected
+			// session misses here and falls through to the table, which
+			// refuses — until one session teaches the window under this
+			// backend, at which point this rung answers.
 			return w, LimitLearned, KeyExact, model
 		}
 	}
@@ -567,13 +593,43 @@ func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, 
 		}
 		r.mu.RUnlock()
 		if ok {
-			return w, LimitFromTable, applyRedirection(key, req.Redirection), model
+			grade := applyRedirection(key, req.Redirection)
+			if refuseOnBackend(grade) {
+				return r.refuseKeyed(model, req.Redirection)
+			}
+			return w, LimitFromTable, grade, model
 		}
 		if aok {
-			return aw, LimitFromTableAlias, applyRedirection(KeyNarrow, req.Redirection), model
+			grade := applyRedirection(KeyNarrow, req.Redirection)
+			if refuseOnBackend(grade) {
+				return r.refuseKeyed(model, req.Redirection)
+			}
+			return aw, LimitFromTableAlias, grade, model
 		}
 	}
 
+	return 0, LimitUnresolved, KeyUndeterminable, model
+}
+
+// refuseOnBackend reports whether a keyed-rung grade is one the refuse-guard
+// withholds: a table value keyed on the vendor's direct-API window cannot be
+// vouched for once the backend is redirected or unobserved.
+func refuseOnBackend(grade KeyConfidence) bool {
+	return grade == KeyRedirected || grade == KeyUndeterminable
+}
+
+// refuseKeyed is the guard of aae-orc-bv7m: a table or alias hit under a
+// redirected or unobserved backend resolves to absence rather than the
+// direct-API window, so CTX% renders "?" (loud) instead of a confident wrong
+// number (silent). It refuses WITHIN the rung — it does not fall through to a
+// lower one, because a lower rung is a worse guess, not a better one — and it
+// returns KeyUndeterminable to keep the ladder invariant that an unresolved
+// resolution is always undeterminable (TestUnresolvedIsUndeterminable). The
+// warning distinguishes this from a plain table miss: the model IS known, its
+// backend is not the default.
+func (r *Resolver) refuseKeyed(model string, redir api.BackendRedirection) (int, LimitSource, KeyConfidence, string) {
+	r.warnOnce("backend-refuse:"+model, "context window: %q has a shipped table window, but this session's backend is %s, so the direct-API value is withheld and CTX%% renders absent",
+		model, redir)
 	return 0, LimitUnresolved, KeyUndeterminable, model
 }
 
@@ -619,33 +675,42 @@ func applyRedirection(entitlement KeyConfidence, r api.BackendRedirection) KeyCo
 //
 // A declaration that contradicts the shipped table logs once per model:
 // that is the drift detector for a vendor window change.
-func (r *Resolver) Learn(model string, window int) {
+//
+// backend is the verdict the learning session ran under; it segregates the
+// cache so a window is only served back to a session on the same backend
+// (aae-orc-bv7m / finding-031 §5 D-key). The drift check against the shipped
+// table stays keyed on the model alone — the table is the direct-API window,
+// and a redirected declaration disagreeing with it is expected, not drift —
+// so drift is only flagged for a default-backend declaration.
+func (r *Resolver) Learn(model string, window int, backend api.BackendRedirection) {
 	if model == "" || window <= 0 {
 		return
 	}
-	key := NormalizeModel(model)
+	mkey := NormalizeModel(model)
+	lk := learnedKey{mkey, backend}
 
 	r.mu.Lock()
-	prev, had := r.learned[key]
-	r.learned[key] = window
-	shipped, inTable := r.table.Lookup(key)
+	prev, had := r.learned[lk]
+	r.learned[lk] = window
+	shipped, inTable := r.table.Lookup(mkey)
 	r.mu.Unlock()
 
-	if inTable && shipped != window {
-		r.warnOnce("drift:"+key, "context window: harness declares %d for %q; the shipped table says %d, so the table is stale",
-			window, key, shipped)
+	if inTable && backend == api.BackendDefault && shipped != window {
+		r.warnOnce("drift:"+mkey, "context window: harness declares %d for %q; the shipped table says %d, so the table is stale",
+			window, mkey, shipped)
 	}
 	if had && prev != window {
-		r.warnOnce("changed:"+key, "context window for %q changed from %d to %d", key, prev, window)
+		r.warnOnce("changed:"+mkey+":"+string(backend), "context window for %q changed from %d to %d", mkey, prev, window)
 	}
 }
 
-// Learned reports the cached window for a model, for tests and
-// diagnostics.
-func (r *Resolver) Learned(model string) (int, bool) {
+// Learned reports the cached window for a model under a backend verdict, for
+// tests and diagnostics. The backend is part of the key (see learnedKey), so
+// a window learned under one backend is invisible under another.
+func (r *Resolver) Learned(model string, backend api.BackendRedirection) (int, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	w, ok := r.learned[NormalizeModel(model)]
+	w, ok := r.learned[learnedKey{NormalizeModel(model), backend}]
 	return w, ok
 }
 

--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"strings"
 	"sync"
+
+	"github.com/arcavenae/marvel/internal/api"
 )
 
 // LimitSource records which rung of the resolution ladder produced a
@@ -117,14 +119,15 @@ func (s LimitSource) Rank() int {
 //     DEFAULT half of a default/max split does not carry the entitlement
 //     that decides which half a session gets. See the default-versus-maximum
 //     convention on DefaultTable and Table.keyConfidence.
-//   - PROVIDER (dynamic, not graded yet). The same id can name different
-//     windows under different backends (finding-031: the catalog assigns
-//     claude-opus-5 1000000 under anthropic and 264000 under copilot), and
-//     marvel cannot observe which backend served a request. The
-//     discriminator that answers "on the vendor default, or redirected?" is
-//     a spawn-time environment read that does not exist yet (aae-orc-b2d0p);
-//     until it lands, ResolveGraded assumes the default backend and never
-//     emits KeyRedirected. See the seam in ResolveGraded.
+//   - PROVIDER (dynamic, graded via req.Redirection). The same id can name
+//     different windows under different backends (finding-031: the catalog
+//     assigns claude-opus-5 1000000 under anthropic and 264000 under
+//     copilot), and marvel cannot observe which backend served a request —
+//     but it observes at spawn whether the backend-selecting environment
+//     departs from the vendor default (api.ClassifyBackendRedirection). That
+//     verdict rides in on Request.Redirection and downgrades a keyed hit to
+//     KeyRedirected or KeyUndeterminable (aae-orc-b2d0p). See applyRedirection
+//     and the discriminator note in ResolveGraded.
 type KeyConfidence string
 
 const (
@@ -140,16 +143,15 @@ const (
 	// at, so a hit that happens to be right is not a keyed fact).
 	KeyNarrow KeyConfidence = "narrow"
 	// KeyRedirected means the discriminator found the session redirected off
-	// the vendor default, so a table value keyed on the direct-API window
-	// does not apply. RESERVED: produced only once the spawn-time
-	// discriminator lands (aae-orc-b2d0p); ResolveGraded never returns it
-	// today. Declared now because it is the vocabulary the refuse-guard
-	// (aae-orc-bv7m) speaks.
+	// the vendor default (req.Redirection == api.BackendRedirected), so a
+	// table or alias value keyed on the direct-API window does not apply.
+	// Produced by applyRedirection; the refuse-guard (aae-orc-bv7m) turns it
+	// into LimitUnresolved on those rungs.
 	KeyRedirected KeyConfidence = "redirected"
-	// KeyUndeterminable means marvel cannot vouch for the window. Today it
-	// marks an unresolved resolution (no rung produced a window). Once the
-	// discriminator lands it will also mark a session whose backend cannot
-	// be determined, which the guard treats as departure from default
+	// KeyUndeterminable means marvel cannot vouch for the window. It marks
+	// an unresolved resolution (no rung produced a window) and a keyed hit
+	// under an unobserved backend (req.Redirection == api.BackendUnknown,
+	// "cannot tell"), which the guard treats as departure from default
 	// (finding-031). Either way: not a number to trust.
 	KeyUndeterminable KeyConfidence = "undeterminable"
 )
@@ -418,6 +420,15 @@ type Request struct {
 	// which ranks BELOW ManifestLimit; SampleLimit ranks above it. That is
 	// the deliberate asymmetry documented at limitLadder.
 	FeedLimit int
+	// Redirection is the spawn-time backend verdict for this session (the
+	// discriminator of finding-031). It grades a keyed rung: the table and
+	// alias rungs hold the vendor's DIRECT-API windows, so a redirected or
+	// unobserved backend downgrades a hit off KeyExact/KeyNarrow. The
+	// directly-declared rungs (stream, manifest, feed) are unaffected — a
+	// number the harness or operator stated is correct on any backend. The
+	// zero value is BackendUnknown ("cannot tell"), treated as departure
+	// from default. See ResolveGraded and api.ClassifyBackendRedirection.
+	Redirection api.BackendRedirection
 }
 
 // Resolver walks the denominator ladder and caches windows a harness has
@@ -479,19 +490,27 @@ func (r *Resolver) Resolve(req Request) (int, LimitSource, string) {
 // unresolved resolution is KeyUndeterminable — marvel cannot vouch for a
 // window it did not find.
 //
-// THE DISCRIMINATOR SEAM (aae-orc-b2d0p, not built here): a redirected
-// backend can serve a different window under the same id, and marvel cannot
-// see the backend today (finding-031). When the spawn-time environment read
-// lands, its verdict enters here — most naturally a field on Request — and
-// downgrades the table (and learned) branch: a redirected KeyExact hit
-// becomes KeyRedirected, and the refuse-guard (aae-orc-bv7m) resolves
-// LimitUnresolved for KeyNarrow ∧ (redirected ∨ undeterminable). How a hit
-// that is BOTH entitlement-narrow and redirected is represented — a
-// precedence over this single enum, or a second field beside it — is that
-// work's design call, deliberately left open here; A-static only fixes the
-// entitlement axis and reserves the vocabulary. Whatever the shape, the guard
-// must refuse WITHIN a rung, never reorder rungs, so it belongs in the table
-// branch below, not before it. Until then this assumes the vendor default.
+// THE DISCRIMINATOR (aae-orc-b2d0p, landed here): a redirected backend can
+// serve a different window under the same id, and marvel cannot see WHICH
+// backend served a request (finding-031). What it can see is the spawn-time
+// backend-selecting environment, carried in as req.Redirection. It grades
+// the KEYED rungs — table and alias — through applyRedirection: a hit under
+// a redirected backend becomes KeyRedirected, and one under an unobserved
+// backend (the zero value, "cannot tell") becomes KeyUndeterminable. The
+// verdict DOMINATES the entitlement grade in this single enum, because a
+// direct-API table value does not apply under redirection whether or not
+// the entitlement was also ambiguous; the entitlement grade stands only on
+// the vendor default. The directly-declared rungs (stream, manifest, feed)
+// are NOT graded by the backend — a number the harness or operator stated
+// is correct on any backend. The learned rung's provider narrowness is a
+// KEY problem, not a grade one, and is fixed by keying it on the same
+// verdict (aae-orc-bv7m / finding-031 §5 D-key), sequenced there.
+//
+// The refuse-guard (aae-orc-bv7m) turns KeyRedirected/KeyUndeterminable on
+// the table and alias rungs into LimitUnresolved, WITHIN the rung and never
+// reordering the ladder (TestResolveAgreesWithTheLadder constrains this).
+// b2d0p stops at the grade; it changes no resolved window, so Resolve (which
+// drops the grade) is unaffected.
 func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, string) {
 	model := req.StreamModel
 	if model == "" {
@@ -548,14 +567,36 @@ func (r *Resolver) ResolveGraded(req Request) (int, LimitSource, KeyConfidence, 
 		}
 		r.mu.RUnlock()
 		if ok {
-			return w, LimitFromTable, key, model
+			return w, LimitFromTable, applyRedirection(key, req.Redirection), model
 		}
 		if aok {
-			return aw, LimitFromTableAlias, KeyNarrow, model
+			return aw, LimitFromTableAlias, applyRedirection(KeyNarrow, req.Redirection), model
 		}
 	}
 
 	return 0, LimitUnresolved, KeyUndeterminable, model
+}
+
+// applyRedirection folds the spawn-time backend verdict into the entitlement
+// grade of a KEYED rung (table or alias — the rungs holding the vendor's
+// direct-API windows). The verdict dominates: a redirected backend
+// invalidates the direct-API value regardless of entitlement, and an
+// unobserved backend cannot be vouched for, so both override KeyExact and
+// KeyNarrow alike. On the vendor default the entitlement grade stands.
+//
+// It is deliberately NOT applied to the directly-declared rungs (a stated
+// number is right on any backend) nor to the learned rung (whose provider
+// narrowness is fixed by keying it on the verdict — aae-orc-bv7m — not by
+// grading it here).
+func applyRedirection(entitlement KeyConfidence, r api.BackendRedirection) KeyConfidence {
+	switch r {
+	case api.BackendRedirected:
+		return KeyRedirected
+	case api.BackendUnknown:
+		return KeyUndeterminable
+	default: // api.BackendDefault
+		return entitlement
+	}
 }
 
 // Learn records a window a harness declared, keyed on NormalizeModel so

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/arcavenae/marvel/internal/api"
 )
 
 func TestNormalizeModel(t *testing.T) {
@@ -568,6 +570,10 @@ func TestResolveGradedGradesEachRung(t *testing.T) {
 		if c.learn != "" {
 			r.Learn(c.learn, c.learnValue)
 		}
+		// These pin the per-rung grade on the vendor default, where the
+		// entitlement axis stands alone. The backend axis is exercised
+		// separately in TestResolveGradedBackendVerdictGradesKeyedRungs.
+		c.req.Redirection = api.BackendDefault
 		limit, src, key, _ := r.ResolveGraded(c.req)
 		if limit != c.wantLimit {
 			t.Errorf("%s: limit = %d, want %d", c.name, limit, c.wantLimit)
@@ -578,6 +584,104 @@ func TestResolveGradedGradesEachRung(t *testing.T) {
 		if key != c.wantKey {
 			t.Errorf("%s: key confidence = %q, want %q", c.name, key, c.wantKey)
 		}
+	}
+}
+
+// TestResolveGradedBackendVerdictGradesKeyedRungs is the backend axis of the
+// grade, orthogonal to the entitlement axis TestResolveGradedGradesEachRung
+// pins. The verdict downgrades ONLY the keyed rungs (table, alias): a
+// directly-declared window is correct on any backend, and the learned rung's
+// provider fix is its key, not its grade (aae-orc-bv7m). The verdict
+// dominates the entitlement grade — a redirected [1m] key (entitlement-exact)
+// is still KeyRedirected, because the direct-API window does not apply under
+// redirection.
+func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
+	t.Parallel()
+	table := Table{
+		"claude-haiku-4-5":    200_000, // single window: entitlement-exact
+		"claude-opus-4-8":     200_000, // split default: entitlement-narrow
+		"claude-opus-4-8[1m]": 1_000_000,
+	}
+	cases := []struct {
+		name        string
+		req         Request
+		learn       string
+		learnValue  int
+		redirection api.BackendRedirection
+		wantSource  LimitSource
+		wantKey     KeyConfidence
+	}{
+		{
+			name:        "default backend leaves the exact table hit exact",
+			req:         Request{StreamModel: "claude-haiku-4-5"},
+			redirection: api.BackendDefault,
+			wantSource:  LimitFromTable,
+			wantKey:     KeyExact,
+		},
+		{
+			name:        "redirected backend downgrades an exact table hit",
+			req:         Request{StreamModel: "claude-haiku-4-5"},
+			redirection: api.BackendRedirected,
+			wantSource:  LimitFromTable,
+			wantKey:     KeyRedirected,
+		},
+		{
+			name:        "redirected backend dominates the [1m] entitlement-exact key",
+			req:         Request{StreamModel: "claude-opus-4-8[1m]"},
+			redirection: api.BackendRedirected,
+			wantSource:  LimitFromTable,
+			wantKey:     KeyRedirected,
+		},
+		{
+			name:        "cannot-tell backend makes a table hit undeterminable",
+			req:         Request{StreamModel: "claude-opus-4-8"},
+			redirection: api.BackendUnknown,
+			wantSource:  LimitFromTable,
+			wantKey:     KeyUndeterminable,
+		},
+		{
+			name:        "redirected backend downgrades an alias hit",
+			req:         Request{RuntimeArgs: []string{"--model", "haiku"}},
+			redirection: api.BackendRedirected,
+			wantSource:  LimitFromTableAlias,
+			wantKey:     KeyRedirected,
+		},
+		{
+			// b2d0p does NOT grade the learned rung by the verdict; that is
+			// the D-key's job (aae-orc-bv7m). A learned hit stays exact here.
+			name:        "learned rung is untouched by the verdict in b2d0p",
+			req:         Request{StreamModel: "claude-haiku-4-5"},
+			learn:       "claude-haiku-4-5",
+			learnValue:  333_333,
+			redirection: api.BackendRedirected,
+			wantSource:  LimitLearned,
+			wantKey:     KeyExact,
+		},
+		{
+			// A directly-declared window is right on any backend.
+			name:        "redirected backend does not downgrade a manifest window",
+			req:         Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
+			redirection: api.BackendRedirected,
+			wantSource:  LimitFromManifest,
+			wantKey:     KeyExact,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewResolver(table)
+			if c.learn != "" {
+				r.Learn(c.learn, c.learnValue)
+			}
+			c.req.Redirection = c.redirection
+			_, src, key, _ := r.ResolveGraded(c.req)
+			if src != c.wantSource {
+				t.Errorf("source = %q, want %q", src, c.wantSource)
+			}
+			if key != c.wantKey {
+				t.Errorf("key confidence = %q, want %q", key, c.wantKey)
+			}
+		})
 	}
 }
 
@@ -683,6 +787,7 @@ func TestResolveGradedOverDefaultTable(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
+		c.req.Redirection = api.BackendDefault // grades over the shipped table on the vendor default
 		limit, src, key, _ := r.ResolveGraded(c.req)
 		if limit != c.wantLimit || src != c.wantSource || key != c.wantKey {
 			t.Errorf("%s: got (%d, %q, %q), want (%d, %q, %q)",

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -181,8 +181,11 @@ func TestResolveLadderPrecedence(t *testing.T) {
 	for _, c := range cases {
 		r := NewResolver(table)
 		if c.learn != "" {
-			r.Learn(c.learn, c.learnValue)
+			r.Learn(c.learn, c.learnValue, api.BackendDefault)
 		}
+		// Precedence is exercised on the vendor default, so the keyed rungs
+		// resolve rather than being refused by the backend guard.
+		c.req.Redirection = api.BackendDefault
 		limit, src, _ := r.Resolve(c.req)
 		if limit != c.wantLimit {
 			t.Errorf("%s: limit = %d, want %d", c.name, limit, c.wantLimit)
@@ -199,6 +202,7 @@ func TestResolveReadsModelFromArgsWhenStreamNamesNone(t *testing.T) {
 	limit, src, model := r.Resolve(Request{
 		Harness:     "codex",
 		RuntimeArgs: []string{"--json", "--model", "claude-haiku-4-5"},
+		Redirection: api.BackendDefault,
 	})
 	if model != "claude-haiku-4-5" {
 		t.Errorf("model = %q, want claude-haiku-4-5", model)
@@ -237,11 +241,12 @@ func TestResolveWarnsWhenLearnedContradictsManifest(t *testing.T) {
 			defer log.SetOutput(restore)
 
 			r := NewResolver(Table{})
-			r.Learn("claude-haiku-4-5", c.learnValue)
+			r.Learn("claude-haiku-4-5", c.learnValue, api.BackendDefault)
 			limit, src, _ := r.Resolve(Request{
 				Harness:       "claude",
 				StreamModel:   "claude-haiku-4-5",
 				ManifestLimit: c.manifestLimit,
+				Redirection:   api.BackendDefault,
 			})
 
 			// The learned rung still wins — this ticket disputes the
@@ -273,24 +278,46 @@ func TestResolveWarnsWhenLearnedContradictsManifest(t *testing.T) {
 func TestLearnKeepsTheSuffixInItsKey(t *testing.T) {
 	t.Parallel()
 	r := NewResolver(Table{})
-	r.Learn("claude-sonnet-4-6[1m]", 1_000_000)
+	r.Learn("claude-sonnet-4-6[1m]", 1_000_000, api.BackendDefault)
 
-	if w, ok := r.Learned("claude-sonnet-4-6[1m]"); !ok || w != 1_000_000 {
+	if w, ok := r.Learned("claude-sonnet-4-6[1m]", api.BackendDefault); !ok || w != 1_000_000 {
 		t.Errorf("learned[1m] = %d (%v), want 1000000", w, ok)
 	}
 	// The 200k sibling must not inherit the 1M window.
-	if _, ok := r.Learned("claude-sonnet-4-6"); ok {
+	if _, ok := r.Learned("claude-sonnet-4-6", api.BackendDefault); ok {
 		t.Error("the 200k sibling inherited the 1M window; the learned key must keep [1m]")
+	}
+}
+
+// The learned cache is segregated by backend verdict (D-key, aae-orc-bv7m):
+// a window measured under one backend is invisible under another, so a
+// value learned on the vendor default is never served to a redirected
+// session and vice versa.
+func TestLearnedIsSegregatedByBackend(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{})
+	r.Learn("claude-haiku-4-5", 200_000, api.BackendDefault)
+	r.Learn("claude-haiku-4-5", 180_000, api.BackendRedirected)
+
+	if w, ok := r.Learned("claude-haiku-4-5", api.BackendDefault); !ok || w != 200_000 {
+		t.Errorf("default-backend learned = %d (%v), want 200000", w, ok)
+	}
+	if w, ok := r.Learned("claude-haiku-4-5", api.BackendRedirected); !ok || w != 180_000 {
+		t.Errorf("redirected-backend learned = %d (%v), want 180000", w, ok)
+	}
+	// A verdict nobody learned under sees nothing, even for a known model.
+	if _, ok := r.Learned("claude-haiku-4-5", api.BackendUnknown); ok {
+		t.Error("a window leaked across backend verdicts; the learned key must carry the verdict")
 	}
 }
 
 func TestLearnIgnoresNonsense(t *testing.T) {
 	t.Parallel()
 	r := NewResolver(Table{})
-	r.Learn("", 200_000)
-	r.Learn("claude-haiku-4-5", 0)
-	r.Learn("claude-haiku-4-5", -1)
-	if _, ok := r.Learned("claude-haiku-4-5"); ok {
+	r.Learn("", 200_000, api.BackendDefault)
+	r.Learn("claude-haiku-4-5", 0, api.BackendDefault)
+	r.Learn("claude-haiku-4-5", -1, api.BackendDefault)
+	if _, ok := r.Learned("claude-haiku-4-5", api.BackendDefault); ok {
 		t.Error("a zero or negative window was cached")
 	}
 }
@@ -327,7 +354,7 @@ func TestEveryDefaultTableEntryResolves(t *testing.T) {
 	t.Parallel()
 	r := NewResolver(DefaultTable())
 	for key, want := range DefaultTable() {
-		limit, src, _ := r.Resolve(Request{StreamModel: key})
+		limit, src, _ := r.Resolve(Request{StreamModel: key, Redirection: api.BackendDefault})
 		if limit != want {
 			t.Errorf("%s: limit = %d, want %d", key, limit, want)
 		}
@@ -346,7 +373,7 @@ func TestOpus5ResolvesUnderBothSpellings(t *testing.T) {
 	t.Parallel()
 	r := NewResolver(DefaultTable())
 	for _, model := range []string{"claude-opus-5", "claude-opus-5[1m]"} {
-		limit, src, _ := r.Resolve(Request{StreamModel: model})
+		limit, src, _ := r.Resolve(Request{StreamModel: model, Redirection: api.BackendDefault})
 		if limit != 1_000_000 {
 			t.Errorf("%s: limit = %d, want 1000000", model, limit)
 		}
@@ -355,7 +382,7 @@ func TestOpus5ResolvesUnderBothSpellings(t *testing.T) {
 		}
 	}
 	// A dated snapshot must land on the bare key, not fall off the table.
-	if limit, src, _ := r.Resolve(Request{StreamModel: "claude-opus-5-20260801"}); limit != 1_000_000 || src != LimitFromTable {
+	if limit, src, _ := r.Resolve(Request{StreamModel: "claude-opus-5-20260801", Redirection: api.BackendDefault}); limit != 1_000_000 || src != LimitFromTable {
 		t.Errorf("dated snapshot: limit = %d, source = %q; want 1000000 from %q", limit, src, LimitFromTable)
 	}
 }
@@ -568,7 +595,7 @@ func TestResolveGradedGradesEachRung(t *testing.T) {
 	for _, c := range cases {
 		r := NewResolver(table)
 		if c.learn != "" {
-			r.Learn(c.learn, c.learnValue)
+			r.Learn(c.learn, c.learnValue, api.BackendDefault)
 		}
 		// These pin the per-rung grade on the vendor default, where the
 		// entitlement axis stands alone. The backend axis is exercised
@@ -587,15 +614,12 @@ func TestResolveGradedGradesEachRung(t *testing.T) {
 	}
 }
 
-// TestResolveGradedBackendVerdictGradesKeyedRungs is the backend axis of the
-// grade, orthogonal to the entitlement axis TestResolveGradedGradesEachRung
-// pins. The verdict downgrades ONLY the keyed rungs (table, alias): a
-// directly-declared window is correct on any backend, and the learned rung's
-// provider fix is its key, not its grade (aae-orc-bv7m). The verdict
-// dominates the entitlement grade — a redirected [1m] key (entitlement-exact)
-// is still KeyRedirected, because the direct-API window does not apply under
-// redirection.
-func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
+// TestResolveGradedBackendVerdictOnKeyedRungs pins the cases the verdict does
+// NOT refuse (the refuse itself is TestResolveRefusesKeyedRungOnBackendDeparture):
+// a default-backend table hit keeps its entitlement grade, a learned hit under
+// a matching backend is trusted (KeyExact — the D-key made the lookup
+// backend-matched), and a directly-declared window is right on any backend.
+func TestResolveGradedBackendVerdictOnKeyedRungs(t *testing.T) {
 	t.Parallel()
 	table := Table{
 		"claude-haiku-4-5":    200_000, // single window: entitlement-exact
@@ -612,44 +636,23 @@ func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
 		wantKey     KeyConfidence
 	}{
 		{
-			name:        "default backend leaves the exact table hit exact",
+			name:        "default backend keeps an exact table hit exact",
 			req:         Request{StreamModel: "claude-haiku-4-5"},
 			redirection: api.BackendDefault,
 			wantSource:  LimitFromTable,
 			wantKey:     KeyExact,
 		},
 		{
-			name:        "redirected backend downgrades an exact table hit",
-			req:         Request{StreamModel: "claude-haiku-4-5"},
-			redirection: api.BackendRedirected,
-			wantSource:  LimitFromTable,
-			wantKey:     KeyRedirected,
-		},
-		{
-			name:        "redirected backend dominates the [1m] entitlement-exact key",
-			req:         Request{StreamModel: "claude-opus-4-8[1m]"},
-			redirection: api.BackendRedirected,
-			wantSource:  LimitFromTable,
-			wantKey:     KeyRedirected,
-		},
-		{
-			name:        "cannot-tell backend makes a table hit undeterminable",
+			name:        "default backend keeps a split table hit narrow",
 			req:         Request{StreamModel: "claude-opus-4-8"},
-			redirection: api.BackendUnknown,
+			redirection: api.BackendDefault,
 			wantSource:  LimitFromTable,
-			wantKey:     KeyUndeterminable,
+			wantKey:     KeyNarrow,
 		},
 		{
-			name:        "redirected backend downgrades an alias hit",
-			req:         Request{RuntimeArgs: []string{"--model", "haiku"}},
-			redirection: api.BackendRedirected,
-			wantSource:  LimitFromTableAlias,
-			wantKey:     KeyRedirected,
-		},
-		{
-			// b2d0p does NOT grade the learned rung by the verdict; that is
-			// the D-key's job (aae-orc-bv7m). A learned hit stays exact here.
-			name:        "learned rung is untouched by the verdict in b2d0p",
+			// The learned rung is backend-matched by its key, so a redirected
+			// session's learned hit is trusted rather than refused.
+			name:        "learned hit under a matching redirected backend is exact",
 			req:         Request{StreamModel: "claude-haiku-4-5"},
 			learn:       "claude-haiku-4-5",
 			learnValue:  333_333,
@@ -659,7 +662,7 @@ func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
 		},
 		{
 			// A directly-declared window is right on any backend.
-			name:        "redirected backend does not downgrade a manifest window",
+			name:        "redirected backend does not touch a manifest window",
 			req:         Request{StreamModel: "claude-haiku-4-5", ManifestLimit: 111_111},
 			redirection: api.BackendRedirected,
 			wantSource:  LimitFromManifest,
@@ -671,7 +674,9 @@ func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
 			t.Parallel()
 			r := NewResolver(table)
 			if c.learn != "" {
-				r.Learn(c.learn, c.learnValue)
+				// Learn under the same verdict the request carries, so the
+				// D-key lookup matches and the case exercises a learned hit.
+				r.Learn(c.learn, c.learnValue, c.redirection)
 			}
 			c.req.Redirection = c.redirection
 			_, src, key, _ := r.ResolveGraded(c.req)
@@ -685,10 +690,92 @@ func TestResolveGradedBackendVerdictGradesKeyedRungs(t *testing.T) {
 	}
 }
 
+// The refuse-guard (aae-orc-bv7m): a table or alias hit under a redirected or
+// unobserved backend resolves to absence rather than the direct-API window.
+// It refuses WITHIN the rung (never falling through to a lower one) and keeps
+// the LimitUnresolved ⇒ KeyUndeterminable invariant. The refuse propagates
+// through Resolve too, so the legacy signature and the heartbeat path that
+// calls it are covered without plumbing the grade.
+func TestResolveRefusesKeyedRungOnBackendDeparture(t *testing.T) {
+	t.Parallel()
+	table := Table{"claude-haiku-4-5": 200_000}
+	cases := []struct {
+		name        string
+		req         Request
+		redirection api.BackendRedirection
+	}{
+		{"redirected table hit refuses", Request{StreamModel: "claude-haiku-4-5"}, api.BackendRedirected},
+		{"cannot-tell table hit refuses", Request{StreamModel: "claude-haiku-4-5"}, api.BackendUnknown},
+		{"redirected alias hit refuses", Request{RuntimeArgs: []string{"--model", "haiku"}}, api.BackendRedirected},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewResolver(table)
+			c.req.Redirection = c.redirection
+			limit, src, key, _ := r.ResolveGraded(c.req)
+			if limit != 0 || src != LimitUnresolved {
+				t.Fatalf("got (%d, %q), want an unresolved resolution", limit, src)
+			}
+			if key != KeyUndeterminable {
+				t.Errorf("key confidence = %q, want KeyUndeterminable", key)
+			}
+			// Resolve must agree — the refuse is what the heartbeat path sees.
+			if l, s, _ := r.Resolve(c.req); l != 0 || s != LimitUnresolved {
+				t.Errorf("Resolve = (%d, %q), want unresolved", l, s)
+			}
+		})
+	}
+}
+
+// A directly-declared window is correct on any backend, so the guard leaves
+// it alone: a redirected session with a manifest override still resolves it.
+func TestResolveDoesNotRefuseDeclaredWindowsUnderRedirection(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{"claude-haiku-4-5": 200_000})
+	limit, src, _ := r.Resolve(Request{
+		StreamModel:   "claude-haiku-4-5",
+		ManifestLimit: 500_000,
+		Redirection:   api.BackendRedirected,
+	})
+	if limit != 500_000 || src != LimitFromManifest {
+		t.Errorf("got (%d, %q), want 500000/manifest — a stated window is right on any backend", limit, src)
+	}
+}
+
+// The finding's "one session teaches the window" behavior: a redirected
+// session refuses the table at cold start, but once a session has taught the
+// window under that backend, the learned rung answers and is trusted.
+func TestRedirectedSessionResolvesOnceLearned(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(Table{"claude-haiku-4-5": 200_000})
+	req := Request{StreamModel: "claude-haiku-4-5", Redirection: api.BackendRedirected}
+
+	// Cold start: the table refuses, so CTX% renders absent.
+	if limit, src, _ := r.Resolve(req); limit != 0 || src != LimitUnresolved {
+		t.Fatalf("cold start = (%d, %q), want unresolved", limit, src)
+	}
+
+	// The harness declares its window under this backend.
+	r.Learn("claude-haiku-4-5", 180_000, api.BackendRedirected)
+
+	limit, src, key, _ := r.ResolveGraded(req)
+	if limit != 180_000 || src != LimitLearned {
+		t.Fatalf("after learning = (%d, %q), want 180000/learned", limit, src)
+	}
+	if key != KeyExact {
+		t.Errorf("learned key confidence = %q, want KeyExact (backend-matched by the key)", key)
+	}
+	// A default-backend session must NOT see the redirected learned window.
+	if limit, src, _ := r.Resolve(Request{StreamModel: "claude-haiku-4-5", Redirection: api.BackendDefault}); limit != 200_000 || src != LimitFromTable {
+		t.Errorf("default session = (%d, %q), want the table's 200000, not the redirected 180000", limit, src)
+	}
+}
+
 // An unresolved resolution always carries KeyUndeterminable: marvel cannot
 // vouch for a window it did not find. This is the invariant the refuse-guard
-// (aae-orc-bv7m) will preserve when it resolves LimitUnresolved for a narrow
-// redirected key.
+// (aae-orc-bv7m) preserves when it resolves LimitUnresolved for a redirected
+// or unobserved keyed hit.
 func TestUnresolvedIsUndeterminable(t *testing.T) {
 	t.Parallel()
 	r := NewResolver(Table{"claude-haiku-4-5": 200_000})
@@ -724,6 +811,7 @@ func TestResolveDelegatesToResolveGraded(t *testing.T) {
 		{StreamModel: "claude-haiku-4-5", FeedLimit: 5}, // feed
 	}
 	for _, req := range reqs {
+		req.Redirection = api.BackendDefault // Resolve/ResolveGraded must agree on any backend; default keeps the keyed rungs resolving
 		gLimit, gSrc, _, gModel := r.ResolveGraded(req)
 		limit, src, model := r.Resolve(req)
 		if limit != gLimit || src != gSrc || model != gModel {


### PR DESCRIPTION
## Why

The context-window table ships the model vendor's **direct-API** windows, so a table value is only right for a session talking to the vendor directly. The same model id served through a different backend (Bedrock, Vertex, an arbitrary proxy) can carry a different window, and today a table hit under such a backend renders a confident wrong CTX% — the silent-wrong failure finding-031 names. A miss is loud (`?`); a wrong hit reads exactly like a correct one.

Marvel cannot observe which backend actually served a request, but it *can* observe, at spawn, whether the backend-selecting environment departs from the vendor default. This PR builds that discriminator and uses it so a redirected or unobserved session renders absence (loud) instead of a wrong number (silent), while leaving the common case — a session on the vendor default — completely unchanged. It closes the two sites finding-031 identified: the shared per-daemon learned cache (fixed by its key) and the shipped table (guarded).

Refs finding-031, aae-orc-b2d0p, aae-orc-bv7m.

## What

Two commits.

**1. Record the spawn-time backend verdict and grade by it (b2d0p).**
- `api.BackendRedirection` (`default` / `redirected` / `cannot-tell`) plus a pure classifier over the backend-selecting environment (the Bedrock/Vertex/gateway switches and a custom base URL / service tier). `cannot-tell` is the zero value, honest for a session marvel never spawned.
- The verdict is classified at `Create` from the constructed spawn environment overlaid on the daemon's own, recorded on the `Session`, and carried into every denominator resolution via `usage.Request.Redirection`.
- `ResolveGraded` folds it into the keyed rungs (table, alias): a redirected hit grades `KeyRedirected`, an unobserved one `KeyUndeterminable`; the verdict dominates the entitlement grade because a direct-API window does not apply under redirection. Directly-declared rungs (stream, manifest, feed) are untouched — a stated number is right on any backend. Grade-only; resolved windows are unchanged in this commit.

**2. Refuse a redirected table window; segregate the learned cache (bv7m).**
- The learned cache key now carries the verdict, so a window measured under one backend is never served to a session on another. A learned hit is backend-matched by construction and stays trusted, which is what lets a redirected session resolve once one session has taught its window.
- The table and alias rungs — which cannot be re-keyed by provider — are guarded instead: a hit graded redirected/unobserved resolves to `LimitUnresolved`, within the rung and without reordering the ladder. The vendor default is never refused.
- The verdict is plumbed to the heartbeat path (the store's resolver hook), so a cooperative feed that falls through to the table refuses identically to the accountant path.

## Residue, stated plainly

The guard closes environment-mediated redirection only. A config-file redirect that never touches the constructed environment still leaves marvel believing the session is on the default. Smaller than today's residue, not zero — and consistent with finding-031.

## Tests

Red/green throughout. New coverage: classifier truth table, the spawn-time recording end to end, the per-rung backend grade, the refuse guard (table/alias, both `ResolveGraded` and `Resolve`), backend segregation of the learned cache, the cold-start-then-learn path, and the heartbeat path refusing a redirected table window end to end through the real resolver. `go test -race ./...` green (24 packages); `golangci-lint` and `gofumpt` clean.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS