### PR TITLE
fix(usage): pin the opus and sonnet aliases to their current -5 models (ldq8)

### DIFF
--- a/internal/usage/limits.go
+++ b/internal/usage/limits.go
@@ -321,10 +321,20 @@ func (t Table) keyConfidence(normalizedKey string, window int) KeyConfidence {
 
 // aliases map the short forms an operator passes to --model onto table
 // keys. A hit here resolves as LimitFromTableAlias, never LimitFromTable.
+//
+// Pin-to-named convention (aae-orc-ldq8, ratified 2026-08-30): each alias
+// points at a SPECIFIC named model, NOT the newest of its family. That
+// trades staleness at each model release for a stable, surprise-free
+// denominator — a bare --model opus gets the window of the model named
+// here, never one that changed under it when a new model shipped. THE
+// MAINTENANCE COST is the point: bump these pins DELIBERATELY when a new
+// model lands. TestAliasesResolveToPinnedWindows locks the current pins so
+// a bump is an explicit, reviewed edit; the loop test below guards that no
+// pin dangles off the table.
 var aliases = map[string]string{
 	"haiku":     "claude-haiku-4-5",
-	"sonnet":    "claude-sonnet-4-6",
-	"opus":      "claude-opus-4-8",
+	"sonnet":    "claude-sonnet-5", // was claude-sonnet-4-6 (pre-5); bumped 2026-08-30
+	"opus":      "claude-opus-5",   // was claude-opus-4-8 (200k default); aae-orc-ldq8, 2026-08-30
 	"fable[1m]": "claude-fable-5[1m]",
 }
 

--- a/internal/usage/limits_test.go
+++ b/internal/usage/limits_test.go
@@ -416,6 +416,44 @@ func TestEveryAliasResolvesToARealEntry(t *testing.T) {
 	}
 }
 
+// TestAliasesArePinnedToCurrentNamedModels locks the pin-to-named values
+// (aae-orc-ldq8). Pins are maintained by hand and bumped deliberately at a
+// model release; this is the tripwire that makes a bump an explicit,
+// reviewed edit rather than silent drift. Update it in the same change that
+// bumps an alias. TestEveryAliasResolvesToARealEntry guards that a pin never
+// dangles off the table.
+func TestAliasesArePinnedToCurrentNamedModels(t *testing.T) {
+	t.Parallel()
+	wantPin := map[string]string{
+		"haiku":     "claude-haiku-4-5",
+		"sonnet":    "claude-sonnet-5",
+		"opus":      "claude-opus-5",
+		"fable[1m]": "claude-fable-5[1m]",
+	}
+	for alias, canon := range aliases {
+		if wantPin[alias] != canon {
+			t.Errorf("alias %q pins to %q, want %q", alias, canon, wantPin[alias])
+		}
+	}
+	for alias := range wantPin {
+		if _, ok := aliases[alias]; !ok {
+			t.Errorf("expected alias %q is missing from the map", alias)
+		}
+	}
+	// The ldq8 fix: opus and sonnet now resolve to the 1M window of their
+	// -5 models, not the pre-5 defaults (claude-opus-4-8 was a 200k default).
+	tbl := DefaultTable()
+	for _, alias := range []string{"opus", "sonnet"} {
+		w, ok := tbl.Lookup(aliases[alias])
+		if !ok {
+			t.Fatalf("alias %q points at %q, which is missing from the table", alias, aliases[alias])
+		}
+		if w != 1_000_000 {
+			t.Errorf("alias %q resolves to %d, want 1000000 (the -5 window)", alias, w)
+		}
+	}
+}
+
 // Only KeyExact is a hard fact; everything else, including the zero value
 // and any grade a later writer adds, must read as soft. A consumer that
 // forgets to set the grade then defaults to soft rather than silently
@@ -877,10 +915,14 @@ func TestResolveGradedOverDefaultTable(t *testing.T) {
 			wantKey:    KeyExact,
 		},
 		{
-			// opus → claude-opus-4-8, a narrow entry: narrow either way.
-			name:       "alias onto a narrow entry is narrow",
+			// opus → claude-opus-5 after the aae-orc-ldq8 pin-to-named bump:
+			// a single-window 1M entry, still floored to narrow because an
+			// alias is never a keyed fact. No alias points at a split-default
+			// entry anymore; the alias-onto-a-narrow-default path is exercised
+			// directly by the "shipped split default key is narrow" case above.
+			name:       "alias onto a single-window entry floors to narrow",
 			req:        Request{RuntimeArgs: []string{"--model", "opus"}},
-			wantLimit:  200_000,
+			wantLimit:  1_000_000,
 			wantSource: LimitFromTableAlias,
 			wantKey:    KeyNarrow,
 		},


### PR DESCRIPTION
## Why

A bare `--model opus` currently reports a **200k** context denominator for the current opus, which carries a **1M** window — because the `opus` alias still points at `claude-opus-4-8` (the previous release's 200k split default) while `claude-opus-5` sits in the table. The denominator an operator sees should match the model they actually get.

This adopts the operator-ratified **pin-to-named** convention (aae-orc-ldq8, 2026-08-30): each `--model` alias points at a *specific named model* and is bumped deliberately at a model release. That accepts staleness between releases in exchange for a stable, surprise-free denominator — the operator never gets a window that silently changed under them when a new model shipped (the alternative, resolve-to-newest-of-family, was rejected for exactly that surprise).

Refreshes the two currently-stale pins: `opus → claude-opus-5` and `sonnet → claude-sonnet-5` (same stale shape — sonnet still pointed at `claude-sonnet-4-6`), both now 1M. `haiku` and `fable[1m]` were already current. A new test locks the pins so a future bump is an explicit, reviewed edit; the pre-existing no-dangling test still guards that every target is a real table key.

https://claude.ai/code/session_01LQpH1S4iwyajyWWcJM39ZS