### PR TITLE
feat(health): activity-staleness advisory — surface non-productive live sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,34 @@ under a new index.
 
 Restart policies: `always`, `on-failure`, `never`.
 
+**Health is LIVENESS, not productivity.** The HEALTH column answers one
+question: is the process alive and does its pane exist? It does NOT mean the
+agent can do anything. A harness sitting at a login prompt (unauthenticated,
+expired credentials, a revoked token, a model the account cannot reach) is a
+live process in a live pane, so health calls it healthy while it does no work
+(aae-orc-9box, finding-025). Read the column as liveness and nothing more.
+
+**Activity advisory (opt-in, restart-neutral).** A separate, orthogonal axis
+answers "has marvel recently seen this harness do work?" — surfaced as a
+`(stalled)` suffix on the HEALTH cell. It is deliberately NOT a health state:
+it never triggers a restart or any destructive path.
+
+- Signal: `SessionContext.ContextAt`, the timestamp both of marvel's activity
+  producers already stamp — the usage accountant on each token-bearing stream
+  sample (headless) and the cooperative heartbeat RPC (interactive
+  `statusline` context feed and the simulator). No harness output is scraped
+  for meaning; marvel does not look for login prompts.
+- Opt-in per role via `activity_timeout` (a duration; `0`/unset disables it).
+  It is opt-in because a signal that over-fires is worse than none: a fixed
+  default would eventually flag a session in a long model call or tool
+  execution. Set the window generous relative to the role's longest legitimate
+  quiet stretch.
+- Only assessed where marvel has an activity channel. A working interactive
+  session with no context feed and no heartbeat healthcheck produces nothing
+  marvel observes, so it stays `unknown`, never `stalled`. Closing that
+  residual would need an adapter `Ready`/`Blocked` verdict (a richer
+  alternative, deferred).
+
 Recovery behavior, all shipped:
 
 - **Crash-loop backoff.** Repeated restarts move the session to

--- a/cmd/marvel/main.go
+++ b/cmd/marvel/main.go
@@ -2165,6 +2165,15 @@ func renderSessionTable(sessions []api.Session) string {
 		if health == "" {
 			health = "unknown"
 		}
+		// Activity is an orthogonal, restart-neutral advisory (aae-orc-9box).
+		// HEALTH is LIVENESS — the process is alive and its pane exists — so a
+		// stalled session still reads healthy/unknown here; the "(stalled)"
+		// suffix says marvel has not observed it do work within its role's
+		// activity_timeout, which liveness cannot tell you. Running sessions
+		// only: a terminated session's last advisory is not news.
+		if s.State == api.SessionRunning && s.ActivityState == api.ActivityStalled {
+			health += " (stalled)"
+		}
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			s.Workspace, s.Team, s.Role, gen, s.Name, s.State, health, ctx, cpu, rss, desk, runtimeName, llm)
 	}
@@ -2186,6 +2195,10 @@ func renderWatch(ws *watchSort, interval time.Duration) string {
 		fmt.Fprintf(&buf, "    c  context        d  desk          r  runtime\n")
 		fmt.Fprintf(&buf, "    l  llm            h  health\n")
 		fmt.Fprintf(&buf, "    p  cpu            m  memory (rss)\n")
+		fmt.Fprintf(&buf, "\n")
+		fmt.Fprintf(&buf, "  HEALTH is liveness (process + pane), not productivity. A live\n")
+		fmt.Fprintf(&buf, "  process at a login prompt still reads healthy. \"(stalled)\" marks a\n")
+		fmt.Fprintf(&buf, "  session marvel has not seen do work within its role's activity_timeout.\n")
 		fmt.Fprintf(&buf, "\n")
 		fmt.Fprintf(&buf, "    ?  toggle help    q  quit\n")
 		fmt.Fprintf(&buf, "\n")

--- a/cmd/marvel/render_test.go
+++ b/cmd/marvel/render_test.go
@@ -92,6 +92,46 @@ func TestRenderSessionTableMeasuredIdle(t *testing.T) {
 	}
 }
 
+// The activity-staleness advisory (aae-orc-9box) rides in the HEALTH column
+// as a parenthetical: HEALTH is liveness, so a stalled session still reads
+// healthy — the suffix is the "marvel has not seen it work" signal liveness
+// cannot carry.
+func TestRenderSessionTableStalledAdvisory(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "claude"},
+		HealthState: api.HealthHealthy, ActivityState: api.ActivityStalled,
+	}})
+	if got := column(t, table, "HEALTH"); got != "healthy (stalled)" {
+		t.Errorf("HEALTH = %q for a stalled running session, want %q", got, "healthy (stalled)")
+	}
+}
+
+// Active and Unknown add nothing — the advisory is a stalled-only annotation.
+func TestRenderSessionTableActiveNoAdvisory(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionRunning, PaneID: "%3", Runtime: api.Runtime{Name: "claude"},
+		HealthState: api.HealthHealthy, ActivityState: api.ActivityActive,
+	}})
+	if got := column(t, table, "HEALTH"); got != "healthy" {
+		t.Errorf("HEALTH = %q for an active session, want plain %q", got, "healthy")
+	}
+}
+
+// A terminated session's last advisory is not news, so the annotation is
+// gated on running state: a stopped-but-stalled row reads plainly.
+func TestRenderSessionTableStalledButNotRunning(t *testing.T) {
+	table := renderSessionTable([]api.Session{{
+		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",
+		State: api.SessionFailed, PaneID: "%3", Runtime: api.Runtime{Name: "claude"},
+		HealthState: api.HealthHealthy, ActivityState: api.ActivityStalled,
+	}})
+	if got := column(t, table, "HEALTH"); got != "healthy" {
+		t.Errorf("HEALTH = %q for a non-running stalled session, want plain %q", got, "healthy")
+	}
+}
+
 func TestRenderSessionTableMeasured(t *testing.T) {
 	table := renderSessionTable([]api.Session{{
 		Name: "agent-0", Workspace: "ws", Team: "squad", Role: "worker",

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -124,6 +124,11 @@ type ManifestRole struct {
 	Identity             string               `toml:"identity,omitempty"            yaml:"identity,omitempty"`
 	Policy               string               `toml:"policy,omitempty"              yaml:"policy,omitempty"`
 	HealthCheck          *ManifestHealthCheck `toml:"healthcheck,omitempty"         yaml:"healthcheck,omitempty"`
+	// ActivityTimeout is a duration string ("10m") opting this role into the
+	// activity-staleness advisory (aae-orc-9box). Empty/unset disables it.
+	// Parsed into Role.ActivityTimeout, the same string→duration shape as
+	// healthcheck.timeout.
+	ActivityTimeout string `toml:"activity_timeout,omitempty"    yaml:"activity_timeout,omitempty"`
 }
 
 // ManifestHealthCheck is the healthcheck section within a role.
@@ -551,6 +556,13 @@ func (m *Manifest) Apply(store *Store) error {
 			}
 			if mr.RestartPolicy != "" {
 				role.RestartPolicy = RestartPolicy(mr.RestartPolicy)
+			}
+			if mr.ActivityTimeout != "" {
+				d, err := time.ParseDuration(mr.ActivityTimeout)
+				if err != nil {
+					return fmt.Errorf("parse role %q activity_timeout %q: %w", mr.Name, mr.ActivityTimeout, err)
+				}
+				role.ActivityTimeout = d
 			}
 			if mr.HealthCheck != nil {
 				timeout := 30 * time.Second

--- a/internal/api/manifest_test.go
+++ b/internal/api/manifest_test.go
@@ -208,6 +208,94 @@ name = "squad"
 	}
 }
 
+func TestParseManifestWithActivityTimeout(t *testing.T) {
+	t.Parallel()
+	m, err := ParseManifestBytes([]byte(`
+[workspace]
+name = "test"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+  activity_timeout = "10m"
+
+    [team.role.runtime]
+    command = "bash"
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	store := NewStore()
+	if err := m.Apply(store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	team, _ := store.GetTeam("test/squad")
+	if got := team.Roles[0].ActivityTimeout; got != 10*time.Minute {
+		t.Fatalf("expected 10m activity_timeout, got %v", got)
+	}
+}
+
+func TestParseManifestActivityTimeoutDefaultsDisabled(t *testing.T) {
+	t.Parallel()
+	m, err := ParseManifestBytes([]byte(`
+[workspace]
+name = "test"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+
+    [team.role.runtime]
+    command = "bash"
+`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	store := NewStore()
+	if err := m.Apply(store); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	team, _ := store.GetTeam("test/squad")
+	if got := team.Roles[0].ActivityTimeout; got != 0 {
+		t.Fatalf("unset activity_timeout must default to 0 (disabled), got %v", got)
+	}
+}
+
+func TestParseManifestBadActivityTimeout(t *testing.T) {
+	t.Parallel()
+	m, err := ParseManifestBytes([]byte(`
+[workspace]
+name = "test"
+
+[[team]]
+name = "squad"
+
+  [[team.role]]
+  name = "worker"
+  replicas = 1
+  activity_timeout = "soon"
+
+    [team.role.runtime]
+    command = "bash"
+`))
+	if err != nil {
+		t.Fatalf("parse should succeed (the duration is validated at apply): %v", err)
+	}
+	err = m.Apply(NewStore())
+	if err == nil {
+		t.Fatal("expected an error for an unparseable activity_timeout")
+	}
+	if !strings.Contains(err.Error(), "activity_timeout") {
+		t.Fatalf("error should name activity_timeout, got %v", err)
+	}
+}
+
 // --- YAML format tests ---
 
 const validYAMLManifest = `

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -56,6 +56,46 @@ const (
 	HealthUnhealthy HealthState = "unhealthy"
 )
 
+// ActivityState is a restart-neutral advisory read of whether marvel has
+// recently observed the harness do work. It is ORTHOGONAL to HealthState:
+// health is liveness (the process is alive and its pane exists), activity
+// is a staleness read over the timestamps marvel already collects.
+//
+// The two answer different questions, and this axis exists because a live
+// process is not a working one: a harness sitting at a login prompt, one
+// whose credentials expired, or one that started and immediately errored
+// is a live process in a live pane, so health calls it healthy while it
+// does nothing (aae-orc-9box, marvel finding-025). Activity is that
+// missing signal — and it is deliberately a SEPARATE field, not a fourth
+// HealthState, so that the restart path (which keys on HealthUnhealthy and
+// FailureCount) can never read it: a stalled session is never restarted.
+//
+// The reading reuses SessionContext.ContextAt, which both activity
+// producers marvel has already stamp — the usage accountant on each
+// token-bearing stream sample (headless) and the cooperative heartbeat RPC
+// (interactive statusline/codex feeds and the simulator). No stream
+// scraping is added. See team.evaluateActivity.
+type ActivityState string
+
+const (
+	// ActivityUnknown is the zero value: the role did not opt into the
+	// signal (Role.ActivityTimeout == 0), or marvel has no activity
+	// channel for this session (an interactive launch with no cooperative
+	// context feed and no heartbeat healthcheck, which produces nothing
+	// marvel observes even while working), or the session is inside its
+	// startup grace. Renders as absence, never as a problem.
+	ActivityUnknown ActivityState = ""
+	// ActivityActive: an activity signal landed within the role's
+	// ActivityTimeout.
+	ActivityActive ActivityState = "active"
+	// ActivityStalled: the role opted in, marvel has an activity channel,
+	// and no activity signal has landed within the window (either none
+	// ever, past the startup grace, or the last one is now older than the
+	// window). Advisory only — it never triggers a restart or any
+	// destructive path.
+	ActivityStalled ActivityState = "stalled"
+)
+
 // RestartPolicy controls what happens when a session becomes unhealthy.
 type RestartPolicy string
 
@@ -138,21 +178,26 @@ const ContextFeedStatusline = "statusline"
 // it exec'd. Resource readings are therefore a rollup over the pid's
 // subtree, not a read of the pid itself. See internal/procstat.
 type Session struct {
-	Name            string       `toml:"name"`
-	Workspace       string       `toml:"workspace"`
-	Team            string       `toml:"team"`
-	Role            string       `toml:"role"`
-	Generation      int64        `toml:"-"`
-	Runtime         Runtime      `toml:"runtime"`
-	State           SessionState `toml:"-"`
-	PaneID          string       `toml:"-"`
-	PID             int          `toml:"-"`
-	LastHeartbeat   time.Time    `toml:"-"`
-	HealthState     HealthState  `toml:"-"`
-	FailureCount    int          `toml:"-"`
-	RestartCount    int          `toml:"-"`
-	LastHealthCheck time.Time    `toml:"-"`
-	CreatedAt       time.Time    `toml:"-"`
+	Name          string       `toml:"name"`
+	Workspace     string       `toml:"workspace"`
+	Team          string       `toml:"team"`
+	Role          string       `toml:"role"`
+	Generation    int64        `toml:"-"`
+	Runtime       Runtime      `toml:"runtime"`
+	State         SessionState `toml:"-"`
+	PaneID        string       `toml:"-"`
+	PID           int          `toml:"-"`
+	LastHeartbeat time.Time    `toml:"-"`
+	HealthState   HealthState  `toml:"-"`
+	// ActivityState is the restart-neutral staleness advisory (aae-orc-9box).
+	// Recomputed every evaluateHealth tick from ContextAt/CreatedAt against
+	// the role's ActivityTimeout; orthogonal to HealthState and never read
+	// by the restart path. Status, not spec (toml:"-"), same as HealthState.
+	ActivityState   ActivityState `toml:"-"`
+	FailureCount    int           `toml:"-"`
+	RestartCount    int           `toml:"-"`
+	LastHealthCheck time.Time     `toml:"-"`
+	CreatedAt       time.Time     `toml:"-"`
 	// Reason is a projection-only annotation: empty on every real session
 	// row, filled by the read-path join (team.Controller.ProjectHeldRoleRows)
 	// on the synthetic rows it invents for a role held down with no live
@@ -328,6 +373,21 @@ type Role struct {
 	// session in SessionFailed. Zero means unlimited; negative values
 	// are clamped to zero. See ArcavenAE/marvel#11.
 	MaxRestarts int `toml:"max_restarts,omitempty"`
+	// ActivityTimeout, when > 0, opts this role's sessions into the
+	// activity-staleness advisory (aae-orc-9box). A running session for
+	// which marvel has an activity channel (headless stream, statusline
+	// context feed, or a heartbeat healthcheck) that has shown no activity
+	// within this window is surfaced as ActivityStalled — an advisory that
+	// NEVER triggers a restart or any destructive path.
+	//
+	// Zero (the default) disables the signal for the role. It is opt-in
+	// because a signal that over-fires is worse than none: a fixed default
+	// window would eventually flag a session in a long model call or a long
+	// tool execution as stalled while it is working. The operator sets a
+	// window generous relative to the role's longest legitimate quiet
+	// stretch. This is the "threshold is a role-level setting" the ticket
+	// names.
+	ActivityTimeout time.Duration `toml:"-"`
 }
 
 // ShiftPhase represents the current phase of a shift operation.

--- a/internal/team/activity_test.go
+++ b/internal/team/activity_test.go
@@ -1,0 +1,324 @@
+package team
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arcavenae/marvel/internal/api"
+)
+
+// headlessRuntime and feedRuntime build the two interactive/headless runtime
+// shapes the observability gate keys on, so the table rows read as intent.
+func headlessRuntime() api.Runtime {
+	return api.Runtime{Name: "claude", Command: "claude", Mode: api.RuntimeModeHeadless}
+}
+
+func statuslineRuntime() api.Runtime {
+	return api.Runtime{Name: "claude", Command: "claude", ContextFeed: api.ContextFeedStatusline}
+}
+
+func bareInteractiveRuntime() api.Runtime {
+	return api.Runtime{Name: "claude", Command: "claude"}
+}
+
+// TestEvaluateActivity is the whole truth table for the restart-neutral
+// staleness advisory (aae-orc-9box). It is a pure-function test: no tmux, no
+// store, no clock injection — every input is explicit, so the false-positive
+// guards are asserted directly rather than inferred from an integration run.
+func TestEvaluateActivity(t *testing.T) {
+	now := time.Now().UTC()
+	const window = 10 * time.Minute
+
+	heartbeatCheck := &api.HealthCheck{Type: api.HealthCheckHeartbeat, Timeout: 30 * time.Second, FailureThreshold: 3}
+	processAliveCheck := &api.HealthCheck{Type: api.HealthCheckProcessAlive}
+
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		runtime api.Runtime
+		check   *api.HealthCheck
+		context time.Time // ContextAt; zero == never observed
+		created time.Time
+		want    api.ActivityState
+	}{
+		{
+			name:    "opt-out: zero timeout disables the signal even when clearly stale",
+			timeout: 0,
+			runtime: headlessRuntime(),
+			context: now.Add(-1 * time.Hour),
+			created: now.Add(-2 * time.Hour),
+			want:    api.ActivityUnknown,
+		},
+		{
+			name:    "active: activity within the window",
+			timeout: window,
+			runtime: headlessRuntime(),
+			context: now.Add(-1 * time.Minute),
+			created: now.Add(-1 * time.Hour),
+			want:    api.ActivityActive,
+		},
+		{
+			name:    "active: activity exactly at the window boundary is not yet stale",
+			timeout: window,
+			runtime: headlessRuntime(),
+			context: now.Add(-window),
+			created: now.Add(-1 * time.Hour),
+			want:    api.ActivityActive,
+		},
+		{
+			name:    "stalled: worked, then went silent past the window (expired-creds / hung harness)",
+			timeout: window,
+			runtime: headlessRuntime(),
+			context: now.Add(-20 * time.Minute),
+			created: now.Add(-1 * time.Hour),
+			want:    api.ActivityStalled,
+		},
+		{
+			name:    "stalled-from-birth: never observed, headless channel, past the startup grace (dead-at-login)",
+			timeout: window,
+			runtime: headlessRuntime(),
+			context: time.Time{},
+			created: now.Add(-20 * time.Minute),
+			want:    api.ActivityStalled,
+		},
+		{
+			name:    "grace: never observed, headless channel, still inside the startup grace",
+			timeout: window,
+			runtime: headlessRuntime(),
+			context: time.Time{},
+			created: now.Add(-1 * time.Minute),
+			want:    api.ActivityUnknown,
+		},
+		{
+			name:    "stalled-from-birth: statusline feed is an activity channel",
+			timeout: window,
+			runtime: statuslineRuntime(),
+			context: time.Time{},
+			created: now.Add(-20 * time.Minute),
+			want:    api.ActivityStalled,
+		},
+		{
+			name:    "stalled-from-birth: a heartbeat healthcheck is an activity channel",
+			timeout: window,
+			runtime: bareInteractiveRuntime(),
+			check:   heartbeatCheck,
+			context: time.Time{},
+			created: now.Add(-20 * time.Minute),
+			want:    api.ActivityStalled,
+		},
+		{
+			// The load-bearing false-positive guard: a working interactive
+			// session with no cooperative feed and no heartbeat check produces
+			// nothing marvel observes, so a zero ContextAt means "unseen", not
+			// "idle". It must NEVER be flagged stalled.
+			name:    "guard: never observed, no activity channel, past grace → Unknown not Stalled",
+			timeout: window,
+			runtime: bareInteractiveRuntime(),
+			context: time.Time{},
+			created: now.Add(-1 * time.Hour),
+			want:    api.ActivityUnknown,
+		},
+		{
+			// process-alive is a liveness check, not an activity channel: a
+			// dead-at-login process is still process-alive. It must not gate
+			// the never-observed branch into Stalled.
+			name:    "guard: process-alive healthcheck is not an activity channel",
+			timeout: window,
+			runtime: bareInteractiveRuntime(),
+			check:   processAliveCheck,
+			context: time.Time{},
+			created: now.Add(-1 * time.Hour),
+			want:    api.ActivityUnknown,
+		},
+		{
+			// Once ContextAt is set the reading is channel-agnostic: marvel
+			// demonstrably saw work, so a later silence is assessable even for
+			// a session whose role declares no channel.
+			name:    "observed-then-stale is assessable regardless of declared channel",
+			timeout: window,
+			runtime: bareInteractiveRuntime(),
+			context: now.Add(-30 * time.Minute),
+			created: now.Add(-2 * time.Hour),
+			want:    api.ActivityStalled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &api.Session{
+				Runtime:   tt.runtime,
+				CreatedAt: tt.created,
+			}
+			s.ContextAt = tt.context
+			role := &api.Role{
+				Name:            "worker",
+				ActivityTimeout: tt.timeout,
+				HealthCheck:     tt.check,
+			}
+			got := evaluateActivity(s, role, now)
+			if got != tt.want {
+				t.Fatalf("evaluateActivity = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEvaluateActivityNilRole guards the nil-role path (a session whose role
+// was removed from the manifest between snapshot and evaluation).
+func TestEvaluateActivityNilRole(t *testing.T) {
+	now := time.Now().UTC()
+	s := &api.Session{Runtime: headlessRuntime(), CreatedAt: now.Add(-1 * time.Hour)}
+	if got := evaluateActivity(s, nil, now); got != api.ActivityUnknown {
+		t.Fatalf("nil role: evaluateActivity = %q, want %q", got, api.ActivityUnknown)
+	}
+}
+
+// TestActivityObservable pins the channel gate the never-observed branch
+// depends on.
+func TestActivityObservable(t *testing.T) {
+	heartbeatCheck := &api.HealthCheck{Type: api.HealthCheckHeartbeat}
+	processAliveCheck := &api.HealthCheck{Type: api.HealthCheckProcessAlive}
+
+	tests := []struct {
+		name    string
+		runtime api.Runtime
+		check   *api.HealthCheck
+		want    bool
+	}{
+		{"headless stream", headlessRuntime(), nil, true},
+		{"statusline context feed", statuslineRuntime(), nil, true},
+		{"heartbeat healthcheck", bareInteractiveRuntime(), heartbeatCheck, true},
+		{"bare interactive, no channel", bareInteractiveRuntime(), nil, false},
+		{"process-alive is not a channel", bareInteractiveRuntime(), processAliveCheck, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &api.Session{Runtime: tt.runtime}
+			role := &api.Role{HealthCheck: tt.check}
+			if got := activityObservable(s, role); got != tt.want {
+				t.Fatalf("activityObservable = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestActivityStalledNeverRestarts is the guarantee test: a session flagged
+// ActivityStalled is NOT restarted and its liveness/restart bookkeeping is
+// untouched. The role uses a process-alive healthcheck so the HEALTH axis
+// never restarts on its own — any restart would therefore have to come from
+// the activity axis, and the assertion is that none does.
+func TestActivityStalledNeverRestarts(t *testing.T) {
+	skipIfNoTmux(t)
+	store, _, ctrl, cleanup := setup(t)
+	t.Cleanup(cleanup)
+
+	createTeamFixture(t, store, "test-activity-norestart", "squad", []api.Role{
+		{
+			Name: "worker", Replicas: 1,
+			Runtime:         api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+			RestartPolicy:   api.RestartAlways,
+			HealthCheck:     &api.HealthCheck{Type: api.HealthCheckProcessAlive},
+			ActivityTimeout: 30 * time.Second,
+		},
+	})
+
+	ctrl.ReconcileOnce()
+	sessions := store.ListSessionsByTeamRole("test-activity-norestart", "squad", "worker")
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	sess := sessions[0]
+
+	// Inject a stale activity timestamp: marvel last saw work an hour ago.
+	if err := store.UpdateSession(sess.Key(), func(live *api.Session) error {
+		live.ContextAt = time.Now().UTC().Add(-1 * time.Hour)
+		return nil
+	}); err != nil {
+		t.Fatalf("inject stale context: %v", err)
+	}
+
+	// Two health evaluations: a stalled session must stay put across ticks,
+	// not accumulate toward any threshold.
+	ctrl.evaluateHealth()
+	ctrl.evaluateHealth()
+
+	got, err := store.GetSession(sess.Key())
+	if err != nil {
+		t.Fatalf("session must still exist — a stalled session is never restarted: %v", err)
+	}
+	if got.ActivityState != api.ActivityStalled {
+		t.Fatalf("expected ActivityStalled, got %q", got.ActivityState)
+	}
+	// Liveness is unaffected: the process is alive, the pane exists.
+	if got.HealthState != api.HealthHealthy {
+		t.Fatalf("expected HealthHealthy (liveness intact), got %q", got.HealthState)
+	}
+	if got.State != api.SessionRunning {
+		t.Fatalf("expected SessionRunning (no restart), got %q", got.State)
+	}
+	if got.FailureCount != 0 {
+		t.Fatalf("activity staleness must not charge FailureCount, got %d", got.FailureCount)
+	}
+	if got.RestartCount != 0 {
+		t.Fatalf("activity staleness must not trigger a restart, RestartCount = %d", got.RestartCount)
+	}
+}
+
+// TestActivityAdvisoryThroughEvaluateHealth exercises the active and opt-out
+// paths end to end through evaluateHealth, so the wiring (closure sets
+// ActivityState on every branch) is covered alongside the pure function.
+func TestActivityAdvisoryThroughEvaluateHealth(t *testing.T) {
+	skipIfNoTmux(t)
+
+	t.Run("fresh activity reads active", func(t *testing.T) {
+		store, _, ctrl, cleanup := setup(t)
+		t.Cleanup(cleanup)
+		createTeamFixture(t, store, "test-activity-active", "squad", []api.Role{
+			{
+				Name: "worker", Replicas: 1,
+				Runtime:         api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+				HealthCheck:     &api.HealthCheck{Type: api.HealthCheckProcessAlive},
+				ActivityTimeout: 30 * time.Second,
+			},
+		})
+		ctrl.ReconcileOnce()
+		sess := store.ListSessionsByTeamRole("test-activity-active", "squad", "worker")[0]
+		if err := store.UpdateSession(sess.Key(), func(live *api.Session) error {
+			live.ContextAt = time.Now().UTC()
+			return nil
+		}); err != nil {
+			t.Fatalf("stamp fresh context: %v", err)
+		}
+		ctrl.evaluateHealth()
+		got, _ := store.GetSession(sess.Key())
+		if got.ActivityState != api.ActivityActive {
+			t.Fatalf("expected ActivityActive, got %q", got.ActivityState)
+		}
+	})
+
+	t.Run("no activity_timeout leaves the axis Unknown even when stale", func(t *testing.T) {
+		store, _, ctrl, cleanup := setup(t)
+		t.Cleanup(cleanup)
+		createTeamFixture(t, store, "test-activity-optout", "squad", []api.Role{
+			{
+				Name: "worker", Replicas: 1,
+				Runtime:     api.Runtime{Name: "sleep", Command: "sleep", Args: []string{"300"}},
+				HealthCheck: &api.HealthCheck{Type: api.HealthCheckProcessAlive},
+				// ActivityTimeout deliberately unset (0 == disabled).
+			},
+		})
+		ctrl.ReconcileOnce()
+		sess := store.ListSessionsByTeamRole("test-activity-optout", "squad", "worker")[0]
+		if err := store.UpdateSession(sess.Key(), func(live *api.Session) error {
+			live.ContextAt = time.Now().UTC().Add(-1 * time.Hour)
+			return nil
+		}); err != nil {
+			t.Fatalf("inject stale context: %v", err)
+		}
+		ctrl.evaluateHealth()
+		got, _ := store.GetSession(sess.Key())
+		if got.ActivityState != api.ActivityUnknown {
+			t.Fatalf("opt-out role must stay ActivityUnknown, got %q", got.ActivityState)
+		}
+	})
+}

--- a/internal/team/controller.go
+++ b/internal/team/controller.go
@@ -1207,6 +1207,11 @@ func (c *Controller) evaluateHealth() {
 		var updated api.Session
 
 		err := c.store.UpdateSession(sess.Key(), func(live *api.Session) error {
+			// Activity is an orthogonal, restart-neutral axis computed from
+			// the same snapshot. It is set first and read by no branch
+			// below, so it rides out on every early return with whatever
+			// HealthState that branch decides — the two axes never touch.
+			live.ActivityState = evaluateActivity(live, role, now)
 			if role == nil || role.HealthCheck == nil {
 				live.HealthState = api.HealthUnknown
 				updated = *live
@@ -1290,6 +1295,101 @@ func (c *Controller) evaluateHealth() {
 	}
 
 	c.decayHealthyRoles(obs, c.nowUTC())
+}
+
+// evaluateActivity is the restart-neutral staleness advisory (aae-orc-9box).
+// It is a pure function of the session snapshot, its role, and the clock: it
+// returns an ActivityState and NOTHING else — it never touches FailureCount,
+// HealthState, or any restart trigger, and no caller routes its result into
+// the restart path. That structural separation is the "a stalled session is
+// never restarted" guarantee.
+//
+// It answers "has marvel recently seen this harness do work?" without parsing
+// harness output for meaning. The signal is SessionContext.ContextAt, the
+// single "measured" sentinel both of marvel's activity producers already
+// stamp: the usage accountant on each token-bearing stream sample (headless),
+// and the cooperative heartbeat RPC (interactive statusline/codex feeds and
+// the simulator; see api.Store.UpdateSessionContext / UpdateSessionHeartbeat).
+// No stream scraping is added here.
+//
+// Two false-positive guards are the reason this is careful rather than a bare
+// timeout:
+//
+//   - Opt-in per role. ActivityTimeout == 0 disables the signal entirely, so a
+//     role whose workload has long legitimate quiet stretches (a long model
+//     call, a multi-minute tool execution) is never flagged unless its
+//     operator sets a window sized to that workload.
+//   - Channel-gated for the never-observed case. A working interactive session
+//     with no cooperative context feed and no heartbeat healthcheck produces
+//     nothing marvel observes, so a zero ContextAt on such a session means
+//     "marvel cannot see it", not "it is idle" — it stays Unknown. Only a
+//     session with a declared activity channel (activityObservable) is a
+//     candidate for "stalled from birth", and only past the startup grace.
+//
+// Once ContextAt is non-zero marvel has demonstrably observed this session
+// work, so staleness is assessable regardless of declared channel — this is
+// the expired-credentials / hung-harness case (worked, then went silent).
+//
+// One accepted transient: a headless session's stream-sourced ContextAt is
+// not persisted (UpdateSessionContext does not persist), so a session adopted
+// across a daemon restart reads ContextAt zero until its next sample. If its
+// role opted in and its (persisted) CreatedAt is older than the window, it can
+// read Stalled for the gap between restart and that next sample. The verdict
+// is advisory, self-corrects on the next sample, and is bounded by the window;
+// the alternative — never seeing the real defect — is worse.
+func evaluateActivity(s *api.Session, role *api.Role, now time.Time) api.ActivityState {
+	if role == nil || role.ActivityTimeout <= 0 {
+		return api.ActivityUnknown
+	}
+	if !s.ContextAt.IsZero() {
+		if now.Sub(s.ContextAt) > role.ActivityTimeout {
+			return api.ActivityStalled
+		}
+		return api.ActivityActive
+	}
+	// Never observed. Without a declared activity channel marvel cannot tell
+	// a dead-at-login session from a healthy one it simply cannot see, so it
+	// stays silent — the residual only an adapter Ready/Blocked verdict
+	// (option 2, deferred) could close.
+	if !activityObservable(s, role) {
+		return api.ActivityUnknown
+	}
+	// Startup grace, measured from creation and sized to the same window, so
+	// a session that has not yet had time to emit its first signal is not
+	// flagged. Mirrors the first-heartbeat grace in evaluateHealth.
+	if now.Sub(s.CreatedAt) > role.ActivityTimeout {
+		return api.ActivityStalled
+	}
+	return api.ActivityUnknown
+}
+
+// activityObservable reports whether marvel has an activity channel it can
+// observe for this session — i.e. whether a working session is EXPECTED to
+// produce a signal marvel already collects. It gates only the never-observed
+// (ContextAt zero) branch of evaluateActivity, where a false positive would
+// otherwise flag a healthy-but-unobservable interactive session.
+//
+//   - Headless sessions redirect their structured output to the usage
+//     accountant, which stamps ContextAt on every token-bearing sample.
+//   - An interactive session with runtime.context_feed = "statusline"
+//     forwards its context figures over the heartbeat RPC, which stamps
+//     ContextAt.
+//   - A role with a heartbeat healthcheck expects cooperative heartbeats,
+//     which stamp ContextAt.
+//
+// An interactive session with none of these produces nothing marvel sees, so
+// it is not a candidate for the never-observed stalled verdict.
+func activityObservable(s *api.Session, role *api.Role) bool {
+	if s.Runtime.Mode == api.RuntimeModeHeadless {
+		return true
+	}
+	if s.Runtime.ContextFeed == api.ContextFeedStatusline {
+		return true
+	}
+	if role != nil && role.HealthCheck != nil && role.HealthCheck.Type == api.HealthCheckHeartbeat {
+		return true
+	}
+	return false
 }
 
 // roleObs is the health a role showed across one evaluateHealth tick: whether


### PR DESCRIPTION
## Why

Marvel's HEALTH column currently calls a dead-at-login session healthy. Health is synthesized as liveness — the process is alive and its tmux pane exists — which says nothing about whether the agent can do anything. A harness sitting at a login prompt (unauthenticated, expired credentials, a revoked token, a model the account cannot reach) is a live process in a live pane, so every one of them reports green while producing zero work. An operator watching the session table has no signal, and an entire fleet can be non-productive while reporting healthy. That is the exact shape marvel exists to prevent (aae-orc-9box, finding-025).

This makes the honest guarantee explicit (HEALTH = liveness, not productivity) and adds a conservative, restart-neutral signal for the gap — without marvel starting to scrape harness output for login prompts, which it deliberately must not do.

## What

A new **activity axis**, orthogonal to health.

- **`api.ActivityState`** (`unknown` / `active` / `stalled`) is a *separate field* from `HealthState`, not a fourth health value. That separation is the "a stalled session is never restarted" guarantee: the restart path keys on `HealthUnhealthy` + `FailureCount` and never reads the activity axis. `evaluateActivity` is a pure function that returns only an `ActivityState` and touches no restart bookkeeping.
- **Signal reuses `SessionContext.ContextAt`** — no stream scraping added. `ContextAt` is already stamped by both of marvel's activity producers: the usage accountant on each token-bearing stream sample (headless), and the cooperative heartbeat RPC (interactive `statusline` feed, codex feed, simulator). It is the unified "last time marvel saw this harness do work" timestamp.
- **Opt-in per role via `Role.ActivityTimeout`** (`0` = disabled, the default), settable from a manifest as `activity_timeout = "10m"`. A signal that over-fires is worse than none, and any fixed default window would eventually flag a session in a long model call or a multi-minute tool execution. The operator sets a window generous relative to the role's longest legitimate quiet stretch — the "threshold is a role-level setting" the ticket names.
- **Channel-gated false-positive guard.** The never-observed (`ContextAt` zero) case is only a `stalled` candidate when marvel actually has an activity channel (headless stream, statusline feed, or heartbeat healthcheck). A working interactive session with no channel produces nothing marvel observes, so it stays `unknown` — never falsely `stalled`. Once `ContextAt` is non-zero, staleness is assessable channel-agnostically (the expired-mid-session / hung-harness case).
- **Render:** a `(stalled)` suffix on the HEALTH cell for running sessions only. HEALTH still reads `healthy`/`unknown` (the process *is* alive) — the suffix carries what liveness cannot. The `watch` help legend and `marvel/CLAUDE.md` document the liveness-vs-productivity distinction (option 3).

### Design decision (which options)

Delivers **option 3** (document HEALTH = liveness) always; implements **option 1** (activity-staleness) conservatively, opt-in and default-off per role, advisory-only with a structural never-restart guarantee; **option 2** (an adapter `Ready`/`Blocked` verdict in the 12-kind event vocabulary) is **deferred** — it is the richer alternative and the only thing that could close the no-channel residual, but it is a larger change to every adapter.

### Tests

Pure-function truth table for `evaluateActivity` (11 cases incl. every false-positive guard) + `activityObservable`, tmux integration tests through `evaluateHealth` (`TestActivityStalledNeverRestarts` asserts a stalled session stays running with `FailureCount`/`RestartCount` at zero across ticks; active/opt-out paths covered), three render tests for the annotation, and three manifest parse tests (valid `10m`, default-disabled when unset, bad-duration error naming the field). `go test -race ./...` green (24 packages); `golangci-lint` 0 issues; gofumpt clean.

## New API surface

- `internal/api/types.go`: `ActivityState` type + `Session.ActivityState` field + `Role.ActivityTimeout time.Duration`.
- `internal/api/manifest.go`: `ManifestRole.ActivityTimeout string` (`activity_timeout`, TOML+YAML) parsed into `Role.ActivityTimeout` at `Apply`.
- No changes to `daemon.go`, `limits.go`, or `mise.toml`. `types.go` additions are new fields in different structs from the already-merged `ShiftState.Drained` / `Session.Reason` (#215) — additive, no collision.

## Residual / follow-ups

- **Adopted-headless transient:** a headless session's stream-sourced `ContextAt` is not persisted, so a session adopted across a daemon restart can read `stalled` for the gap between restart and its next sample if its role opted in and its `CreatedAt` predates the window. Advisory-only, self-corrects on the next sample, bounded by the window; documented in `evaluateActivity`.
- **Option 2 (adapter `Ready`/`Blocked`)** deferred — the richer alternative, and the only thing that closes the no-channel residual.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS