### PR TITLE
Pin gofumpt to match CI; key claude-sonnet-5 under its [1m] spelling

### DIFF
--- a/internal/toolchain/pin_test.go
+++ b/internal/toolchain/pin_test.go
@@ -1,13 +1,14 @@
-// Package toolchain carries no source of its own. It exists for the test
-// below, which keeps the repo's pinned lint toolchain and the version CI
+// Package toolchain carries no source of its own. It exists for the tests
+// below, which keep the repo's pinned dev toolchain and the versions CI
 // installs from drifting apart.
 //
 // `just lint` and lefthook's pre-commit lint step both invoke a bare
-// `golangci-lint`, so without a repo-level pin the name resolves against
-// ambient machine state: absent on a fresh machine, and some other version
-// on a machine that happens to have one. CI is unaffected because it
-// installs its own copy, which is exactly why the gap stayed invisible.
-// See issue #119.
+// `golangci-lint`; `just fmt` and lefthook's fmt-check both invoke a bare
+// `gofumpt`. Without a repo-level pin those names resolve against ambient
+// machine state: absent on a fresh machine, and some other version on a
+// machine that happens to have one. CI is unaffected because it installs
+// its own copies, which is exactly why the gap stayed invisible. See
+// issue #119 (golangci-lint) and the gofumpt follow-on.
 package toolchain
 
 import (
@@ -20,7 +21,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const lintTool = "golangci-lint"
+const (
+	lintTool = "golangci-lint"
+	fmtTool  = "gofumpt"
+)
 
 func TestGolangciLintPinMatchesCI(t *testing.T) {
 	t.Parallel()
@@ -31,6 +35,18 @@ func TestGolangciLintPinMatchesCI(t *testing.T) {
 
 	if pinned != installed {
 		t.Errorf("%s pin drift: mise.toml pins %q, ci.yml installs %q", lintTool, pinned, installed)
+	}
+}
+
+func TestGofumptPinMatchesCI(t *testing.T) {
+	t.Parallel()
+
+	repo := filepath.Join("..", "..")
+	pinned := misePin(t, filepath.Join(repo, "mise.toml"), fmtTool)
+	installed := ciGofumptVersion(t, filepath.Join(repo, ".github", "workflows", "ci.yml"))
+
+	if pinned != installed {
+		t.Errorf("%s pin drift: mise.toml pins %q, ci.yml installs %q", fmtTool, pinned, installed)
 	}
 }
 
@@ -96,5 +112,45 @@ func ciLintVersion(t *testing.T, path string) string {
 		}
 	}
 	t.Fatalf("%s has no %s-action step", path, lintTool)
+	return ""
+}
+
+// ciGofumptVersion returns the gofumpt version the CI workflow installs,
+// without any leading "v". Unlike golangci-lint (a pinned action with a
+// `version:` input), gofumpt is installed by a plain run step,
+// `go install mvdan.cc/gofumpt@<version>`, so the version is parsed out of
+// the step's command rather than a structured field.
+func ciGofumptVersion(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var wf struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	const marker = "mvdan.cc/gofumpt@"
+	for _, job := range wf.Jobs {
+		for _, step := range job.Steps {
+			idx := strings.Index(step.Run, marker)
+			if idx < 0 {
+				continue
+			}
+			fields := strings.Fields(step.Run[idx+len(marker):])
+			if len(fields) == 0 {
+				t.Fatalf("%s installs gofumpt without a version", path)
+			}
+			return strings.TrimPrefix(fields[0], "v")
+		}
+	}
+	t.Fatalf("%s has no `go install %s<version>` step", path, marker)
 	return ""
 }

--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -220,7 +220,8 @@ func DefaultTable() Table {
 		"claude-fable-5[1m]":    1_000_000, // fixture-verified, max output 64000
 		"claude-sonnet-4-6":     200_000,
 		"claude-sonnet-4-6[1m]": 1_000_000,
-		"claude-sonnet-5":       1_000_000, // no 200k variant on the API
+		"claude-sonnet-5":       1_000_000, // no 200k variant on the API; both spellings, same window (see opus-5 below)
+		"claude-sonnet-5[1m]":   1_000_000,
 		"claude-opus-4-7":       200_000,
 		"claude-opus-4-7[1m]":   1_000_000,
 		"claude-opus-4-8":       200_000,

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -387,6 +387,25 @@ func TestOpus5ResolvesUnderBothSpellings(t *testing.T) {
 	}
 }
 
+// sonnet-5 is the same case as opus-5: no 200k variant, so Claude Code's
+// [1m] stamp on the init model and modelUsage key is a spelling split, not
+// a default/max split. Both spellings must resolve to the one 1M window;
+// before the [1m] key was added, a real claude-sonnet-5[1m] session fell
+// off the table and rendered "?".
+func TestSonnet5ResolvesUnderBothSpellings(t *testing.T) {
+	t.Parallel()
+	r := NewResolver(DefaultTable())
+	for _, model := range []string{"claude-sonnet-5", "claude-sonnet-5[1m]"} {
+		limit, src, _ := r.Resolve(Request{StreamModel: model, Redirection: api.BackendDefault})
+		if limit != 1_000_000 {
+			t.Errorf("%s: limit = %d, want 1000000", model, limit)
+		}
+		if src != LimitFromTable {
+			t.Errorf("%s: source = %q, want %q", model, src, LimitFromTable)
+		}
+	}
+}
+
 func TestEveryAliasResolvesToARealEntry(t *testing.T) {
 	t.Parallel()
 	tbl := DefaultTable()
@@ -434,7 +453,8 @@ func TestDefaultTableEntryGrades(t *testing.T) {
 		"claude-fable-5[1m]":    KeyExact,  // [1m] key names the entitlement
 		"claude-sonnet-4-6":     KeyNarrow, // default half of a 200k/1M split
 		"claude-sonnet-4-6[1m]": KeyExact,
-		"claude-sonnet-5":       KeyExact, // no 200k variant
+		"claude-sonnet-5":       KeyExact, // 1M under both spellings: spelling split, not default/max
+		"claude-sonnet-5[1m]":   KeyExact,
 		"claude-opus-4-7":       KeyNarrow,
 		"claude-opus-4-7[1m]":   KeyExact,
 		"claude-opus-4-8":       KeyNarrow,

--- a/mise.toml
+++ b/mise.toml
@@ -1,18 +1,22 @@
 # Repo-level toolchain pins.
 #
 # `just lint` and the lefthook pre-commit lint step both invoke a bare
-# `golangci-lint`. Without a pin here that name resolves against whatever
-# the machine's global mise config happens to carry, so the command fails
+# `golangci-lint`; `just fmt` and lefthook's fmt-check both invoke a bare
+# `gofumpt`. Without a pin here those names resolve against whatever the
+# machine's global mise config happens to carry, so the command fails
 # outright on a machine that has never installed the tool, and silently
 # runs a different version from CI on a machine that has. A blocked
 # pre-commit hook is the moment someone reaches for --no-verify, which
 # skips fmt-check and vet along with the lint.
 #
-# The version MUST match the one .github/workflows/ci.yml passes to
-# step-security/golangci-lint-action. internal/toolchain/pin_test.go
-# asserts that, so the two cannot drift apart unnoticed.
+# Each version MUST match the one .github/workflows/ci.yml installs:
+# golangci-lint from step-security/golangci-lint-action, gofumpt from
+# `go install mvdan.cc/gofumpt@<version>`. internal/toolchain/pin_test.go
+# asserts both, so they cannot drift apart unnoticed.
 #
-# Additive on purpose: go and gofumpt keep resolving the way they do
-# today (global mise config, or CI's own install step). See issue #119.
+# Additive on purpose: go keeps resolving the way it does today (global
+# mise config, or CI's own setup-go step). See issues #119 (golangci-lint)
+# and the gofumpt follow-on.
 [tools]
 golangci-lint = "2.12.2"
+gofumpt = "0.7.0"


### PR DESCRIPTION
## Why

Two small correctness pins, each closing a silent-failure gap.

1. **gofumpt drifts between CI and local.** `just fmt` and lefthook's fmt-check both invoke a bare `gofumpt`, so the name resolves against ambient machine state — absent on a fresh machine, and a *different version* from CI where present (measured: local 0.11.0 vs CI-pinned v0.7.0). A blocked fmt-check is exactly the moment someone reaches for `--no-verify`, which skips vet and lint alongside it. This is the same defect #119 fixed for `golangci-lint`, which `mise.toml` deliberately left gofumpt out of at the time.

2. **A real `claude-sonnet-5[1m]` session renders `?`.** `DefaultTable` carried `claude-sonnet-5` under the bare key only. Claude Code stamps the `[1m]` suffix on the init model and the `modelUsage` key even for a single-window model, and `NormalizeModel` keeps the suffix — so a suffixed sonnet-5 session missed the table and lost its window.

## Ticket 1 — pin gofumpt (aae-orc-pcev)

- `mise.toml`: add `gofumpt = "0.7.0"`, matching the version CI installs via `go install mvdan.cc/gofumpt@v0.7.0`.
- `internal/toolchain/pin_test.go`: add `TestGofumptPinMatchesCI`, asserting the pin matches CI the same way the existing test does for golangci-lint. Because gofumpt is installed by a plain `run:` step rather than a pinned action, the new `ciGofumptVersion` parser extracts the version from the `go install` command instead of an action's `version:` input.

**No tree reformat.** The tree formats identically under v0.7.0 and local 0.11.0 (both `gofumpt -l .` empty), so this is a pure config pin — zero `.go` source touched. Nothing deferred.

## Ticket 2 — sonnet-5 `[1m]` spelling (aae-orc-rm6o)

Verified sonnet-5 is single-window (no 200k variant — the table's own comment, and the opus-5/fable-5 precedent). Both spellings therefore carry the same 1M window and neither can be the wrong denominator for the other, exactly as `claude-opus-5` already is.

- `internal/usage/limits.go`: add `"claude-sonnet-5[1m]": 1_000_000` beside the bare entry.
- `internal/usage/limits_test.go`: pin the new key's `KeyExact` grade in `TestDefaultTableEntryGrades` (which requires every table key to declare one) and add `TestSonnet5ResolvesUnderBothSpellings`, mirroring the opus-5 test.

## Quality gates

- `go build ./...` — clean
- `go test -race ./...` — all 24 test packages pass
- `golangci-lint run ./...` — 0 issues
- `gofumpt -l .` (v0.7.0) — empty, before and after

Files changed: `mise.toml`, `internal/toolchain/pin_test.go`, `internal/usage/limits.go`, `internal/usage/limits_test.go` — nothing else.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS