### PR TITLE
fix(daemon): stop doubling the "parse manifest:" prefix on apply errors

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -800,7 +800,12 @@ func (d *Daemon) handleApply(params json.RawMessage) Response {
 
 	m, err := api.ParseManifestBytes(p.ManifestData)
 	if err != nil {
-		return Response{Error: fmt.Sprintf("parse manifest: %v", err)}
+		// ParseManifestBytes already prefixes its errors ("parse manifest:"
+		// for a validation failure, "parse yaml/toml manifest:" for a syntax
+		// one), so return it as-is. Re-wrapping with "parse manifest: %v"
+		// doubled the prefix. Matches the ValidateRuntimes/ValidateBudgets
+		// pre-flight siblings below, which also surface err.Error() directly.
+		return Response{Error: err.Error()}
 	}
 
 	// Pre-flight: refuse to apply if any role's runtime command/script

--- a/internal/daemon/manifest_error_test.go
+++ b/internal/daemon/manifest_error_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHandleApplyDoesNotDoublePrefixParseError guards the operator-facing
+// error string on the only apply path. ParseManifestBytes already prefixes
+// every validation failure with "parse manifest:", so wrapping it again in
+// handleApply produced "parse manifest: parse manifest: <rule>". The rule
+// still has to reach the operator; only the doubled prefix is a defect.
+func TestHandleApplyDoesNotDoublePrefixParseError(t *testing.T) {
+	// A YAML manifest with a validation error (replicas must be >= 1). The
+	// masking fix (PR #101) already routes this to the real rule; this test
+	// covers the formatting of that error, not the routing.
+	const badYAML = `
+workspace:
+  name: doubled
+teams:
+  - name: crew
+    roles:
+      - name: crew
+        replicas: 0
+        runtime:
+          command: sleep
+`
+	d := newHandlerDaemon(t)
+	resp := applyManifest(t, d, badYAML)
+
+	if resp.Error == "" {
+		t.Fatal("expected a parse error for replicas: 0, got none")
+	}
+	if !strings.Contains(resp.Error, "replicas must be >= 1") {
+		t.Errorf("error = %q, want it to name the broken rule", resp.Error)
+	}
+	if strings.Contains(resp.Error, "parse manifest: parse manifest:") {
+		t.Errorf("error = %q, want no doubled %q prefix", resp.Error, "parse manifest:")
+	}
+	// The operator reads a YAML manifest; a TOML complaint would name the
+	// wrong language (the masking regression this ticket also tracked).
+	if strings.Contains(resp.Error, "toml") {
+		t.Errorf("error = %q, want no TOML complaint about a YAML manifest", resp.Error)
+	}
+}


### PR DESCRIPTION
## Why

An operator applying a bad manifest currently sees the `parse manifest:` prefix **doubled** — e.g.

```
parse manifest: parse manifest: team[0].role[0].replicas must be >= 1
```

`ParseManifestBytes` already prefixes every error it returns (`parse manifest:` for a validation failure, `parse yaml/toml manifest:` for a syntax one), and `handleApply` re-wrapped that with `"parse manifest: %v"` — so every apply-time parse error reaches the operator with a stuttered prefix. It's small, but it's the exact string someone reads while debugging a manifest, so it earns a clean fix.

The larger half of the tracked issue — YAML validation errors being masked by a TOML parse fallback — was already resolved in #101: the parser now settles format on `workspace.name` before validating, and ships dedicated tests (`TestParseManifestBytesReportsYAMLValidationErrors`, `TestParseManifestBytesStillAcceptsTOML`). This PR closes only the residual cosmetic. The parser is untouched.

## What changed

- **`internal/daemon/daemon.go`** — `handleApply` returns the parser error as-is instead of re-wrapping it with `"parse manifest: %v"`. This matches the `ValidateRuntimes` / `ValidateBudgets` pre-flight siblings immediately below, which already surface `err.Error()` directly. One logical line (+ an explanatory comment).
- **`internal/daemon/manifest_error_test.go`** (new) — regression test: a bad YAML manifest (`replicas: 0`) surfaces the broken rule (`replicas must be >= 1`), with no doubled prefix and no TOML complaint about a YAML file.

## Testing

- `go build ./...` — clean
- `go test -race ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- gofumpt / gofmt — clean
- All 35 `examples/` manifests still parse (parser unchanged; verified with a throwaway corpus walk)

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS
